### PR TITLE
New resource IAM account alias

### DIFF
--- a/docs/resources/aws_iam_account_alias.md
+++ b/docs/resources/aws_iam_account_alias.md
@@ -25,16 +25,16 @@ The following examples show how to use this InSpec audit resource.
 
     # Check that the account alias has not be set
     
-        describe aws_iam_account_alias do
-          it { should_not exist }
-        end
+      describe aws_iam_account_alias do
+        it { should_not exist }
+      end
 
     # Test if the account alias starts with expected prefix
     
-        describe aws_iam_account_alias do
-          it { should exist }
-          its('alias') { should match /^fancy-/ }
-        end
+      describe aws_iam_account_alias do
+        it { should exist }
+        its('alias') { should match /^fancy-/ }
+      end
 
 <br>
 

--- a/docs/resources/aws_iam_account_alias.md
+++ b/docs/resources/aws_iam_account_alias.md
@@ -1,0 +1,53 @@
+---
+title: About the aws_iam_account_alias Resource
+platform: aws
+---
+
+# aws\_iam\_account\_alias
+
+Use the `aws_iam_account_alias` InSpec audit resource to test properties of the AWS IAM account alias.
+
+<br>
+
+## Syntax
+
+An `aws_iam_account_alias` resource block may be used to perform tests on details of the AWS account alias.
+   
+    describe aws_iam_account_alias do
+      it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+    # Check that the account alias has not be set
+    
+        describe aws_iam_account_alias do
+          it { should_not exist }
+        end
+
+    # Test if the account alias starts with expected prefix
+    
+        describe aws_iam_account_alias do
+          it { should exist }
+          its('alias') { should match /^fancy-/ }
+        end
+
+<br>
+
+## Properties
+
+* alias - The `alias` property identifies the AWS account alias.
+
+## Matchers
+
+### exist
+
+The control will pass if an account alias has been created.
+
+    describe aws_iam_account_alias do
+      it { should exist }
+    end

--- a/docs/resources/aws_sts_caller_identity.md
+++ b/docs/resources/aws_sts_caller_identity.md
@@ -11,7 +11,7 @@ Use the `aws_sts_caller_identity` InSpec audit resource to test properties of AW
 
 ## Syntax
 
-An `aws_sts_caller_identity` resource block may be used to perform tests on details of the AWS credentials being used in the current Inspec scan. You can also test if the credentials belong to a GocCloud account or not.
+An `aws_sts_caller_identity` resource block may be used to perform tests on details of the AWS credentials being used in the current Inspec scan. You can also test if the credentials belong to a GovCloud account or not.
    
     describe aws_sts_caller_identity do
       it { should exist }

--- a/libraries/aws_iam_account_alias.rb
+++ b/libraries/aws_iam_account_alias.rb
@@ -1,0 +1,32 @@
+class AwsIamAccountAlias < AwsResourceBase
+  name 'aws_iam_account_alias'
+  desc 'Verifies settings for an AWS IAM Account Alias.'
+  example '
+    describe aws_iam_account_alias do
+      it  { should exist }
+      its ("alias") { should match /^fancy-/ }
+    end
+  '
+  supports platform: 'aws'
+
+  attr_reader :alias
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters([])
+
+    catch_aws_errors do
+      # Note, although this is an array, you can only have one account alias
+      # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/IAM/Client.html#list_account_aliases-instance_method
+      @alias = @aws.iam_client.list_account_aliases.account_aliases[0]
+    end
+  end
+
+  def exists?
+    !@alias.nil?
+  end
+
+  def to_s
+    'AWS IAM Account Alias'
+  end
+end

--- a/libraries/aws_iam_account_alias.rb
+++ b/libraries/aws_iam_account_alias.rb
@@ -3,8 +3,8 @@ class AwsIamAccountAlias < AwsResourceBase
   desc 'Verifies settings for an AWS IAM Account Alias.'
   example '
     describe aws_iam_account_alias do
-      it  { should exist }
-      its ("alias") { should match /^fancy-/ }
+      it { should exist }
+      its("alias") { should match /^fancy-/ }
     end
   '
   supports platform: 'aws'
@@ -27,6 +27,6 @@ class AwsIamAccountAlias < AwsResourceBase
   end
 
   def to_s
-    'AWS IAM Account Alias'
+    "AWS IAM Account Alias #{@alias}"
   end
 end

--- a/test/integration/verify/controls/aws_iam_account_alias.rb
+++ b/test/integration/verify/controls/aws_iam_account_alias.rb
@@ -4,6 +4,7 @@ control 'aws-iam-account-alias-1.0' do
   title 'Test the AWS IAM Account Alias'
 
   describe aws_iam_account_alias do
-    it { should_not exist }
+    it            { should exist }
+    its('alias')  { should_not be_nil}
   end
 end

--- a/test/integration/verify/controls/aws_iam_account_alias.rb
+++ b/test/integration/verify/controls/aws_iam_account_alias.rb
@@ -1,0 +1,9 @@
+control 'aws-iam-account-alias-1.0' do
+
+  impact 1.0
+  title 'Test the AWS IAM Account Alias'
+
+  describe aws_iam_account_alias do
+    it { should_not exist }
+  end
+end

--- a/test/unit/resources/aws_iam_account_alias_test.rb
+++ b/test/unit/resources/aws_iam_account_alias_test.rb
@@ -1,0 +1,25 @@
+require 'aws-sdk-core'
+require 'aws_iam_account_alias'
+require 'helper'
+require_relative 'mock/iam/aws_iam_account_alias_mock'
+
+class AwsIamAccountAliasTest < Minitest::Test
+
+  def setup
+    # Given
+    @mock      = AwsIamAccountAliasMock.new
+    @mock_alias = @mock.alias
+
+    # When
+    @alias = AwsIamAccountAlias.new(client_args: { stub_responses: true }, stub_data: @mock.stub_data)
+  end
+
+  def test_exists
+    assert(@alias.exists?)
+  end
+
+  def test_alias_name
+    assert_equal(@alias.alias, @mock_alias[:account_aliases][0])
+  end
+
+end

--- a/test/unit/resources/aws_iam_account_alias_test.rb
+++ b/test/unit/resources/aws_iam_account_alias_test.rb
@@ -7,7 +7,7 @@ class AwsIamAccountAliasTest < Minitest::Test
 
   def setup
     # Given
-    @mock      = AwsIamAccountAliasMock.new
+    @mock = AwsIamAccountAliasMock.new
     @mock_alias = @mock.alias
 
     # When

--- a/test/unit/resources/mock/iam/aws_iam_account_alias_mock.rb
+++ b/test/unit/resources/mock/iam/aws_iam_account_alias_mock.rb
@@ -1,0 +1,23 @@
+require_relative '../aws_base_resource_mock'
+
+class AwsIamAccountAliasMock < AwsBaseResourceMock
+
+  # Default attributes.
+  def initialize
+    super
+    @alias = {
+      account_aliases: [
+        @aws.any_string
+      ]
+    }
+  end
+
+  # Provide the mapping for what to return when mocking calls to the AWS SDK.
+  def stub_data
+    [{ :client => Aws::IAM::Client, :method => :list_account_aliases, :data => @alias }]
+  end
+
+  def alias
+    @alias
+  end
+end


### PR DESCRIPTION
Signed-off-by: Nathan Haneysmith <nathan@chef.io>

### Description

Add a new resource for IAM account alias. 
Also includes a typo fix in doc for sts caller identity.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [N/A] New Terraform resources
- [X] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
