### PR TITLE
Adds aws_sts_caller_identity

### DIFF
--- a/docs/resources/aws_sts_caller_identity.md
+++ b/docs/resources/aws_sts_caller_identity.md
@@ -1,0 +1,67 @@
+---
+title: About the aws_sts_caller_identity Resource
+platform: aws
+---
+
+# aws\_sts\_caller\_identity
+
+Use the `aws_sts_caller_identity` InSpec audit resource to test properties of AWS IAM identity whose credentials are used in the current InSpec scan.
+
+<br>
+
+## Syntax
+
+An `aws_sts_caller_identity` resource block may be used to perform tests on details of the AWS credentials being used in the current Inspec scan. You can also test if the credentials belong to a GocCloud account or not.
+   
+    describe aws_sts_caller_identity do
+        ...
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+    # Check that the credentials used to run the scan is correct
+    
+        describe aws_sts_caller_identity do
+          its("arn") { should match "arn:aws:iam::.*:user/service-account-inspec" }
+        end
+
+    # Test if the account belongs to GovCloud
+    
+        describe aws_sts_caller_identity do
+          it { should be_govcloud }
+        end
+
+
+    # Skip a test if we are using GovCloud
+    
+        if aws_sts_caller_identity.govcloud?
+          describe 'Skipping Root User MFA check as we are on GovCloud' do
+            skip
+          end
+        else
+          describe aws_iam_root_user do
+            it { should have_mfa_enabled }  
+          end
+        end
+
+<br>
+
+## Properties
+
+* arn - The `arn` property identifies the AWS ARN of the credentials being used in the current InSpec scan.
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### be\_govcloud
+
+The `be_govcloud` matcher tests if the account is a 'GovCloud' AWS Account.
+
+    describe aws_sts_caller_identity do
+        it { should_not be_govcloud }
+    end

--- a/docs/resources/aws_sts_caller_identity.md
+++ b/docs/resources/aws_sts_caller_identity.md
@@ -14,7 +14,7 @@ Use the `aws_sts_caller_identity` InSpec audit resource to test properties of AW
 An `aws_sts_caller_identity` resource block may be used to perform tests on details of the AWS credentials being used in the current Inspec scan. You can also test if the credentials belong to a GocCloud account or not.
    
     describe aws_sts_caller_identity do
-        ...
+      it { should exist }
     end
 
 <br>

--- a/libraries/aws_sts_caller_identity.rb
+++ b/libraries/aws_sts_caller_identity.rb
@@ -1,0 +1,42 @@
+class AwsStsCallerIdentity < AwsResourceBase
+  name 'aws_sts_caller_identity'
+  desc 'Verifies settings for an AWS STS Caller Identity.'
+  example '
+    describe aws_sts_caller_identity do
+      its("arn") { should match "arn:aws:iam::.*:user/service-account-inspec" }
+    end
+
+    describe aws_sts_caller_identity do
+      it { should be_govcloud }
+    end
+  '
+
+  attr_reader :arn
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters([])
+
+    catch_aws_errors do
+      @arn = @aws.sts_client.get_caller_identity.arn
+    end
+  end
+
+  def govcloud?
+    fetch_arn_components[:partition] == 'aws-us-gov'
+  end
+
+  def exists?
+    !@arn.nil?
+  end
+
+  def to_s
+    'AWS Security Token Service Caller Identity'
+  end
+
+  private
+
+  def fetch_arn_components
+    Hash[%i(arn partition service region account_id resource).zip(@arn.split(':'))]
+  end
+end

--- a/test/integration/verify/controls/aws_sts_caller_identity.rb
+++ b/test/integration/verify/controls/aws_sts_caller_identity.rb
@@ -1,0 +1,13 @@
+title 'Ensure AWS credentials being used for the Inspec scan have the correct properties.'
+
+control 'aws-sts-caller-identity-1.0' do
+
+  impact 1.0
+  title 'Make sure we are not on GovCloud'
+
+  describe aws_sts_caller_identity do
+    it          { should exist }
+    it          { should_not be_govcloud }
+    its ('arn') { should_not be_nil }
+  end
+end

--- a/test/unit/resources/aws_sts_caller_identity_test.rb
+++ b/test/unit/resources/aws_sts_caller_identity_test.rb
@@ -1,0 +1,43 @@
+require 'aws-sdk-core'
+require 'aws_sts_caller_identity'
+require 'helper'
+require_relative 'mock/aws_sts_caller_identity_mock'
+
+class AwsStsCallerIdentityTest < Minitest::Test
+
+  def setup
+    # Given
+    @mock = AwsStsCallerIdentityMock.new
+    @mock_identity = @mock.identity
+
+  end
+
+  def test_params_not_ok
+    assert_raises(ArgumentError) { AwsIamUser.new(this_param: 'not-ok') }
+  end
+
+  def test_arn
+    # When
+    @identity = AwsStsCallerIdentity.new(client_args: { stub_responses: true }, stub_data: @mock.stub_data(false))
+
+    # Then
+    assert_equal(@identity.arn, @mock_identity[:arn])
+  end
+
+  def test_is_gov_cloud
+    # When
+    @identity = AwsStsCallerIdentity.new(client_args: { stub_responses: true }, stub_data: @mock.stub_data(true))
+
+    # Then
+    assert(@identity.govcloud?)
+  end
+
+  def test_arn
+    # When
+    @identity = AwsStsCallerIdentity.new(client_args: { stub_responses: true }, stub_data: @mock.stub_data(false))
+
+    # Then
+    assert(!@identity.govcloud?)
+  end
+
+end

--- a/test/unit/resources/mock/aws_givens.rb
+++ b/test/unit/resources/mock/aws_givens.rb
@@ -3,8 +3,17 @@ require 'securerandom'
 class AwsGivens
 
   # Standardised AWS "arn" field.
-  def any_arn
-    "arn:aws:mocked::#{any_int}:#{any_string}/#{any_string}"
+  def any_arn(components = {})
+    "arn:aws:mocked::#{any_int}:#{any_string}/#{any_string}" if components.empty?
+
+    arn = ''
+    components.key?(:arn)        ? arn << "#{components[:arn]}:"        : arn << 'arn:'
+    components.key?(:partition)  ? arn << "#{components[:partition]}:"  : arn << 'aws:'
+    components.key?(:service)    ? arn << "#{components[:service]}:"    : arn << 'mocked:'
+    components.key?(:region)     ? arn << "#{components[:region]}:"     : arn << "#{any_region}:"
+    components.key?(:account_id) ? arn << "#{components[:account_id]}:" : arn << "#{any_int}:"
+    components.key?(:resource)   ? arn << "#{components[:resource]}:"   : arn << "#{any_string}:"
+    arn
   end
 
   # Any standardised AWS "id" field.

--- a/test/unit/resources/mock/aws_sts_caller_identity_mock.rb
+++ b/test/unit/resources/mock/aws_sts_caller_identity_mock.rb
@@ -1,0 +1,31 @@
+require_relative 'aws_base_resource_mock'
+
+class AwsStsCallerIdentityMock < AwsBaseResourceMock
+
+  def initialize
+    super
+
+    @sts = {
+        account: @aws.any_string,
+        arn: @aws.any_arn,
+        user_id: @aws.any_string,
+    }
+  end
+
+  def stub_data(is_govcloud)
+    stub_data = []
+
+    @sts[:arn] = @aws.any_arn({ partition: 'aws-us-gov' }) if is_govcloud
+
+    sts = { :client => Aws::STS::Client,
+            :method => :get_caller_identity,
+            :data => @sts }
+
+    stub_data += [sts]
+  end
+
+  def identity
+    @sts
+  end
+
+end


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Adds `aws_sts_caller_identity` resource, allowing the testing of the current credentials being used for the Inspec scan. Original issue opened on Inspec @ https://github.com/inspec/inspec/pull/3701

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [NA] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
