### PR TITLE
Addresses #76

### DIFF
--- a/docs/resources/aws_iam_policy.md
+++ b/docs/resources/aws_iam_policy.md
@@ -59,6 +59,9 @@ The following examples show how to use this InSpec audit resource.
       # have_statement does not expand wildcards. If you want to verify
       # they are absent, an explicit check is required.
       it { should_not have_statement(Action: 's3:*') }
+
+      # You can also check NotAction
+      it { should_not have_statement(NotAction: 'iam:*') }
     end
 
 <br>

--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -81,7 +81,7 @@ class AwsIamPolicy < AwsResourceBase
       notactions = s[:NotAction] || []
       effect     = s[:Effect]
       resource   = s[:Resource]
-      statement_match = true if (notactions.include?(criteria["NotAction"]) || actions.include?(criteria["Action"])) && effect.eql?(criteria["Effect"]) && resource.eql?(criteria["Resource"])
+      statement_match = true if (criteria['NotAction'].nil? ? actions.include?(criteria['Action']) : notactions.include?(criteria['NotAction'])) && effect.eql?(criteria['Effect']) && resource.eql?(criteria['Resource'])
     end
     statement_match
   end

--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -77,10 +77,11 @@ class AwsIamPolicy < AwsResourceBase
     statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document[:Statement]
     statement_match = false
     statements.each do |s|
-      actions  = s[:Action]
-      effect   = s[:Effect]
-      resource = s[:Resource]
-      statement_match = true if actions.include?(criteria['Action']) && effect.eql?(criteria['Effect']) && resource.eql?(criteria['Resource'])
+      actions    = s[:Action] || []
+      notactions = s[:NotAction] || []
+      effect     = s[:Effect]
+      resource   = s[:Resource]
+      statement_match = true if (notactions.include?(criteria['NotAction']) || actions.include?(criteria['Action'])) && effect.eql?(criteria['Effect']) && resource.eql?(criteria['Resource'])
     end
     statement_match
   end

--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -81,7 +81,7 @@ class AwsIamPolicy < AwsResourceBase
       notactions = s[:NotAction] || []
       effect     = s[:Effect]
       resource   = s[:Resource]
-      statement_match = true if (notactions.include?(criteria['NotAction']) || actions.include?(criteria['Action'])) && effect.eql?(criteria['Effect']) && resource.eql?(criteria['Resource'])
+      statement_match = true if (notactions.include?(criteria[:NotAction]) || actions.include?(criteria[:Action])) && effect.eql?(criteria[:Effect]) && resource.eql?(criteria[:Resource])
     end
     statement_match
   end

--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -81,7 +81,7 @@ class AwsIamPolicy < AwsResourceBase
       notactions = s[:NotAction] || []
       effect     = s[:Effect]
       resource   = s[:Resource]
-      statement_match = true if (notactions.include?(criteria[:NotAction]) || actions.include?(criteria[:Action])) && effect.eql?(criteria[:Effect]) && resource.eql?(criteria[:Resource])
+      statement_match = true if (notactions.include?(criteria["NotAction"]) || actions.include?(criteria["Action"])) && effect.eql?(criteria["Effect"]) && resource.eql?(criteria["Resource"])
     end
     statement_match
   end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1001,12 +1001,16 @@ resource "aws_iam_policy" "aws_policy_1" {
       ],
       "Effect": "Allow",
       "Resource": "*"
+    },
+    {
+      "NotAction": "s3:DeleteBucket",
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::*"
     }
   ]
 }
 EOF
 }
-
 
 resource "aws_sqs_queue" "aws_sqs_queue_1" {
   count = "${var.aws_enable_creation}"

--- a/test/integration/verify/controls/aws_iam_policy.rb
+++ b/test/integration/verify/controls/aws_iam_policy.rb
@@ -19,5 +19,6 @@ control 'aws-iam-policy-1.0' do
     its ('arn')  { should eq aws_iam_policy_arn }
     it { should_not have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => '*') }
     it { should have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => 'ec2:Describe*') }
+    it { should have_statement('Effect' => 'Allow', 'Resource' => 'arn:aws:s3:::*', 'NotAction' => 's3:DeleteBucket') }
   end
 end


### PR DESCRIPTION
Support NotAction in IAM Policies.

Signed-off-by: Nathan Haneysmith <nathan@chef.io>

### Description

Support NotAction in aws_iam_policy "has_statement". See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html

### Issues Resolved

#76 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [N/A] New functionality includes integration tests/controls
- [N/A] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
