### PR TITLE
Adds aws_iam_role

### DIFF
--- a/docs/resources/aws_iam_role.md
+++ b/docs/resources/aws_iam_role.md
@@ -9,12 +9,6 @@ Use the `aws_iam_role` InSpec audit resource to test properties of an AWS IAM Ro
 
 <br>
 
-## Availability
-
-### Installation
-
-    ...
-    
 ## Syntax
 
 An `aws_iam_role` resource block declares the tests for a single AWS IAM Role by Role Name.

--- a/docs/resources/aws_iam_role.md
+++ b/docs/resources/aws_iam_role.md
@@ -1,0 +1,69 @@
+---
+title: About the aws_iam_role Resource
+platform: aws
+---
+
+# aws\_iam\_role
+
+Use the `aws_iam_role` InSpec audit resource to test properties of an AWS IAM Role.
+
+<br>
+
+## Availability
+
+### Installation
+
+    ...
+    
+## Syntax
+
+An `aws_iam_role` resource block declares the tests for a single AWS IAM Role by Role Name.
+
+    describe aws_iam_role(role_name: 'my-role') do
+        it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+    # Test that an IAM Role exists
+      
+    describe aws_iam_role(role_name: aws_iam_role_name) do
+        it               { should exist }
+        its('role_name') { should eq aws_iam_role_name }
+    end
+
+<br>
+
+## Properties
+
+* role_name 
+* role_id 
+* description 
+* arn 
+* path 
+* create_date
+* assume_role_policy_document 
+* max_session_duration
+* permissions_boundary_type 
+* permissions_boundary_arn
+
+<br>
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exists
+
+The `exists` matcher tests if the described IAM Role exists.
+
+    it { should exist }
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the following permissions action set to allow: 
+`iam:GetRole` 

--- a/docs/resources/aws_iam_roles.md
+++ b/docs/resources/aws_iam_roles.md
@@ -1,0 +1,81 @@
+---
+title: About the aws_iam_roles Resource
+platform: aws
+---
+
+# aws\_iam\_roles
+
+Use the `aws_iam_roles` InSpec audit resource to test properties of some or all AWS IAM Roles.
+
+
+<br>
+
+## Availability
+
+### Installation
+
+    ...
+
+
+## Syntax
+
+An `aws_iam_roles` resource block returns all IAM Roles and allows the testing of that group of Roles.
+
+    describe aws_iam_roles do
+      it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+
+    # Ensure the Role 'RDS-RW' exists.
+      
+      describe aws_iam_roles do
+        its('role_names') { should include 'RDS-RW' }
+      end
+      
+      
+    # Ensure no Roles have `max_session_duration` greater or equal to 2hrs.
+      
+      describe aws_iam_roles.where{ max_session_duration >= (60*120) } do
+        it { should_not exist }
+      end
+      
+<br>
+
+## Properties
+
+* role_name 
+* role_id 
+* description 
+* arn 
+* path 
+* create_date
+* assume_role_policy_document 
+* max_session_duration
+* permissions_boundary_type 
+* permissions_boundary_arn
+
+<br>
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exists
+
+The `exists` matcher tests if the filtered IAM User(s) exists.
+
+      describe aws_iam_roles.where( <property>: <param>) do
+        it { should exist }
+      end
+You may also use `it { should_not exist }`.
+    
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the following permissions set to Allow: 
+`iam:ListRoles` 

--- a/docs/resources/aws_iam_roles.md
+++ b/docs/resources/aws_iam_roles.md
@@ -10,13 +10,6 @@ Use the `aws_iam_roles` InSpec audit resource to test properties of some or all 
 
 <br>
 
-## Availability
-
-### Installation
-
-    ...
-
-
 ## Syntax
 
 An `aws_iam_roles` resource block returns all IAM Roles and allows the testing of that group of Roles.

--- a/libraries/aws_iam_role.rb
+++ b/libraries/aws_iam_role.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class AwsIamRole < AwsResourceBase
+  name 'aws_iam_role'
+  desc 'Verifies settings for an IAM Role'
+  example "
+    describe aws_iam_role('my-role') do
+      it { should exist }
+    end
+  "
+
+  attr_reader :path, :role_name, :role_id, :arn, :create_date,
+              :assume_role_policy_document, :description, :max_session_duration,
+              :permissions_boundary_type, :permissions_boundary_arn
+
+  def initialize(opts = {})
+    opts = { role_name: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters([:role_name])
+    catch_aws_errors do
+      resp = @aws.iam_client.get_role(role_name: opts[:role_name]).role
+
+      @role_name    = resp.role_name
+      @role_id      = resp.role_id
+      @arn          = resp.arn
+      @description  = resp.description
+      @create_date  = resp.create_date
+      @path         = resp.path
+      @assume_role_policy_document = resp.assume_role_policy_document
+      @max_session_duration        = resp.max_session_duration
+      @permissions_boundary_type   = nil
+      @permissions_boundary_arn    = nil
+      if resp.permissions_boundary
+        @permissions_boundary_type = resp.permissions_boundary.permissions_boundary_type
+        @permissions_boundary_arn  = resp.permissions_boundary.permissions_boundary_arn
+      end
+    end
+  end
+
+  def exists?
+    !@arn.nil?
+  end
+
+  def to_s
+    "AWS IAM Role #{@role_name}"
+  end
+end

--- a/libraries/aws_iam_roles.rb
+++ b/libraries/aws_iam_roles.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsIamRoles < AwsResourceBase
+  name 'aws_iam_roles'
+  desc 'Verifies settings for a collection AWS IAM Roles'
+  example '
+    describe aws_iam_roles do
+      it { should exist }
+    end
+  '
+
+  attr_reader :table
+
+  FilterTable.create
+             .register_column(:role_names,  field: :role_name)
+             .register_column(:role_ids,    field: :role_id)
+             .register_column(:paths,       field: :path)
+             .register_column(:arns,        field: :arn)
+             .register_column(:create_date, field: :create_date)
+             .register_column(:description, field: :description)
+             .register_column(:assume_role_policy_document, field: :assume_role_policy_document)
+             .register_column(:max_session_duration,        field: :max_session_duration)
+             .register_column(:permissions_boundary_type,   field: :permissions_boundary_type)
+             .register_column(:permissions_boundary_arn,    field: :permissions_boundary_arn)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters([])
+    @table = fetch_data
+  end
+
+  def fetch_data
+    role_rows = []
+    roles = {}
+    pagination_options = {}
+
+    loop do
+      catch_aws_errors do
+        roles = @aws.iam_client.list_roles(pagination_options)
+        return [] if !roles || roles.empty?
+
+        roles.roles.each do |r|
+          permissions_boundary_type = nil
+          permissions_boundary_arn  = nil
+
+          if r.permissions_boundary
+            permissions_boundary_type = r.permissions_boundary.permissions_boundary_type
+            permissions_boundary_arn  = r.permissions_boundary.permissions_boundary_arn
+          end
+          role_rows += [{ role_name:   r.role_name,
+                          role_id:     r.role_id,
+                          path:        r.path,
+                          arn:         r.arn,
+                          create_date: r.create_date,
+                          description: r.description,
+                          assume_role_policy_document: r.assume_role_policy_document,
+                          max_session_duration:        r.max_session_duration,
+                          permissions_boundary_type:   permissions_boundary_type,
+                          permissions_boundary_arn:    permissions_boundary_arn }]
+        end
+      end
+      break unless roles.marker
+      pagination_options = { marker: roles.marker }
+    end
+    @table = role_rows
+  end
+end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -58,6 +58,7 @@ variable "aws_elb_name" {}
 variable "aws_enable_creation" {}
 variable "aws_flow_log_bucket_name" {}
 variable "aws_iam_group_name" {}
+variable "aws_iam_role_generic_name" {}
 variable "aws_iam_user_name" {}
 variable "aws_iam_user_policy_name" {}
 variable "aws_internet_gateway_name" {}
@@ -1068,4 +1069,24 @@ resource "aws_eks_cluster" "aws_eks_cluster" {
   vpc_config {
     subnet_ids = ["${aws_subnet.eks_subnet-2.*.id}", "${aws_subnet.eks_subnet.*.id}"]
   }
+}
+
+resource "aws_iam_role" "aws_role_generic" {
+  count = "${var.aws_enable_creation}"
+  name = "${var.aws_iam_role_generic_name}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -70,6 +70,7 @@ module AWSInspecConfig
       aws_iam_user_policy_name: "iam-user-policy-#{add_random_string}",
       aws_internet_gateway_name: 'inspec-aws-internet-gateway',
       aws_iam_group_name: "iam_group-#{add_random_string}",
+      aws_iam_role_generic_name: "aws-iam-role-#{add_random_string}",
       aws_iam_policy_arn: "aws-iam-policy-arn-#{add_random_string}",
       aws_iam_policy_name: "aws-iam-policy-name-#{add_random_string}",
       aws_key_description_disabled: 'InSpec KMS Key Test Disabled',

--- a/test/integration/verify/controls/aws_iam_role.rb
+++ b/test/integration/verify/controls/aws_iam_role.rb
@@ -1,0 +1,8 @@
+aws_iam_role_name = attribute(:aws_iam_role_generic_name, default: '', description: 'The AWS IAM Role name.')
+
+control 'AWS IAM Role search for default AWS role' do
+  describe aws_iam_role(role_name: aws_iam_role_name) do
+    it               { should exist }
+    its('role_name') { should eq aws_iam_role_name }
+  end
+end

--- a/test/integration/verify/controls/aws_iam_roles.rb
+++ b/test/integration/verify/controls/aws_iam_roles.rb
@@ -1,0 +1,12 @@
+aws_iam_role_name = attribute(:aws_iam_role_generic_name, default: '', description: 'The AWS IAM Role name.')
+
+control 'AWS IAM Role search for default AWS role' do
+  describe aws_iam_roles do
+    its('role_names') { should include aws_iam_role_name }
+  end
+
+  # Ensure no Roles have `max_session_duration` greater or equal to 2hrs.
+  describe aws_iam_roles.where{ max_session_duration >= (60*120) } do
+    it { should_not exist }
+  end
+end

--- a/test/unit/resources/aws_iam_role_test.rb
+++ b/test/unit/resources/aws_iam_role_test.rb
@@ -1,0 +1,52 @@
+require 'aws-sdk-core'
+require 'aws_iam_role'
+require 'helper'
+require_relative 'mock/iam/aws_iam_role_mock'
+
+class AwsIamRoleTest < Minitest::Test
+
+  def setup
+    # Given
+    @mock      = AwsIamRoleMock.new
+    @mock_role = @mock.role[:role]
+
+    # When
+    @role = AwsIamRole.new(role_name: @mock_role[:role_name],
+                           client_args: { stub_responses: true },
+                           stub_data: @mock.stub_data)
+  end
+
+  def test_exists
+    assert(@role.exists?)
+  end
+
+  def test_role_name
+    assert_equal(@role.role_name, @mock_role[:role_name])
+  end
+
+  def test_role_id
+    assert_equal(@role.role_id, @mock_role[:role_id])
+  end
+
+  def test_arn
+    assert_equal(@role.arn, @mock_role[:arn])
+  end
+
+  def test_description
+    assert_equal(@role.description, @mock_role[:description])
+  end
+
+  def test_create_date
+    assert(@role.create_date.to_i == @mock_role[:create_date].to_i)
+  end
+
+  def test_path
+    assert_equal(@role.path, @mock_role[:path])
+  end
+
+  def test_permission_boundaries
+    assert_nil(@role.permissions_boundary_type)
+    assert_nil(@role.permissions_boundary_arn)
+  end
+
+end

--- a/test/unit/resources/mock/iam/aws_iam_role_mock.rb
+++ b/test/unit/resources/mock/iam/aws_iam_role_mock.rb
@@ -1,0 +1,29 @@
+require_relative '../aws_base_resource_mock'
+
+class AwsIamRoleMock < AwsBaseResourceMock
+
+  # Default attributes.
+  def initialize
+    super
+    @role = {
+        role: {
+            arn: @aws.any_arn,
+            assume_role_policy_document: '<URL-encoded-JSON>',
+            create_date: @aws.any_date,
+            path: '/',
+            role_id: 'AIDIODR4TAW7CSEXAMPLE',
+            role_name: @aws.any_string,
+            description: @aws.any_string
+        }
+    }
+  end
+
+  # Provide the mapping for what to return when mocking calls to the AWS SDK.
+  def stub_data
+    [{ :client => Aws::IAM::Client, :method => :get_role, :data => @role }]
+  end
+
+  def role
+    @role
+  end
+end


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Adds `aws_iam_role` and `aws_iam_roles` resources, controls, tests, infra.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
