### PR TITLE
Add statement_count to aws_iam_policy

### DIFF
--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -85,6 +85,14 @@ class AwsIamPolicy < AwsResourceBase
     statement_match
   end
 
+  def statement_count
+    return false unless @policy_document
+    puts "DEBUG policy doc: #{@policy_document.inspect}"
+    document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document))
+    statements = document['Statement'].is_a?(Hash) ? [document['Statement']] : document['Statement']
+    statements.length
+  end
+
   def get_policy_document(arn, default_version_id)
     catch_aws_errors do
       @policy_document = @aws.iam_client.get_policy_version(policy_arn: arn, version_id: default_version_id)

--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -73,8 +73,8 @@ class AwsIamPolicy < AwsResourceBase
 
   def has_statement?(criteria = {})
     return false unless @policy_document
-    document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document))
-    statements = document['Statement'].is_a?(Hash) ? [document['Statement']] : document['Statement']
+    document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document), { symbolize_names: true })
+    statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document[:Statement]
     statement_match = false
     statements.each do |s|
       actions = s['Action']
@@ -87,8 +87,8 @@ class AwsIamPolicy < AwsResourceBase
 
   def statement_count
     return false unless @policy_document
-    document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document))
-    statements = document['Statement'].is_a?(Hash) ? [document['Statement']] : document['Statement']
+    document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document), { symbolize_names: true })
+    statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document[:Statement]
     statements.length
   end
 

--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -87,7 +87,6 @@ class AwsIamPolicy < AwsResourceBase
 
   def statement_count
     return false unless @policy_document
-    puts "DEBUG policy doc: #{@policy_document.inspect}"
     document = JSON.parse(URI.decode_www_form_component(@policy_document.policy_version.document))
     statements = document['Statement'].is_a?(Hash) ? [document['Statement']] : document['Statement']
     statements.length


### PR DESCRIPTION

Signed-off-by: Nathan Haneysmith <nathan@chef.io>

### Description

This feature is already in the docs, just adding functionality back in

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [X] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
