### PR TITLE
AWS Organizations service name is plural

### DIFF
--- a/docs/resources/aws_organizations_member.md
+++ b/docs/resources/aws_organizations_member.md
@@ -1,21 +1,21 @@
 ---
-title: About the aws_organization_member Resource
+title: About the aws_organizations_member Resource
 ---
 
-# aws\_organization\_member
+# aws\_organizations\_member
 
-Use the `aws_organization_member` InSpec audit resource to test the current AWS Account being used within organization.
+Use the `aws_organizations_member` InSpec audit resource to test the current AWS Account being used within organization.
 
 ## Syntax
 
-An `aws_organization_member` resource block tests if the current AWS Account is the Master Account.
+An `aws_organizations_member` resource block tests if the current AWS Account is the Master Account.
  
 The `master` matcher will return `true` or `false` accordingly. 
 You may also verify that the `master_account_id` and `master_account_arn` properties match known values.
 
 If the current AWS Account _**is**_ the Master Account, you may also access properties of that account.
   
-        describe aws_organization_member do
+        describe aws_organizations_member do
             ...
         end
 <br>
@@ -26,14 +26,14 @@ The following examples show how to use this InSpec audit resource.
 
     # Ensure you are a child account with a certain ID for the top level account.
     
-        describe aws_organization_member do
+        describe aws_organizations_member do
           it                       { should_not be_master }
           its('master_account_id') { should cmp '56845218745' }
         end
     
     # Ensure you are the top level account, with the right name and email associated.
         
-        describe aws_organization_member do
+        describe aws_organizations_member do
           it                   { should be_master }
           its('account_name')  { should eq 'MyAWSMasterAccount' }
           its('account_email') { should eq 'aws.admin@org.com' }
@@ -43,8 +43,8 @@ The following examples show how to use this InSpec audit resource.
 
 ## Properties
 
-* `master_account_id` - The ID of the AWS Organization's Master Account
-* `master_account_arn` - The ARN of the AWS Organization's Master Account
+* `master_account_id` - The ID of the AWS Organizations Master Account
+* `master_account_arn` - The ARN of the AWS Organizations Master Account
 
 _**If the current Account is the Master Account, the following properties are also available:**_
 * `account_id`      - The ID of the current Account.

--- a/libraries/aws_organizations_member.rb
+++ b/libraries/aws_organizations_member.rb
@@ -2,11 +2,11 @@
 
 require 'aws_backend'
 
-class AwsOrganizationMember < AwsResourceBase
-  name 'aws_organization_member'
+class AwsOrganizationsMember < AwsResourceBase
+  name 'aws_organizations_member'
   desc 'Verifies status of the current AWWS Account within Organizations service.'
   example '
-    describe aws_organization_member do
+    describe aws_organizations_member do
       it                       { should_not be_master }
       its("master_account_id") { should cmp "6525687452" }
     end

--- a/test/integration/verify/controls/aws_organizations_member.rb
+++ b/test/integration/verify/controls/aws_organizations_member.rb
@@ -3,7 +3,7 @@ control 'aws-organizations-member-1.0' do
   impact 1.0
   title 'Ensure the current AWS Account is not the Master Account'
 
-  describe aws_organization_member do
+  describe aws_organizations_member do
     it { should exist }
     it { should_not be_master }
   end

--- a/test/unit/resources/aws_organizations_member_test.rb
+++ b/test/unit/resources/aws_organizations_member_test.rb
@@ -1,19 +1,19 @@
 require 'aws-sdk-core'
-require 'aws_organization_member'
+require 'aws_organizations_member'
 require 'helper'
-require_relative 'mock/aws_organization_member_mock'
+require_relative 'mock/aws_organizations_member_mock'
 
-class AwsOrganizationMemberTest < Minitest::Test
+class AwsOrganizationsMemberTest < Minitest::Test
 
   def test_constructor
     # Given
-    mock = AwsOrganizationMemberMock.new
+    mock = AwsOrganizationsMemberMock.new
     @mock_account = mock.account
     @mock_org = mock.organization
     stub_data = mock.stub_data(true)
 
     # When
-    @org_member = AwsOrganizationMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
+    @org_member = AwsOrganizationsMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
 
     # Then
     assert_equal(@org_member.master_account_id, @mock_org[:master_account_id])
@@ -25,16 +25,16 @@ class AwsOrganizationMemberTest < Minitest::Test
   end
 
   def test_no_params_allowed
-    assert_raises(ArgumentError) { AwsOrganizationMember.new(arguments_not_allowed: 'expect_failure') }
+    assert_raises(ArgumentError) { AwsOrganizationsMember.new(arguments_not_allowed: 'expect_failure') }
   end
 
   def test_exists
     # Given
-    mock = AwsOrganizationMemberMock.new
+    mock = AwsOrganizationsMemberMock.new
     stub_data = mock.stub_data(false)
 
     # When
-    org_member = AwsOrganizationMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
+    org_member = AwsOrganizationsMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
 
     # Then
     assert(org_member.exists?)
@@ -42,11 +42,11 @@ class AwsOrganizationMemberTest < Minitest::Test
 
   def test_not_master_account
     # Given
-    mock = AwsOrganizationMemberMock.new
+    mock = AwsOrganizationsMemberMock.new
     stub_data = mock.stub_data(false)
 
     # When
-    org_member = AwsOrganizationMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
+    org_member = AwsOrganizationsMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
 
     # Then
     assert(!org_member.master?)
@@ -58,12 +58,12 @@ class AwsOrganizationMemberTest < Minitest::Test
 
   def test_is_master_account
     # Given
-    mock = AwsOrganizationMemberMock.new
+    mock = AwsOrganizationsMemberMock.new
     mock_account = mock.account
     stub_data = mock.stub_data(true)
 
     # When
-    org_member = AwsOrganizationMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
+    org_member = AwsOrganizationsMember.new(client_args: { stub_responses: true }, stub_data: stub_data)
 
     # Then
     assert(org_member.master?)

--- a/test/unit/resources/mock/aws_organizations_member_mock.rb
+++ b/test/unit/resources/mock/aws_organizations_member_mock.rb
@@ -1,6 +1,6 @@
 require_relative 'aws_base_resource_mock'
 
-class AwsOrganizationMemberMock < AwsBaseResourceMock
+class AwsOrganizationsMemberMock < AwsBaseResourceMock
 
   def initialize
     super


### PR DESCRIPTION
`aws_organization_member` -> `aws_organizations_member`

Obvious Fix.