### PR TITLE
Adds aws_iam_saml_provider

### DIFF
--- a/docs/resources/aws_iam_saml_provider.md
+++ b/docs/resources/aws_iam_saml_provider.md
@@ -1,0 +1,59 @@
+---
+title: About the aws_iam_saml_provider Resource
+platform: aws
+---
+
+# aws\_iam\_saml\_provider
+
+Use the `aws_iam_saml_provider` InSpec audit resource to test properties of an AWS IAM SAML Provider.
+
+<br>
+
+## Syntax
+
+An `aws_iam_saml_provider` resource block declares the tests for a single AWS IAM SAML Provider by Provider ARN.
+
+    describe aws_iam_saml_provider('arn:aws:iam::123456789012:saml-provider/FANCY') do
+        it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this Inspec audit resource.
+
+    # Ensure we have at least one provider currently valid
+      describe aws_iam_saml_provider("arn:aws:iam::123456789012:saml-provider/FANCY") do
+        it { should exist }
+        its("arn") { should match("arn:aws:iam::.*:saml-provider\/FANCY") }
+        its("valid_until") { should be > Time.now + 90 * 86400 }
+    end
+
+<br>
+
+## Properties
+
+* arn
+* valid_until
+* create_date
+
+<br>
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exists
+
+The `exists` matcher tests if the filtered IAM SAML Provider(s) exists.
+
+      describe aws_iam_saml_provider('arn:aws:iam::123456789012:saml-provider/FANCY') do
+        it { should exist }
+      end
+You may also use `it { should_not exist }`.
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the following permissions set to Allow:
+`iam:GetSamlProvider`

--- a/docs/resources/aws_iam_saml_providers.md
+++ b/docs/resources/aws_iam_saml_providers.md
@@ -1,0 +1,74 @@
+---
+title: About the aws_iam_saml_providers Resource
+platform: aws
+---
+
+# aws\_iam\_saml\_providers
+
+Use the `aws_iam_saml_providers` InSpec audit resource to test properties of some or all AWS IAM SAML Providers.
+
+
+<br>
+
+## Syntax
+
+An `aws_iam_saml_providers` resource block returns all IAM SAML Providers and allows the testing of that group of Providers.
+
+    describe aws_iam_saml_providers do
+      it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this Inspec audit resource.
+
+    # Ensure we have at least one provider currently valid
+      describe.one do
+        aws_iam_saml_providers.provider_arns.each do |provider_arn|
+          describe aws_iam_saml_provider(provider_arn) do
+            it { should exist }
+            its('arn') { should match("arn:aws:iam::.*:saml-provider\/FANCY") }
+            its('valid_until') { should be > Time.now + 90 * 86400 }
+          end
+        end
+      end
+
+    # Ensure we have one and only one SAML provider
+      describe aws_iam_saml_providers do
+        its('entries.count') { should cmp 1 }
+      end
+
+    # Ensure we have at least one provider that matches
+      describe aws_iam_saml_providers.where{ arn =~ /arn:aws:iam::.*:saml-provider\/FANCY/ } do
+        it { should exist }
+      end
+
+<br>
+
+## Properties
+
+* arn
+* valid_until
+
+<br>
+
+## Matchers
+
+For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exists
+
+The `exists` matcher tests if the filtered IAM SAML Provider(s) exists.
+
+      describe aws_iam_saml_providers.where( <property>: <param>) do
+        it { should exist }
+      end
+You may also use `it { should_not exist }`.
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the following permissions set to Allow:
+`iam:ListSamlProviders`
+`iam:GetSamlProvider`

--- a/libraries/aws_iam_saml_provider.rb
+++ b/libraries/aws_iam_saml_provider.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsIamSamlProvider < AwsResourceBase
+  name 'aws_iam_saml_provider'
+  desc 'Verifies settings for a SAML Provider.'
+  example '
+    describe aws_iam_saml_provider("arn:aws:iam::123456789012:saml-provider/FANCY") do
+        it { should exist }
+        its("arn") { should match("arn:aws:iam::.*:saml-provider\/FANCY") }
+        its("valid_until") { should be > Time.now + 90 * 86400 }
+    end
+  '
+  supports platform: 'aws'
+
+  attr_reader :provider, :arn, :create_date, :valid_until
+
+  def initialize(opts = {})
+    opts = { saml_provider_arn: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters([:saml_provider_arn])
+
+    catch_aws_errors do
+      @provider = @aws.iam_client.get_saml_provider(saml_provider_arn: opts[:saml_provider_arn])
+      @arn = opts[:saml_provider_arn]
+      @create_date = @provider.create_date
+      @valid_until = @provider.valid_until
+      # Not currently doing anything with metadata doc, future improvement?
+      # @saml_metadata_document = @provider.saml_metadata_document
+    end
+  end
+
+  def exists?
+    !@provider.saml_metadata_document.nil?
+  end
+
+  def to_s
+    "AWS IAM SAML Provider #{@opts[:saml_provider_arn]}"
+  end
+end

--- a/libraries/aws_iam_saml_provider.rb
+++ b/libraries/aws_iam_saml_provider.rb
@@ -14,7 +14,7 @@ class AwsIamSamlProvider < AwsResourceBase
   '
   supports platform: 'aws'
 
-  attr_reader :provider, :arn, :create_date, :valid_until
+  attr_reader :provider, :arn, :saml_metadata_document, :create_date, :valid_until
 
   def initialize(opts = {})
     opts = { saml_provider_arn: opts } if opts.is_a?(String)
@@ -26,8 +26,7 @@ class AwsIamSamlProvider < AwsResourceBase
       @arn = opts[:saml_provider_arn]
       @create_date = @provider.create_date
       @valid_until = @provider.valid_until
-      # Not currently doing anything with metadata doc, future improvement?
-      # @saml_metadata_document = @provider.saml_metadata_document
+      @saml_metadata_document = @provider.saml_metadata_document
     end
   end
 

--- a/libraries/aws_iam_saml_providers.rb
+++ b/libraries/aws_iam_saml_providers.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsIamSamlProviders < AwsResourceBase
+  name 'aws_iam_saml_providers'
+  desc 'Verifies settings for a collection of SAML Providers.'
+  example '
+    describe aws_iam_saml_providers do
+      it { should exist }
+    end
+  '
+  supports platform: 'aws'
+
+  attr_reader :table
+
+  FilterTable.create
+             .register_column(:provider_arns, field: :arn)
+             .register_column(:valid_untils, field: :valid_until)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters([])
+    @table = fetch_data
+  end
+
+  def fetch_data
+    provider_rows = []
+    catch_aws_errors do
+      @providers = @aws.iam_client.list_saml_providers
+    end
+    return [] if !@providers || @providers.empty?
+
+    @providers.saml_provider_list.each do |p|
+      provider_rows += [{ arn:      p.arn,
+                       valid_until: p.valid_until,
+                       create_date: p.create_date }]
+    end
+
+    @table = provider_rows
+  end
+
+  def to_s
+    'AWS IAM SAML Providers'
+  end
+end

--- a/libraries/aws_iam_saml_providers.rb
+++ b/libraries/aws_iam_saml_providers.rb
@@ -28,14 +28,14 @@ class AwsIamSamlProviders < AwsResourceBase
   def fetch_data
     provider_rows = []
     catch_aws_errors do
-      @providers = @aws.iam_client.list_saml_providers
-    end
-    return [] if !@providers || @providers.empty?
+      providers = @aws.iam_client.list_saml_providers
+      return [] if !providers || providers.empty?
 
-    @providers.saml_provider_list.each do |p|
-      provider_rows += [{ arn:      p.arn,
-                       valid_until: p.valid_until,
-                       create_date: p.create_date }]
+      providers.saml_provider_list.each do |p|
+        provider_rows += [{ arn:      p.arn,
+                         valid_until: p.valid_until,
+                         create_date: p.create_date }]
+      end
     end
 
     @table = provider_rows

--- a/test/unit/resources/aws_iam_saml_provider_test.rb
+++ b/test/unit/resources/aws_iam_saml_provider_test.rb
@@ -1,0 +1,34 @@
+require 'aws-sdk-core'
+require 'aws_iam_saml_provider'
+require 'helper'
+require_relative 'mock/iam/aws_iam_saml_provider_mock'
+
+class AwsIamSamlProviderTest < Minitest::Test
+
+  def setup
+    # Given
+    @mock          = AwsIamSamlProviderMock.new
+    @mock_provider = @mock.provider
+
+    # When
+    @provider = AwsIamSamlProvider.new(saml_provider_arn: @mock_provider[:saml_provider_arn],
+                                       client_args: { stub_responses: true },
+                                       stub_data: @mock.stub_data)
+  end
+
+  def test_exists
+    assert(@provider.exists?)
+  end
+
+  def test_arn
+    assert_equal(@provider.arn, @mock_provider[:saml_provider_arn])
+  end
+
+  def test_create_date
+    assert_equal(@provider.create_date, @mock_provider[:create_date])
+  end
+
+  def test_valid_until
+    assert_equal(@provider.valid_until, @mock_provider[:valid_until])
+  end
+end

--- a/test/unit/resources/mock/iam/aws_iam_saml_provider_mock.rb
+++ b/test/unit/resources/mock/iam/aws_iam_saml_provider_mock.rb
@@ -1,0 +1,25 @@
+require_relative '../aws_base_resource_mock'
+
+class AwsIamSamlProviderMock < AwsBaseResourceMock
+
+  # Default attributes.
+  def initialize
+    super
+    @provider = OpenStruct.new(
+        saml_provider_arn: @aws.any_arn,
+        arn: @aws.any_arn,
+        saml_metadata_document: @aws.any_string,
+        create_date: @aws.any_date,
+        valid_until: @aws.any_date
+    )
+  end
+
+  # Provide the mapping for what to return when mocking calls to the AWS SDK.
+  def stub_data
+    [{ :client => Aws::IAM::Client, :method => :get_saml_provider, :data => @provider }]
+  end
+
+  def provider
+    @provider
+  end
+end


### PR DESCRIPTION
### Description

Add a new resource and tests for IAM SAML Provider.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [X] New functionality includes integration tests/controls
- [N/A] New Terraform resources
- [X] Documentation provided or updated for resources 
- [N/A] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
