### PR TITLE
Add Aws launch configuration resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'bundle'
 # Note that 'aws-sdk' pulls in a large number of libraries, choose explicitly those to include instead
 # gem 'aws-sdk', '~> 3'
 # See service list here: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/index.html
+gem 'aws-sdk-autoscaling', '~> 1'
 gem 'aws-sdk-ec2', '~> 1'
 gem 'aws-sdk-s3', '~> 1'
 gem 'aws-sdk-cloudtrail', '~> 1'

--- a/docs/resources/aws_launch_configuration.md
+++ b/docs/resources/aws_launch_configuration.md
@@ -1,0 +1,159 @@
+---
+title: About the aws_launch_configuration Resource
+---
+
+# aws\_launch\_configuration
+
+Use the `aws_launch_configuration` InSpec audit resource to test properties of a single AWS Launch Configuration. 
+
+<br>
+
+## Availability
+
+### Installation
+
+### Version
+
+
+## Syntax
+
+    # Ensure that a queue exists and has a visibility timeout of 300 seconds
+    describe aws_launch_configuration('my-config') do
+      it { should exist }
+      its('key_name') { should be 'my-key-name' }
+    end
+
+    # You may also use hash syntax to pass the launch configuration name
+    describe aws_launch_configuration(launch_configuration_name: 'my-config') do
+      it { should exist }
+    end
+
+## Resource Parameters
+
+### name
+
+This resource expects a single parameter, the name that uniquely identifies the of a Launch Configuration.
+
+See also the [AWS documentation on Launch Configurations](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchConfiguration.html).
+
+<br>
+
+## Properties
+
+### arn
+
+An string indicating the ARN of the launch configuration
+    
+    describe aws_launch_configuration('my-config') do
+      its('arn') { should eq 'arn:aws:autoscaling:us-east-1:0123456'}
+    end
+
+### image\_id
+
+An string indicating the AMI of the launch configuration
+    
+    describe aws_launch_configuration('my-config') do
+      its('image_id') { should eq 'ami-012345'}
+    end
+
+### instance\_type
+
+A string indicating the instance type of the launch configuration
+    
+    describe aws_launch_configuration('my-config') do
+      its('instance_type') { should eq 't2.micro'}
+    end
+
+### iam\_instance\_profile
+
+A string indicating the IAM profile for the launch configuration
+
+    describe aws_launch_configuration('my-config') do
+      its('iam_instance_profile') { should eq 'iam-profile' }
+    end
+
+### key\_name
+
+A string indicating the AWS key pair for the launch configuration
+
+    describe aws_launch_configuration('my-config') do
+      its('key_name') { should eq 'key-name' }
+    end
+
+### security\_groups
+
+An array of strings of the security group IDs associated with the launch configuration
+
+    describe aws_launch_configuration('my-config') do
+      its('security_groups') { should include 'security-group'}
+    end
+
+### associate\_public\_ip\_address
+
+A boolean indicating if the launch configuration is configured to set a public IP address
+
+    describe aws_launch_configuration('my-config') do
+      its('associate_public_ip_address') { should be true }
+    end
+
+### user\_data
+
+A string containing the user data configured for the launch configuration
+
+    describe aws_launch_configuration('my-config') do
+      its('user_data') { should include 'user-data' }
+    end
+
+### ebs\_optimized
+
+A boolean indicating if the launch configuration is optimized for Amazon EBS
+
+    describe aws_launch_configuration('my-config') do
+      its('ebs_optimized') { should be true }
+    end
+
+### instance\_monitoring
+
+A string indicating if instance monitoring is set to `detailed` or `basic`
+
+    describe aws_launch_configuration('my-config') do
+      its('instance_monitoring') { should eq 'detailed' }
+    end
+
+    describe aws_launch_configuration('my-config') do
+        its('instance_monitoring') { should eq 'basic' }
+    end
+
+### spot\_price
+
+A floating point number indicating the spot price configured
+
+    describe aws_launch_configuration('my-config') do
+      its('spot_price') { should be 0.1 }
+    end
+    
+<br>
+    
+    
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exist
+
+Indicates that the Launch Configuration name provided was found.  Use `should_not` to test for Launch Configurations that should not exist.
+
+    # Expect good news
+    describe aws_launch_configuration('existing-launch-configuration') do
+      it { should exist }
+    end
+
+    # No bad news allowed
+    describe aws_launch_configuration('non-existing-launch-configuration') do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `autoscaling:Describe*` action with Effect set to Allow.
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Auto Scaling Groups and launch configurations](https://docs.aws.amazon.com/autoscaling/ec2/userguide/control-access-using-iam.html).

--- a/docs/resources/aws_launch_configuration.md
+++ b/docs/resources/aws_launch_configuration.md
@@ -7,25 +7,17 @@ title: About the aws_launch_configuration Resource
 Use the `aws_launch_configuration` InSpec audit resource to test properties of a single AWS Launch Configuration. 
 
 <br>
-
-## Availability
-
-### Installation
-
-### Version
-
-
 ## Syntax
 
-    # Ensure that a queue exists and has a visibility timeout of 300 seconds
+    # Ensure that a launch configuration exists and has the correct key name
     describe aws_launch_configuration('my-config') do
-      it { should exist }
+      it              { should exist }
       its('key_name') { should be 'my-key-name' }
     end
 
     # You may also use hash syntax to pass the launch configuration name
     describe aws_launch_configuration(launch_configuration_name: 'my-config') do
-      it { should exist }
+      it              { should exist }
     end
 
 ## Resource Parameters

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'aws-sdk-autoscaling'
 require 'aws-sdk-cloudtrail'
 require 'aws-sdk-cloudwatch'
 require 'aws-sdk-cloudwatchlogs'
@@ -95,6 +96,10 @@ class AwsConnection
 
   def rds_client
     aws_client(Aws::RDS::Client)
+  end
+
+  def service_client
+    aws_client(Aws::AutoScaling::Client)
   end
 
   def sqs_client

--- a/libraries/aws_launch_configuration.rb
+++ b/libraries/aws_launch_configuration.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsLaunchConfiguration < AwsResourceBase
+  name 'aws_launch_configuration'
+  desc 'Verifies settings for an AWS Launch Configuration'
+
+  example "
+    describe aws_launch_configuration('config-name') do
+      it { should exist }
+    end
+  "
+
+  attr_reader :name, :arn, :image_id, :instance_type, :iam_instance_profile, :key_name, :security_groups, :associate_public_ip_address,
+              :ebs_optimized, :spot_price, :instance_monitoring, :user_data
+
+  def initialize(opts = {})
+    opts = { launch_configuration_name: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters([:launch_configuration_name])
+
+    catch_aws_errors do
+      resp = @aws.service_client.describe_launch_configurations(launch_configuration_names: [opts[:launch_configuration_name]])
+      return nil if resp.launch_configurations.nil? || resp.launch_configurations.empty?
+      configuration = resp.launch_configurations[0]
+      @name                        = configuration[:launch_configuration_name]
+      @arn                         = configuration[:launch_configuration_arn]
+      @image_id                    = configuration[:image_id]
+      @instance_type               = configuration[:instance_type]
+      @iam_instance_profile        = configuration[:iam_instance_profile]
+      @key_name                    = configuration[:key_name]
+      @security_groups             = configuration[:security_groups]
+      @associate_public_ip_address = configuration[:associate_public_ip_address].nil? ? false : true
+      @ebs_optimized               = configuration[:ebs_optimized]
+      @spot_price                  = configuration[:spot_price].to_f
+      @instance_monitoring         = configuration[:instance_monitoring][:enabled] ? 'detailed': 'basic'
+      @user_data                   = configuration[:user_data] ? Base64.decode64(configuration[:user_data]) : nil
+    end
+  end
+
+  def exists?
+    !@name.nil?
+  end
+
+  def to_s
+    "AWS Launch Configuration #{@name}"
+  end
+end

--- a/libraries/aws_launch_configurations.rb
+++ b/libraries/aws_launch_configurations.rb
@@ -40,7 +40,7 @@ class AwsLaunchConfigurations < AwsResourceBase
       response = @aws.service_client.describe_launch_configurations
       return [] if !response || response.empty?
       response.launch_configurations.each do |config|
-        config_rows += [{name:                        config[:launch_configuration_name],
+        config_rows += [{ name:                        config[:launch_configuration_name],
                          arn:                         config[:launch_configuration_arn],
                          image_id:                    config[:image_id],
                          instance_type:               config[:instance_type],
@@ -51,7 +51,7 @@ class AwsLaunchConfigurations < AwsResourceBase
                          ebs_optimized:               config[:ebs_optimized],
                          spot_price:                  config[:spot_price].to_f,
                          instance_monitoring:         config[:instance_monitoring][:enabled] ? 'detailed': 'basic',
-                         user_data:                   config[:user_data] ? Base64.decode64(config[:user_data]) : nil}]
+                         user_data:                   config[:user_data] ? Base64.decode64(config[:user_data]) : nil }]
       end
     end
     @table = config_rows

--- a/libraries/aws_launch_configurations.rb
+++ b/libraries/aws_launch_configurations.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsLaunchConfigurations < AwsResourceBase
+  name 'aws_launch_configurations'
+  desc 'Verifies settings for a collection AWS Launch Configurations'
+  example '
+    describe aws_launch_configurations do
+      it { should exist }
+    end
+  '
+
+  attr_reader :table
+
+  FilterTable.create
+             .register_column(:arns,                          field: :arn)
+             .register_column(:names,                         field: :name)
+             .register_column(:image_ids,                     field: :image_id)
+             .register_column(:instance_types,                field: :instance_type)
+             .register_column(:iam_instance_profiles,         field: :iam_instance_profile)
+             .register_column(:key_names,                     field: :key_name)
+             .register_column(:security_groups,               field: :security_groups)
+             .register_column(:associate_public_ip_addresses, field: :associate_public_ip_address)
+             .register_column(:ebs_optimizeds,                field: :ebs_optimized)
+             .register_column(:spot_prices,                   field: :spot_price)
+             .register_column(:instance_monitoring,           field: :instance_monitoring)
+             .register_column(:user_data,                     field: :user_data)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters([])
+    @table = fetch_data
+  end
+
+  def fetch_data
+    config_rows = []
+    catch_aws_errors do
+      response = @aws.service_client.describe_launch_configurations
+      return [] if !response || response.empty?
+      response.launch_configurations.each do |config|
+        config_rows += [{name:                        config[:launch_configuration_name],
+                         arn:                         config[:launch_configuration_arn],
+                         image_id:                    config[:image_id],
+                         instance_type:               config[:instance_type],
+                         iam_instance_profile:        config[:iam_instance_profile],
+                         key_name:                    config[:key_name],
+                         security_groups:             config[:security_groups],
+                         associate_public_ip_address: config[:associate_public_ip_address].nil? ? false : true,
+                         ebs_optimized:               config[:ebs_optimized],
+                         spot_price:                  config[:spot_price].to_f,
+                         instance_monitoring:         config[:instance_monitoring][:enabled] ? 'detailed': 'basic',
+                         user_data:                   config[:user_data] ? Base64.decode64(config[:user_data]) : nil}]
+      end
+    end
+    @table = config_rows
+  end
+end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1109,6 +1109,7 @@ data "aws_ami" "aws_vm_config" {
 }
 
 resource "aws_launch_configuration" "as_conf" {
+  count         = "${var.aws_enable_creation}"
   name          = "${var.aws_launch_configuration_name}"
   image_id      = "${data.aws_ami.aws_vm_config.id}"
   instance_type = "t2.micro"

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -64,6 +64,7 @@ variable "aws_internet_gateway_name" {}
 variable "aws_iam_policy_name" {}
 variable "aws_key_description_disabled" {}
 variable "aws_key_description_enabled" {}
+variable "aws_launch_configuration_name" {}
 variable "aws_rds_db_engine" {}
 variable "aws_rds_db_engine_version" {}
 variable "aws_rds_db_identifier" {}
@@ -1068,4 +1069,28 @@ resource "aws_eks_cluster" "aws_eks_cluster" {
   vpc_config {
     subnet_ids = ["${aws_subnet.eks_subnet-2.*.id}", "${aws_subnet.eks_subnet.*.id}"]
   }
+}
+
+data "aws_ami" "aws_vm_config" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_launch_configuration" "as_conf" {
+  name          = "${var.aws_launch_configuration_name}"
+  image_id      = "${data.aws_ami.aws_vm_config.id}"
+  instance_type = "t2.micro"
+  spot_price    = "0.1"
+  user_data     = "#!/bin/bash"
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -74,6 +74,7 @@ module AWSInspecConfig
       aws_iam_policy_name: "aws-iam-policy-name-#{add_random_string}",
       aws_key_description_disabled: 'InSpec KMS Key Test Disabled',
       aws_key_description_enabled: 'InSpec KMS Key Test Enabled',
+      aws_launch_configuration_name: "aws-launch-configuration-name-#{add_random_string}",
       aws_rds_db_engine: 'mysql',
       aws_rds_db_engine_version: '5.6.37',
       aws_rds_db_identifier: "awsrds#{add_random_string}",

--- a/test/integration/verify/controls/aws_launch_configuration.rb
+++ b/test/integration/verify/controls/aws_launch_configuration.rb
@@ -1,0 +1,13 @@
+title 'Test single AWS Launch Configuration'
+
+config_name = attribute(:aws_launch_configuration_name, default: '', description: 'The AWS launch configuration name.')
+
+control 'aws-launch-configuration-1.0' do
+  impact 1.0
+  title 'Ensure AWS Launch Configuration has the correct properties.'
+
+  describe aws_launch_configuration(launch_configuration_name: config_name) do
+    it           { should exist }
+    its ('name') { should eq config_name}
+  end
+end

--- a/test/integration/verify/controls/aws_launch_configurations.rb
+++ b/test/integration/verify/controls/aws_launch_configurations.rb
@@ -1,0 +1,13 @@
+title 'Test collection of AWS Launch Configurations'
+
+config_name = attribute(:aws_launch_configuration_name, default: '', description: 'The AWS launch configuration name.')
+
+control 'aws-launch-configurations-1.0' do
+  impact 1.0
+  title 'Ensure AWS Launch Configuration plural resource have the correct properties.'
+
+  describe aws_launch_configurations() do
+    it            { should exist }
+    its ('names') { should include config_name}
+  end
+end

--- a/test/unit/resources/aws_launch_configuration_test.rb
+++ b/test/unit/resources/aws_launch_configuration_test.rb
@@ -1,0 +1,85 @@
+require 'aws-sdk-core'
+require 'aws_launch_configuration'
+require 'helper'
+require_relative 'mock/aws_launch_configuration_mock'
+
+class AwsLaunchConfigurationConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsLaunchConfiguration.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_accepts_config_name
+    AwsLaunchConfiguration.new(launch_configuration_name: 'my-config', client_args: { stub_responses: true })
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsLaunchConfiguration.new(rubbish: 9) }
+  end
+
+  def test_launch_configuration_not_existing
+    refute AwsLaunchConfiguration.new(launch_configuration_name: 'my-config', client_args: { stub_responses: true }).exists?
+  end
+end
+
+class AwsLaunchConfigurationTest < Minitest::Test
+
+  def setup
+    # Given
+    @mock = AwsLaunchConfigurationMock.new
+    @mock_config = @mock.configuration
+
+    # When
+    @config = AwsLaunchConfiguration.new(launch_configuration_name: "my-config",
+                            client_args: { stub_responses: true },
+                            stub_data: @mock.stub_data)
+  end
+
+  def test_exists
+    assert @config.exists?
+  end
+
+  def test_launch_configuration_arn
+    assert_equal(@config.arn, @mock_config[:launch_configurations].first[:launch_configuration_arn])
+  end
+
+  def test_launch_configuration_name
+    assert_equal(@config.name, @mock_config[:launch_configurations].first[:launch_configuration_name])
+  end
+
+  def test_image_id
+    assert_equal(@config.image_id, @mock_config[:launch_configurations].first[:image_id])
+  end
+
+  def test_instance_type
+    assert_equal(@config.instance_type, @mock_config[:launch_configurations].first[:instance_type])
+  end
+
+  def test_iam_instance_profile
+    assert_equal(@config.iam_instance_profile, @mock_config[:launch_configurations].first[:iam_instance_profile])
+  end
+
+  def test_key_name
+    assert_equal(@config.key_name, @mock_config[:launch_configurations].first[:key_name])
+  end
+
+  def test_security_groups
+    assert_equal(@config.security_groups, @mock_config[:launch_configurations].first[:security_groups])
+  end
+
+  def test_ebs_optimized
+    assert_equal(@config.ebs_optimized, @mock_config[:launch_configurations].first[:ebs_optimized])
+  end
+
+  def test_spot_price
+    assert_equal(@config.spot_price, @mock_config[:launch_configurations].first[:spot_price].to_f)
+  end
+
+  def test_instance_monitoring
+    assert_equal(@config.instance_monitoring, 'detailed')
+  end
+
+  def test_user_data
+    assert_equal(@config.user_data, Base64.decode64(@mock_config[:launch_configurations].first[:user_data]))
+  end
+end

--- a/test/unit/resources/mock/aws_launch_configuration_mock.rb
+++ b/test/unit/resources/mock/aws_launch_configuration_mock.rb
@@ -1,0 +1,35 @@
+require_relative 'aws_base_resource_mock'
+
+class AwsLaunchConfigurationMock < AwsBaseResourceMock
+
+  def initialize
+    super
+    @launch_configurations = {launch_configurations: [{launch_configuration_name: @aws.any_string,
+                               launch_configuration_arn: @aws.any_arn,
+                               image_id: @aws.any_id,
+                               instance_type: @aws.any_string,
+                               iam_instance_profile: @aws.any_string,
+                               key_name: @aws.any_arn,
+                               security_groups: [],
+                               associate_public_ip_address: false,
+                               ebs_optimized: false,
+                               spot_price: '0.4',
+                               instance_monitoring: {:enabled=>true},
+                               user_data: Base64.encode64(@aws.any_string),
+                               created_time: @aws.any_date}]}
+  end
+
+  def stub_data
+    stub_data = []
+
+    config = {:client => Aws::AutoScaling::Client,
+             :method => :describe_launch_configurations,
+             :data => @launch_configurations}
+
+    stub_data += [config]
+  end
+
+  def configuration
+    @launch_configurations
+  end
+end


### PR DESCRIPTION
### Description
Add Aws Launch Configuration resource, terraform, control, tests and docs

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
