### PR TITLE
update aws_security_group.md

### DIFF
--- a/docs/resources/aws_security_group.md
+++ b/docs/resources/aws_security_group.md
@@ -244,7 +244,7 @@ A String in the format 'vpc-' followed by 8 hexadecimal characters reflecting VP
         
     The tags of the security group.
         
-        describe aws_security_group do
+        describe aws_security_group('sg-12345678') do
           its('tags') { should include(:Environment => 'env-name',
                                        :Name => 'group-name')}
         end


### PR DESCRIPTION


### Description

Small change to documentation. 'tags' property was missing parameters for aws_security_group

### Issues Resolved

Further clarity for this parameter's property

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
