### PR TITLE
Adds tags property to S3, VPC, SG and RDS resources.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,3 +94,5 @@ Style/IfUnlessModifier:
   Enabled: false
 Style/RescueStandardError:
   Enabled: false
+Metrics/BlockNesting:
+  Enabled: false

--- a/docs/resources/aws_s3_bucket.md
+++ b/docs/resources/aws_s3_bucket.md
@@ -70,6 +70,15 @@ The `region` property identifies the AWS Region in which the S3 bucket is locate
       # Check if the correct region is set
       its('region') { should eq 'us-east-1' }
     end
+    
+### tags
+
+The tags of the S3 bucket.
+        
+    describe aws_s3_bucket do
+        its('tags') { should include(:Environment => 'env-name',
+                                     :Name => 'bucket-name')}
+    end
 
 ## Unsupported Properties
 

--- a/docs/resources/aws_s3_buckets.md
+++ b/docs/resources/aws_s3_buckets.md
@@ -52,6 +52,15 @@ Provides an array of strings containing the names of the buckets.
       its('bucket_names') { should include 'my_bucket' }
     end
 
+### tags
+
+Provides a list of hashes containing the tags of the buckets.
+        
+    describe aws_s3_buckets do
+        its('tags') { should include(:Environment => 'env-name',
+                                     :Name => 'bucket-name')}
+    end
+
 ## AWS Permissions
 
 Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `s3:ListAllMyBuckets` action with Effect set to Allow.

--- a/docs/resources/aws_security_group.md
+++ b/docs/resources/aws_security_group.md
@@ -239,6 +239,15 @@ A String in the format 'vpc-' followed by 8 hexadecimal characters reflecting VP
     describe aws_security_group('sg-12345678') do
       its('vpc_id') { should cmp 'vpc-12345678' }
     end
+    
+### tags
+        
+    The tags of the security group.
+        
+        describe aws_security_group do
+          its('tags') { should include(:Environment => 'env-name',
+                                       :Name => 'group-name')}
+        end
 
 <br>
 

--- a/docs/resources/aws_security_groups.md
+++ b/docs/resources/aws_security_groups.md
@@ -54,7 +54,7 @@ A string identifying a group. Since groups are contained in VPCs, group names ar
 
 ## Properties
 
-* `entries`, `group_ids`
+* `entries`, `group_ids`, `tags`
 
 <br>
 
@@ -76,6 +76,15 @@ Provides a list of all security group IDs matched.
     describe aws_security_groups do
       its('group_ids') { should include('sg-12345678') }
     end
+    
+### tags
+        
+Provides a list of hashes containing the tags of the groups.
+        
+        describe aws_security_group do
+          its('tags') { should include(:Environment => 'env-name',
+                                       :Name => 'group-name')}
+        end
 
 ## Matchers
 

--- a/docs/resources/aws_vpc.md
+++ b/docs/resources/aws_vpc.md
@@ -109,6 +109,15 @@ The ID of the VPC.
     describe aws_vpc do
       its('vpc_id') { should eq 'vpc-87654321' }
     end
+    
+### tags
+    
+The tags of the VPC.
+    
+    describe aws_vpc do
+      its('tags') { should include(:Environment => 'env-name',
+                                   :Name => 'vpc-name')}
+    end
 
 <br>
 

--- a/docs/resources/aws_vpcs.md
+++ b/docs/resources/aws_vpcs.md
@@ -105,6 +105,15 @@ The vpc_ids property provides a list of the IDs of the matched VPCs.
       # Do something with vpc_id
     end
 
+### tags
+    
+Provides a list of hashes containing the tags of the VPCs.
+    
+    describe aws_vpc do
+      its('tags') { should include(:Environment => 'env-name',
+                                   :Name => 'vpc-name')}
+    end
+
 ## Matchers
 
 This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -211,7 +211,6 @@ class AwsResourceBase < Inspec.resource(1)
     end
     tags
   end
-
 end
 
 # Class to create methods on the calling object at run time.  Heavily based on the Azure Inspec resources.

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -255,11 +255,11 @@ class AwsResourceDynamicMethods
             probes[tag[:key].to_sym] = tag[:value]
           end
         else
-        probes = []
-        value.each do |value_item|
-          # p value_item
-          value_item = value_item.to_h if value_item.respond_to? :to_h
-          probes << AwsResourceProbe.new(value_item)
+          probes = []
+          value.each do |value_item|
+            # p value_item
+            value_item = value_item.to_h if value_item.respond_to? :to_h
+            probes << AwsResourceProbe.new(value_item)
           end
         end
       end

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -278,7 +278,7 @@ class AwsResourceDynamicMethods
       when 'String', 'Integer', 'TrueClass', 'FalseClass', 'Fixnum'
         probes = value
       else
-        if name.eql?('tags'.to_sym)
+        if name.eql?(:tags)
           probes = {}
           value.each do |tag|
             probes[tag[:key]] = tag[:value]
@@ -286,7 +286,6 @@ class AwsResourceDynamicMethods
         else
           probes = []
           value.each do |value_item|
-            # p value_item
             value_item = value_item.to_h if value_item.respond_to? :to_h
             probes << AwsResourceProbe.new(value_item)
           end

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -249,11 +249,18 @@ class AwsResourceDynamicMethods
       when 'String', 'Integer', 'TrueClass', 'FalseClass', 'Fixnum'
         probes = value
       else
+        if name.eql?('tags'.to_sym)
+          probes = {}
+          value.each do |tag|
+            probes[tag[:key].to_sym] = tag[:value]
+          end
+        else
         probes = []
         value.each do |value_item|
           # p value_item
           value_item = value_item.to_h if value_item.respond_to? :to_h
           probes << AwsResourceProbe.new(value_item)
+          end
         end
       end
       object.define_singleton_method name do

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -202,6 +202,16 @@ class AwsResourceBase < Inspec.resource(1)
   def is_permissions_error(error)
     true if error.context.http_response.status_code == 403
   end
+
+  def map_tags(tag_list)
+    return {} if tag_list.nil? || tag_list.empty?
+    tags = {}
+    tag_list.each do |tag|
+      tags[tag[:key]] = tag[:value]
+    end
+    tags
+  end
+
 end
 
 # Class to create methods on the calling object at run time.  Heavily based on the Azure Inspec resources.
@@ -272,7 +282,7 @@ class AwsResourceDynamicMethods
         if name.eql?('tags'.to_sym)
           probes = {}
           value.each do |tag|
-            probes[tag[:key].to_sym] = tag[:value]
+            probes[tag[:key]] = tag[:value]
           end
         else
           probes = []

--- a/libraries/aws_rds_instance.rb
+++ b/libraries/aws_rds_instance.rb
@@ -36,12 +36,12 @@ class AwsRdsInstance < AwsResourceBase
   end
 
   def tags
-    tags = {}
-    tag_list = @aws.rds_client.list_tags_for_resource(resource_name: @rds_instance[:db_instance_arn]).tag_list
-    tag_list.each do |tag|
-      tags[tag[:key].to_sym] = tag[:value]
+    begin
+      tag_list = @aws.rds_client.list_tags_for_resource(resource_name: @rds_instance[:db_instance_arn]).tag_list
+    rescue
+      return {}
     end
-    tags
+    map_tags(tag_list)
   end
 
   def to_s

--- a/libraries/aws_rds_instance.rb
+++ b/libraries/aws_rds_instance.rb
@@ -35,6 +35,15 @@ class AwsRdsInstance < AwsResourceBase
     end
   end
 
+  def tags
+    tags = {}
+    tag_list = @aws.rds_client.list_tags_for_resource(resource_name: @rds_instance[:db_instance_arn]).tag_list
+    tag_list.each do |tag|
+      tags[tag[:key].to_sym] = tag[:value]
+    end
+    tags
+  end
+
   def to_s
     "RDS Instance #{@display_name}"
   end

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -104,7 +104,7 @@ class AwsS3Bucket < AwsResourceBase
 
   def tags
     begin
-      tag_list =@aws.storage_client.get_bucket_tagging(bucket: @bucket_name).tag_set
+      tag_list = @aws.storage_client.get_bucket_tagging(bucket: @bucket_name).tag_set
     rescue
       return {}
     end

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -103,12 +103,12 @@ class AwsS3Bucket < AwsResourceBase
   end
 
   def tags
-    tags = {}
-    tag_list = @aws.storage_client.get_bucket_tagging(bucket: @bucket_name).tag_set
-    tag_list.each do |tag|
-      tags[tag[:key].to_sym] = tag[:value]
+    begin
+      tag_list =@aws.storage_client.get_bucket_tagging(bucket: @bucket_name).tag_set
+    rescue
+      return {}
     end
-    tags
+    map_tags(tag_list)
   end
 
   def to_s

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -102,6 +102,15 @@ class AwsS3Bucket < AwsResourceBase
     policy_list
   end
 
+  def tags
+    tags = {}
+    tag_list = @aws.storage_client.get_bucket_tagging(bucket: @bucket_name).tag_set
+    tag_list.each do |tag|
+      tags[tag[:key].to_sym] = tag[:value]
+    end
+    tags
+  end
+
   def to_s
     "S3 Bucket #{@bucket_name}"
   end

--- a/libraries/aws_s3_buckets.rb
+++ b/libraries/aws_s3_buckets.rb
@@ -20,17 +20,34 @@ class AwsS3Buckets < AwsResourceBase
   # FilterTable setup
   filter_table_config = FilterTable.create
   filter_table_config.add(:bucket_names, field: :bucket_name)
+  filter_table_config.add(:tags, field: :tags)
   filter_table_config.connect(self, :fetch_data)
 
   def fetch_data
     bucket_rows = []
     catch_aws_errors do
-      @api_response = @aws.storage_client.list_buckets.each do |resp|
+      @api_response = @aws.storage_client.list_buckets
+    end
+    @api_response.each do |resp|
         resp.buckets.each do |bucket|
-          bucket_rows += [{ bucket_name: bucket[:name] }]
+          bucket_rows += [{ bucket_name: bucket[:name],
+                            tags: fetch_tags(bucket[:name])}]
         end
       end
-    end
     @table = bucket_rows
+  end
+
+  def fetch_tags(bucket_name)
+    tags = {}
+    begin
+      tag_list = @aws.storage_client.get_bucket_tagging(bucket: bucket_name)
+      unless tag_list.nil? || tag_list.empty?
+        tag_list.tag_set.each do |tag|
+        tags[tag[:key].to_sym] = tag[:value]
+        end
+      end
+    rescue
+    end
+    tags
   end
 end

--- a/libraries/aws_s3_buckets.rb
+++ b/libraries/aws_s3_buckets.rb
@@ -15,6 +15,7 @@ class AwsS3Buckets < AwsResourceBase
 
   FilterTable.create
              .register_column(:bucket_names, field: :bucket_name)
+             .register_column(:tags,         field: :tags)
              .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
@@ -23,12 +24,6 @@ class AwsS3Buckets < AwsResourceBase
     validate_parameters([])
     @table = fetch_data
   end
-
-  # FilterTable setup
-  filter_table_config = FilterTable.create
-  filter_table_config.add(:bucket_names, field: :bucket_name)
-  filter_table_config.add(:tags, field: :tags)
-  filter_table_config.connect(self, :fetch_data)
 
   def fetch_data
     bucket_rows = []

--- a/libraries/aws_s3_buckets.rb
+++ b/libraries/aws_s3_buckets.rb
@@ -45,16 +45,11 @@ class AwsS3Buckets < AwsResourceBase
   end
 
   def fetch_tags(bucket_name)
-    tags = {}
     begin
       tag_list = @aws.storage_client.get_bucket_tagging(bucket: bucket_name)
-      unless tag_list.nil? || tag_list.empty?
-        tag_list.tag_set.each do |tag|
-          tags[tag[:key].to_sym] = tag[:value]
-        end
-      end
     rescue
+      return {}
     end
-    tags
+    map_tags(tag_list)
   end
 end

--- a/libraries/aws_s3_buckets.rb
+++ b/libraries/aws_s3_buckets.rb
@@ -29,11 +29,11 @@ class AwsS3Buckets < AwsResourceBase
       @api_response = @aws.storage_client.list_buckets
     end
     @api_response.each do |resp|
-        resp.buckets.each do |bucket|
-          bucket_rows += [{ bucket_name: bucket[:name],
-                            tags: fetch_tags(bucket[:name])}]
-        end
+      resp.buckets.each do |bucket|
+        bucket_rows += [{ bucket_name: bucket[:name],
+                          tags: fetch_tags(bucket[:name]) }]
       end
+    end
     @table = bucket_rows
   end
 
@@ -43,7 +43,7 @@ class AwsS3Buckets < AwsResourceBase
       tag_list = @aws.storage_client.get_bucket_tagging(bucket: bucket_name)
       unless tag_list.nil? || tag_list.empty?
         tag_list.tag_set.each do |tag|
-        tags[tag[:key].to_sym] = tag[:value]
+          tags[tag[:key].to_sym] = tag[:value]
         end
       end
     rescue

--- a/libraries/aws_s3_buckets.rb
+++ b/libraries/aws_s3_buckets.rb
@@ -45,6 +45,6 @@ class AwsS3Buckets < AwsResourceBase
     rescue
       return {}
     end
-    map_tags(tag_list)
+    map_tags(tag_list.tag_set)
   end
 end

--- a/libraries/aws_security_group.rb
+++ b/libraries/aws_security_group.rb
@@ -50,10 +50,7 @@ class AwsSecurityGroup < AwsResourceBase
       @inbound_rules_count = count_sg_rules(@security_group.ip_permissions.map(&:to_h))
       @outbound_rules = @security_group.ip_permissions_egress.map(&:to_h)
       @outbound_rules_count = count_sg_rules(@security_group.ip_permissions_egress.map(&:to_h))
-      @tags = {}
-      unless @security_group.tags.nil?
-        @security_group.tags.each { |tag| @tags[tag[:key].to_sym] = tag[:value] }
-      end
+      @tags = map_tags(@security_group.tags)
     end
   end
 

--- a/libraries/aws_security_group.rb
+++ b/libraries/aws_security_group.rb
@@ -12,7 +12,7 @@ class AwsSecurityGroup < AwsResourceBase
     it { should exist }
   end
   "
-  attr_reader :description, :group_id, :group_name, :vpc_id, :inbound_rules, :outbound_rules, :inbound_rules_count, :outbound_rules_count, :exists
+  attr_reader :description, :group_id, :group_name, :vpc_id, :inbound_rules, :outbound_rules, :inbound_rules_count, :outbound_rules_count, :exists, :tags
   alias exists? exists
 
   def initialize(opts = {})
@@ -50,6 +50,10 @@ class AwsSecurityGroup < AwsResourceBase
       @inbound_rules_count = count_sg_rules(@security_group.ip_permissions.map(&:to_h))
       @outbound_rules = @security_group.ip_permissions_egress.map(&:to_h)
       @outbound_rules_count = count_sg_rules(@security_group.ip_permissions_egress.map(&:to_h))
+      @tags = {}
+      unless @security_group.tags.nil?
+        @security_group.tags.each { |tag| @tags[tag[:key].to_sym] = tag[:value] }
+      end
     end
   end
 

--- a/libraries/aws_security_groups.rb
+++ b/libraries/aws_security_groups.rb
@@ -45,20 +45,12 @@ class AwsSecurityGroups < AwsResourceBase
           group_id: security_group.group_id,
                                     vpc_id: security_group.vpc_id,
                                     group_name: security_group.group_name,
-                                    tags: fetch_tags(security_group.tags),
+                                    tags: map_tags(security_group.tags),
         }]
       end
       break unless @api_response.next_token
       pagination_options = { next_token: @api_response.next_token }
     end
     @table = security_group_rows
-  end
-
-  def fetch_tags(tag_list)
-    tags = {}
-    tag_list.each do |tag|
-      tags[tag[:key].to_sym] = tag[:value]
-    end
-    tags
   end
 end

--- a/libraries/aws_security_groups.rb
+++ b/libraries/aws_security_groups.rb
@@ -17,19 +17,22 @@ class AwsSecurityGroups < AwsResourceBase
     end
   "
 
+  attr_reader :table
+
+  # FilterTable setup
+  FilterTable.create
+             .register_column(:tags,        field: :tags)
+             .register_column(:group_names, field: :group_name)
+             .register_column(:vpc_ids,     field: :vpc_id)
+             .register_column(:group_ids,   field: :group_id)
+             .install_filter_methods_on_resource(self, :table)
+
   def initialize(opts = {})
     # Call the parent class constructor
     super(opts)
     validate_parameters([])
+    @table = fetch_data
   end
-
-  # FilterTable setup
-  filter_table_config = FilterTable.create
-  filter_table_config.add(:group_ids, field: :group_id)
-  filter_table_config.add(:vpc_ids, field: :vpc_id)
-  filter_table_config.add(:group_names, field: :group_name)
-  filter_table_config.add(:tags, field: :tags)
-  filter_table_config.connect(self, :fetch_data)
 
   def fetch_data
     security_group_rows = []

--- a/libraries/aws_security_groups.rb
+++ b/libraries/aws_security_groups.rb
@@ -28,6 +28,7 @@ class AwsSecurityGroups < AwsResourceBase
   filter_table_config.add(:group_ids, field: :group_id)
   filter_table_config.add(:vpc_ids, field: :vpc_id)
   filter_table_config.add(:group_names, field: :group_name)
+  filter_table_config.add(:tags, field: :tags)
   filter_table_config.connect(self, :fetch_data)
 
   def fetch_data
@@ -44,11 +45,20 @@ class AwsSecurityGroups < AwsResourceBase
           group_id: security_group.group_id,
                                     vpc_id: security_group.vpc_id,
                                     group_name: security_group.group_name,
+                                    tags: fetch_tags(security_group.tags),
         }]
       end
       break unless @api_response.next_token
       pagination_options = { next_token: @api_response.next_token }
     end
     @table = security_group_rows
+  end
+
+  def fetch_tags(tag_list)
+    tags = {}
+    tag_list.each do |tag|
+      tags[tag[:key].to_sym] = tag[:value]
+    end
+    tags
   end
 end

--- a/libraries/aws_vpcs.rb
+++ b/libraries/aws_vpcs.rb
@@ -11,23 +11,25 @@ class AwsVpcs < AwsResourceBase
       it { should exist }
     end
   '
+  attr_reader :table
+
+  # FilterTable setup
+  FilterTable.create
+             .register_column(:cidr_blocks,        field: :cidr_block)
+             .register_column(:vpc_ids,            field: :vpc_id)
+             .register_column(:states,             field: :state)
+             .register_column(:dhcp_options_ids,   field: :dhcp_options_id)
+             .register_column(:instance_tenancys,  field: :instance_tenancy)
+             .register_column(:is_defaults,        field: :is_default)
+             .register_column(:tags,               field: :tags)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
     # Call the parent class constructor
     super(opts)
     validate_parameters([])
+    @table = fetch_data
   end
-
-  # FilterTable setup
-  filter_table_config = FilterTable.create
-  filter_table_config.add(:cidr_blocks, field: :cidr_block)
-  filter_table_config.add(:vpc_ids, field: :vpc_id)
-  filter_table_config.add(:states, field: :state)
-  filter_table_config.add(:dhcp_options_ids, field: :dhcp_options_id)
-  filter_table_config.add(:instance_tenancys, field: :instance_tenancy)
-  filter_table_config.add(:is_defaults, field: :is_default)
-  filter_table_config.add(:tags, field: :tags)
-  filter_table_config.connect(self, :fetch_data)
 
   def fetch_data
     vpc_rows = []

--- a/libraries/aws_vpcs.rb
+++ b/libraries/aws_vpcs.rb
@@ -26,6 +26,7 @@ class AwsVpcs < AwsResourceBase
   filter_table_config.add(:dhcp_options_ids, field: :dhcp_options_id)
   filter_table_config.add(:instance_tenancys, field: :instance_tenancy)
   filter_table_config.add(:is_defaults, field: :is_default)
+  filter_table_config.add(:tags, field: :tags)
   filter_table_config.connect(self, :fetch_data)
 
   def fetch_data
@@ -40,8 +41,19 @@ class AwsVpcs < AwsResourceBase
                    dhcp_options_id: vpc[:dhcp_options_id],
                    state: vpc[:state],
                    is_default: vpc[:is_default],
-                   instance_tenancy: vpc[:instance_tenancy] }]
+                   instance_tenancy: vpc[:instance_tenancy],
+                   tags: map_tags(vpc[:tags]) }]
     end
     @table = vpc_rows
+  end
+
+  def map_tags(tag_list)
+    tags = {}
+    unless tag_list.nil? || tag_list.empty?
+    tag_list.each do |tag|
+      tags[tag[:key].to_sym] = tag[:value]
+    end
+    tags
+    end
   end
 end

--- a/libraries/aws_vpcs.rb
+++ b/libraries/aws_vpcs.rb
@@ -46,14 +46,4 @@ class AwsVpcs < AwsResourceBase
     end
     @table = vpc_rows
   end
-
-  def map_tags(tag_list)
-    tags = {}
-    unless tag_list.nil? || tag_list.empty?
-      tag_list.each do |tag|
-        tags[tag[:key].to_sym] = tag[:value]
-      end
-      tags
-    end
-  end
 end

--- a/libraries/aws_vpcs.rb
+++ b/libraries/aws_vpcs.rb
@@ -50,10 +50,10 @@ class AwsVpcs < AwsResourceBase
   def map_tags(tag_list)
     tags = {}
     unless tag_list.nil? || tag_list.empty?
-    tag_list.each do |tag|
-      tags[tag[:key].to_sym] = tag[:value]
-    end
-    tags
+      tag_list.each do |tag|
+        tags[tag[:key].to_sym] = tag[:value]
+      end
+      tags
     end
   end
 end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -221,6 +221,10 @@ resource "aws_s3_bucket" "bucket_public" {
   count = "${var.aws_enable_creation}"
   bucket = "${var.aws_bucket_public_name}"
   acl = "public-read"
+  tags = {
+    Name = "${var.aws_bucket_public_name}"
+    Environment = "Dev"
+  }
 }
 
 resource "aws_s3_bucket" "bucket_private" {
@@ -233,6 +237,10 @@ resource "aws_s3_bucket" "bucket_public_for_objects" {
   count = "${var.aws_enable_creation}"
   bucket = "${var.aws_bucket_public_objects_name}"
   acl = "public-read"
+  tags = {
+    Name = "${var.aws_bucket_public_objects_name}"
+    Environment = "Dev"
+  }
 }
 
 resource "aws_s3_bucket" "bucket_auth" {
@@ -401,6 +409,10 @@ resource "aws_security_group" "alpha" {
   name = "${var.aws_security_group_alpha}"
   description = "SG alpha"
   vpc_id = "${data.aws_vpc.default.id}"
+  tags = {
+    Name = "${var.aws_security_group_alpha}"
+    Environment = "Dev"
+  }
 }
 
 resource "aws_security_group" "beta" {
@@ -538,6 +550,10 @@ resource "aws_db_instance" "db_rds" {
   password = "testpassword"
   parameter_group_name = "default.mysql5.6"
   skip_final_snapshot = true
+  tags = {
+    Name = "${var.aws_rds_db_name}"
+    Environment = "Dev"
+  }
 }
 
 # Cloudtrail

--- a/test/integration/verify/controls/aws_rds_instance.rb
+++ b/test/integration/verify/controls/aws_rds_instance.rb
@@ -22,6 +22,7 @@ control 'aws-rds-instance-1.0' do
     its ('master_username') { should eq aws_rds_db_master_user }
     its ('allocated_storage') { should eq 10 }
     its ('db_instance_class') { should eq 'db.t2.micro' }
+    its ('tags') { should include(:Name => aws_rds_db_name)}
   end
 
   describe aws_rds_instance(aws_rds_db_identifier) do

--- a/test/integration/verify/controls/aws_rds_instance.rb
+++ b/test/integration/verify/controls/aws_rds_instance.rb
@@ -22,7 +22,7 @@ control 'aws-rds-instance-1.0' do
     its ('master_username') { should eq aws_rds_db_master_user }
     its ('allocated_storage') { should eq 10 }
     its ('db_instance_class') { should eq 'db.t2.micro' }
-    its ('tags') { should include(:Name => aws_rds_db_name)}
+    its ('tags') { should include('Name' => aws_rds_db_name)}
   end
 
   describe aws_rds_instance(aws_rds_db_identifier) do

--- a/test/integration/verify/controls/aws_s3_bucket.rb
+++ b/test/integration/verify/controls/aws_s3_bucket.rb
@@ -18,8 +18,8 @@ control 'aws-s3-bucket-1.0' do
   describe aws_s3_bucket(bucket_name: aws_bucket_public_name) do
     it { should exist }
     its('region') { should eq aws_bucket_public_region }
-    its('tags')   { should include(:Environment => 'Dev',
-                                   :Name => aws_bucket_public_name)}
+    its('tags')   { should include('Environment' => 'Dev',
+                                   'Name' => aws_bucket_public_name)}
     it { should be_public }
   end
 

--- a/test/integration/verify/controls/aws_s3_bucket.rb
+++ b/test/integration/verify/controls/aws_s3_bucket.rb
@@ -18,6 +18,8 @@ control 'aws-s3-bucket-1.0' do
   describe aws_s3_bucket(bucket_name: aws_bucket_public_name) do
     it { should exist }
     its('region') { should eq aws_bucket_public_region }
+    its('tags')   { should include(:Environment => 'Dev',
+                                   :Name => aws_bucket_public_name)}
     it { should be_public }
   end
 

--- a/test/integration/verify/controls/aws_s3_buckets.rb
+++ b/test/integration/verify/controls/aws_s3_buckets.rb
@@ -14,6 +14,8 @@ control 'aws-s3-buckets-1.0' do
     its('bucket_names') { should include aws_bucket_public_name }
     its('bucket_names') { should include aws_bucket_private_name }
     its('bucket_names') { should_not include 'not-there-hopefully' }
+    its('tags')         { should include(:Environment=>"Dev",
+                                         :Name => aws_bucket_public_name)}
   end
 
 end

--- a/test/integration/verify/controls/aws_s3_buckets.rb
+++ b/test/integration/verify/controls/aws_s3_buckets.rb
@@ -14,8 +14,8 @@ control 'aws-s3-buckets-1.0' do
     its('bucket_names') { should include aws_bucket_public_name }
     its('bucket_names') { should include aws_bucket_private_name }
     its('bucket_names') { should_not include 'not-there-hopefully' }
-    its('tags')         { should include(:Environment=>"Dev",
-                                         :Name => aws_bucket_public_name)}
+    its('tags')         { should include('Environment' => "Dev",
+                                         'Name' => aws_bucket_public_name)}
   end
 
 end

--- a/test/integration/verify/controls/aws_security_group.rb
+++ b/test/integration/verify/controls/aws_security_group.rb
@@ -62,8 +62,8 @@ control 'aws-security-group-1.0' do
     its('outbound_rules.first') { should be_a_kind_of(Hash) }
     its('outbound_rules.count') { should cmp 1 } # 1 explicit
     its('outbound_rules_count') { should cmp 3 } # 3 CIDR blocks specified
-    its('tags') { should include(:Environment => 'Dev',
-                                 :Name => aws_security_group_alpha)}
+    its('tags') { should include('Environment' => 'Dev',
+                                 'Name' => aws_security_group_alpha)}
     it { should allow_in(port: 22) }
     it { should_not allow_in(port: 631, ipv4_range: "0.0.0.0/0") }
     it { should allow_in(ipv4_range: "0.0.0.0/0", port: 80) }

--- a/test/integration/verify/controls/aws_security_group.rb
+++ b/test/integration/verify/controls/aws_security_group.rb
@@ -62,6 +62,8 @@ control 'aws-security-group-1.0' do
     its('outbound_rules.first') { should be_a_kind_of(Hash) }
     its('outbound_rules.count') { should cmp 1 } # 1 explicit
     its('outbound_rules_count') { should cmp 3 } # 3 CIDR blocks specified
+    its('tags') { should include(:Environment => 'Dev',
+                                 :Name => aws_security_group_alpha)}
     it { should allow_in(port: 22) }
     it { should_not allow_in(port: 631, ipv4_range: "0.0.0.0/0") }
     it { should allow_in(ipv4_range: "0.0.0.0/0", port: 80) }

--- a/test/integration/verify/controls/aws_security_groups.rb
+++ b/test/integration/verify/controls/aws_security_groups.rb
@@ -31,6 +31,8 @@ control 'aws-security-groups-1.0' do
     its('group_names') { should include aws_security_group_beta }
     its('group_names') { should include aws_security_group_gamma }
     its('group_names') { should include aws_security_group_omega }
+    its('tags') { should include(:Environment => 'Dev',
+                                 :Name => aws_security_group_alpha)}
   end
 
 end

--- a/test/integration/verify/controls/aws_security_groups.rb
+++ b/test/integration/verify/controls/aws_security_groups.rb
@@ -19,20 +19,20 @@ control 'aws-security-groups-1.0' do
 
   describe aws_security_groups do
     it { should exist }
-    its('count') { should be >= 4 }
-    its('vpc_ids') { should include aws_vpc_id }
-    its('vpc_ids') { should include aws_default_vpc_id }
-    its('group_ids') { should include aws_security_group_default_id }
-    its('group_ids') { should include aws_security_group_alpha_id }
-    its('group_ids') { should include aws_security_group_beta_id }
-    its('group_ids') { should include aws_security_group_gamma_id }
-    its('group_ids') { should include aws_security_group_omega_id }
+    its('count')       { should be >= 4 }
+    its('vpc_ids')     { should include aws_vpc_id }
+    its('vpc_ids')     { should include aws_default_vpc_id }
+    its('group_ids')   { should include aws_security_group_default_id }
+    its('group_ids')   { should include aws_security_group_alpha_id }
+    its('group_ids')   { should include aws_security_group_beta_id }
+    its('group_ids')   { should include aws_security_group_gamma_id }
+    its('group_ids')   { should include aws_security_group_omega_id }
     its('group_names') { should include aws_security_group_alpha }
     its('group_names') { should include aws_security_group_beta }
     its('group_names') { should include aws_security_group_gamma }
     its('group_names') { should include aws_security_group_omega }
-    its('tags') { should include(:Environment => 'Dev',
-                                 :Name => aws_security_group_alpha)}
+    its('tags')        { should include('Environment' => 'Dev',
+                                        'Name' => aws_security_group_alpha)}
   end
 
 end

--- a/test/integration/verify/controls/aws_vpc.rb
+++ b/test/integration/verify/controls/aws_vpc.rb
@@ -5,6 +5,7 @@ aws_vpc_id = attribute(:aws_vpc_id, default: '', description: 'The AWS VPC ID.')
 aws_vpc_cidr_block = attribute(:aws_vpc_cidr_block, default: '', description: 'The AWS VPC CIDR block.')
 aws_vpc_instance_tenancy = attribute(:aws_vpc_instance_tenancy, default: '', description: 'The AWS VPC instance tenancy option.')
 aws_vpc_dhcp_options_id = attribute(:aws_vpc_dhcp_options_id, default: '', description: 'The AWS VPC DHCP options ID.')
+aws_vpc_name = attribute(:aws_vpc_name, default: '', description: 'The AWS VPC name.')
 
 control 'aws-vpc-1.0' do
 
@@ -18,6 +19,7 @@ control 'aws-vpc-1.0' do
     its ('vpc_id') { should eq aws_vpc_id }
     its ('state') { should eq 'available' }
     its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
+    its ('tags') { should include(:Name => aws_vpc_name)}
     it { should_not be_default }
   end
 

--- a/test/integration/verify/controls/aws_vpc.rb
+++ b/test/integration/verify/controls/aws_vpc.rb
@@ -19,7 +19,7 @@ control 'aws-vpc-1.0' do
     its ('vpc_id') { should eq aws_vpc_id }
     its ('state') { should eq 'available' }
     its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
-    its ('tags') { should include(:Name => aws_vpc_name)}
+    its ('tags') { should include('Name' => aws_vpc_name)}
     it { should_not be_default }
   end
 

--- a/test/integration/verify/controls/aws_vpcs.rb
+++ b/test/integration/verify/controls/aws_vpcs.rb
@@ -12,14 +12,14 @@ control 'aws-vpcs-1.0' do
 
   describe aws_vpcs do
     it { should exist }
-    its('count') { should be <= 100 }
-    its('cidr_blocks') { should include aws_vpc_cidr_block }
-    its('vpc_ids') { should include aws_vpc_id }
-    its('states') { should include 'available' }
-    its('dhcp_options_ids') { should include aws_vpc_dhcp_options_id }
+    its('count')             { should be <= 100 }
+    its('cidr_blocks')       { should include aws_vpc_cidr_block }
+    its('vpc_ids')           { should include aws_vpc_id }
+    its('states')            { should include 'available' }
+    its('dhcp_options_ids')  { should include aws_vpc_dhcp_options_id }
     its('instance_tenancys') { should include aws_vpc_instance_tenancy }
-    its('is_defaults') { should be_in [true, false] }
-    its ('tags') { should include(:Name => 'inspec-aws-vpc')}
+    its('is_defaults')       { should be_in [true, false] }
+    its('tags')              { should include 'inspec-aws-vpc' }
   end
 
 end

--- a/test/integration/verify/controls/aws_vpcs.rb
+++ b/test/integration/verify/controls/aws_vpcs.rb
@@ -19,8 +19,7 @@ control 'aws-vpcs-1.0' do
     its('dhcp_options_ids')  { should include aws_vpc_dhcp_options_id }
     its('instance_tenancys') { should include aws_vpc_instance_tenancy }
     its('is_defaults')       { should be_in [true, false] }
-    its('tags')              { should include('Name' => 'inspec-aws-vpc',
-                                              'Environment' => 'Dev') }
+    its('tags')              { should include('Name' => 'inspec-aws-vpc') }
   end
 
 end

--- a/test/integration/verify/controls/aws_vpcs.rb
+++ b/test/integration/verify/controls/aws_vpcs.rb
@@ -19,6 +19,7 @@ control 'aws-vpcs-1.0' do
     its('dhcp_options_ids') { should include aws_vpc_dhcp_options_id }
     its('instance_tenancys') { should include aws_vpc_instance_tenancy }
     its('is_defaults') { should be_in [true, false] }
+    its ('tags') { should include(:Name => 'inspec-aws-vpc')}
   end
 
 end

--- a/test/integration/verify/controls/aws_vpcs.rb
+++ b/test/integration/verify/controls/aws_vpcs.rb
@@ -19,7 +19,8 @@ control 'aws-vpcs-1.0' do
     its('dhcp_options_ids')  { should include aws_vpc_dhcp_options_id }
     its('instance_tenancys') { should include aws_vpc_instance_tenancy }
     its('is_defaults')       { should be_in [true, false] }
-    its('tags')              { should include 'inspec-aws-vpc' }
+    its('tags')              { should include('Name' => 'inspec-aws-vpc',
+                                              'Environment' => 'Dev') }
   end
 
 end

--- a/test/unit/resources/aws_route_table_test.rb
+++ b/test/unit/resources/aws_route_table_test.rb
@@ -61,7 +61,7 @@ class AwsRouteTableHappyPathTest < Minitest::Test
   end
 
   def test_route_table_tags
-    assert_equal(@route_table.tags, [])
+    assert_equal(@route_table.tags, {})
   end
 
   def test_route_table_vpc_id


### PR DESCRIPTION
### Description
Add tags to plural and singluar resources: s3 bucket, security group, vpc and rds instance.

### Issues Resolved
https://github.com/inspec/inspec-aws/issues/12
https://github.com/inspec/inspec-aws/issues/23
https://github.com/inspec/inspec-aws/issues/24
https://github.com/inspec/inspec-aws/issues/25
https://github.com/inspec/inspec-aws/issues/26

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
