### PR TITLE
Adds better error handling to Resource base class

### DIFF
--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -184,9 +184,9 @@ class AwsResourceBase < Inspec.resource(1)
       end
       fail_resource("Unable to execute control: #{e.message}\n#{advice}")
     else
-      Inspec::Log.warn "AWS Service Error encountered running a control with Resource #{@__resource_name__}. " +
-                       "Error message: #{e.message}. You should address this error to ensure your controls are " +
-                       "behaving as expected."
+      Inspec::Log.warn "AWS Service Error encountered running a control with Resource #{@__resource_name__}. " \
+                       "Error message: #{e.message}. You should address this error to ensure your controls are " \
+                       'behaving as expected.'
       @failed_resource = true
       nil
     end
@@ -199,8 +199,8 @@ class AwsResourceBase < Inspec.resource(1)
 
   # Each client has its own variation of Aws::*::Errors::AccessDenied, making the checking cumbersome and flaky.
   # Checking the status code is more reliable.
-  def is_permissions_error(e)
-    true if e.context.http_response.status_code == 403
+  def is_permissions_error(error)
+    true if error.context.http_response.status_code == 403
   end
 end
 

--- a/libraries/aws_s3_buckets.rb
+++ b/libraries/aws_s3_buckets.rb
@@ -11,16 +11,18 @@ class AwsS3Buckets < AwsResourceBase
     end
   "
 
+  attr_reader :table
+
+  FilterTable.create
+             .register_column(:bucket_names, field: :bucket_name)
+             .install_filter_methods_on_resource(self, :table)
+
   def initialize(opts = {})
     # Call the parent class constructor
     super(opts)
     validate_parameters([])
+    @table = fetch_data
   end
-
-  # FilterTable setup
-  filter_table_config = FilterTable.create
-  filter_table_config.add(:bucket_names, field: :bucket_name)
-  filter_table_config.connect(self, :fetch_data)
 
   def fetch_data
     bucket_rows = []


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Currently we swallow both `AccessDenied` and `InvalidAccessKeyId` exceptions returned from the AWS SDK. This change forces the failure of resources which encounter these errors, and provides advice on remediation. Examples below;

With an invalid Access Key set:
```
  ×  aws-s3-buckets-1.0: Ensure AWS S3 Buckets plural resource has the correct properties.
     ×  aws_s3_buckets 
     Unable to execute control: The AWS Access Key Id you provided does not exist in our records.
     Please ensure your AWS Access Key ID is set correctly.
```

With insufficient permissions to perform an operation:
```
  ×  aws-s3-buckets-1.0: Ensure AWS S3 Buckets plural resource has the correct properties.
     ×  aws_s3_buckets 
     Unable to execute control: Access Denied
     Please check the IAM permissions required for this Resource in the documentation, and ensure your Service Principal has these permissions set.
```

### Issues Resolved

Resolves https://github.com/inspec/inspec-aws/issues/17

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [N/A] New functionality includes integration tests/controls
- [N/A] New Terraform resources
- [N/A] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
