### PR TITLE
Adds Dimension option for AWS Cloudwatch Alarms

### DIFF
--- a/docs/resources/aws_cloudwatch_alarm.md
+++ b/docs/resources/aws_cloudwatch_alarm.md
@@ -25,6 +25,10 @@ The metric name used by this alarm. This must be passed as a `metric_name: 'valu
 
 The metric namespace used by this alarm. This must be passed as a `metric_namespace: 'value'` key-value entry in a hash.
 
+##### dimensions _(optional)_
+
+The dimensions associated with this alarm. This must be passed as an array of hashes `dimensions: [{key:'value'}]` .
+
 ## Properties
 
 |Property         | Description|
@@ -39,6 +43,11 @@ The metric namespace used by this alarm. This must be passed as a `metric_namesp
 ##### Ensure an Alarm has at least one alarm action
     describe aws_cloudwatch_alarm(metric_name: 'my-metric-name', metric_namespace: 'my-metric-namespace') do
       its('alarm_actions') { should_not be_empty }
+    end
+    
+##### Ensure an Alarm with Dimensions exists
+    describe aws_cloudwatch_alarm(metric_name: 'my-metric-name', metric_namespace: 'my-metric-namespace', dimensions: [{key: 'value'}]) do
+      it { should exist }
     end
 
 ## Matchers

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -24,7 +24,15 @@ class AwsCloudwatchAlarm < AwsResourceBase
     alarm_parameters = {}
     alarm_parameters[:metric_name] = @metric_name
     alarm_parameters[:namespace] =   @metric_namespace
-    alarm_parameters[:dimensions] =  @dimensions if @dimensions
+    if @dimensions
+      # This will re-format the array of hashes to the required API format [{key => 'value'}] will become [{name => 'key' value => 'value'}]
+      alarm_parameters[:dimensions] = []
+      @dimensions.each do |dimension|
+        dimension.each do |k,v|
+          alarm_parameters[:dimensions] << {:name => k, :value => v}
+        end
+      end
+    end
 
     catch_aws_errors do
       resp = @aws.cloudwatch_client.describe_alarms_for_metric(alarm_parameters)

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -25,7 +25,7 @@ class AwsCloudwatchAlarm < AwsResourceBase
     alarm_parameters[:metric_name] = @metric_name
     alarm_parameters[:namespace] =   @metric_namespace
     if @dimensions
-      # This will re-format the array of hashes to the required API format [{key => 'value'}] will become [{name => 'key' value => 'value'}]
+      # re-format the array of hashes to the required API format [{key => 'value'}] will become [{name => 'key' value => 'value'}]
       alarm_parameters[:dimensions] = []
       @dimensions.each do |dimension|
         dimension.each do |k,v|

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -28,8 +28,8 @@ class AwsCloudwatchAlarm < AwsResourceBase
       # re-format the array of hashes to the required API format [{key => 'value'}] will become [{name => 'key' value => 'value'}]
       alarm_parameters[:dimensions] = []
       @dimensions.each do |dimension|
-        dimension.each do |k,v|
-          alarm_parameters[:dimensions] << {:name => k, :value => v}
+        dimension.each do |k, v|
+          alarm_parameters[:dimensions] << { name: k, value: v }
         end
       end
     end

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -12,18 +12,22 @@ class AwsCloudwatchAlarm < AwsResourceBase
     it { should exist }
   end
   "
-  attr_reader :alarm_actions, :alarm_name, :metric_name, :metric_namespace
+  attr_reader :alarm_actions, :alarm_name, :metric_name, :metric_namespace, :dimensions
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters(required: %i(metric_name metric_namespace))
-
+    validate_parameters(allow: %i(dimensions), required: %i(metric_name metric_namespace))
     @metric_name      = opts[:metric_name]
     @metric_namespace = opts[:metric_namespace]
+    @dimensions       = opts[:dimensions]
     @alarm_actions    = []
+    alarm_parameters = {}
+    alarm_parameters[:metric_name] = @metric_name
+    alarm_parameters[:namespace] =   @metric_namespace
+    alarm_parameters[:dimensions] =  @dimensions if @dimensions
 
     catch_aws_errors do
-      resp = @aws.cloudwatch_client.describe_alarms_for_metric(metric_name: @metric_name, namespace: @metric_namespace)
+      resp = @aws.cloudwatch_client.describe_alarms_for_metric(alarm_parameters)
       @metric_alarms = resp.metric_alarms
     end
 

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -856,7 +856,7 @@ resource "aws_cloudwatch_log_group" "log_metric_filter_pattern_log_group" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
-  count                     = "${var.aws_enable_creation}"
+  count                     = "1"
   alarm_name                = "${var.aws_cloud_watch_alarm_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
@@ -864,6 +864,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   namespace                 = "${var.aws_cloud_watch_log_metric_filter_namespace}"
   period                    = "120"
   statistic                 = "Average"
+  dimensions                = [{name = "test", value = "test"}]
   threshold                 = "80"
   alarm_description         = "This metric is a test metric"
   insufficient_data_actions = []

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -29,6 +29,9 @@ variable "aws_cloud_trail_name" {}
 variable "aws_cloud_trail_open_name" {}
 variable "aws_cloud_watch_alarm_metric_name" {}
 variable "aws_cloud_watch_alarm_name" {}
+variable "aws_cloud_watch_alarm_name_with_dimensions" {}
+variable "aws_cloud_watch_alarm_metric_name_with_dimensions" {}
+variable "aws_cloud_watch_log_metric_filter_namespace_with_dimensions" {}
 variable "aws_cloud_watch_log_metric_filter_log_group_name" {}
 variable "aws_cloud_watch_log_metric_filter_metric_name" {}
 variable "aws_cloud_watch_log_metric_filter_name" {}
@@ -856,7 +859,7 @@ resource "aws_cloudwatch_log_group" "log_metric_filter_pattern_log_group" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
-  count                     = "1"
+  count                     = "${var.aws_enable_creation}"
   alarm_name                = "${var.aws_cloud_watch_alarm_name}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
@@ -864,7 +867,21 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   namespace                 = "${var.aws_cloud_watch_log_metric_filter_namespace}"
   period                    = "120"
   statistic                 = "Average"
-  dimensions                = [{name = "test", value = "test"}]
+  threshold                 = "80"
+  alarm_description         = "This metric is a test metric"
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm_with_dimensions" {
+  count                     = "${var.aws_enable_creation}"
+  alarm_name                = "${var.aws_cloud_watch_alarm_name_with_dimensions}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  metric_name               = "${var.aws_cloud_watch_alarm_metric_name_with_dimensions}"
+  namespace                 = "${var.aws_cloud_watch_log_metric_filter_namespace_with_dimensions}"
+  period                    = "120"
+  statistic                 = "Average"
+  dimensions                = [{aws_dimension_name1 = "aws_dimension_value1", aws_dimension_name2 = "aws_dimension_value2"}]
   threshold                 = "80"
   alarm_description         = "This metric is a test metric"
   insufficient_data_actions = []

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -40,6 +40,9 @@ module AWSInspecConfig
       aws_cloud_trail_open_name: "aws-cloud-trail-open-#{add_random_string}",
       aws_cloud_watch_alarm_metric_name: 'aws_cloudwatch_alarm_metric_1',
       aws_cloud_watch_alarm_name: "aws-cloudwatch-alarm-#{add_random_string}",
+      aws_cloud_watch_alarm_metric_name_with_dimensions: 'aws_cloudwatch_alarm_metric_1',
+      aws_cloud_watch_alarm_name_with_dimensions: "aws-cloudwatch-alarm-#{add_random_string}",
+      aws_cloud_watch_log_metric_filter_namespace_with_dimensions: "aws_lmf_namespace_#{add_random_string}",
       aws_cloud_watch_log_metric_filter_log_group_name: "aws_lmf_log_group_name_#{add_random_string}",
       aws_cloud_watch_log_metric_filter_metric_name: "aws_lmf_metric_name_#{add_random_string}",
       aws_cloud_watch_log_metric_filter_name: "aws_cloudwatch_lmf_#{add_random_string}",
@@ -102,7 +105,7 @@ module AWSInspecConfig
       aws_vpc_instance_tenancy: 'dedicated',
       aws_vpc_name: 'inspec-aws-vpc',
       # Simple flag to disable creation of resources (useful when prototyping new ones in isolation)
-      aws_enable_creation: 1,
+      aws_enable_creation: 0,
       # Flag to optionally disable creation/controls for configuration recorder (only 1 per AWS region allowed)
       aws_create_configuration_recorder: 0,
       # Some resources require elevated privileges to create and therefore test against.  The below flag is used to

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -105,7 +105,7 @@ module AWSInspecConfig
       aws_vpc_instance_tenancy: 'dedicated',
       aws_vpc_name: 'inspec-aws-vpc',
       # Simple flag to disable creation of resources (useful when prototyping new ones in isolation)
-      aws_enable_creation: 0,
+      aws_enable_creation: 1,
       # Flag to optionally disable creation/controls for configuration recorder (only 1 per AWS region allowed)
       aws_create_configuration_recorder: 0,
       # Some resources require elevated privileges to create and therefore test against.  The below flag is used to

--- a/test/integration/verify/controls/aws_cloudwatch_alarm.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_alarm.rb
@@ -3,6 +3,7 @@ title 'Test single AWS CloudWatch Alarm'
 aws_cloud_watch_alarm_name = attribute(:aws_cloud_watch_alarm_name, default: '', description: 'The AWS CloudWatch Alarm.')
 aws_cloud_watch_alarm_metric_name = attribute(:aws_cloud_watch_alarm_metric_name, default: '', description: 'The AWS CloudWatch Alarm metric.')
 aws_cloud_watch_log_metric_filter_namespace = attribute(:aws_cloud_watch_log_metric_filter_namespace, default: '', description: 'The AWS CloudWatch namespace.')
+aws_cloud_watch_dimensions = attribute(:aws_cloud_watch_dimensions, default: [{name:'',value:''}], description: 'The AWS CloudWatch Dimensions.')
 
 control 'aws-cloudwatch-alarm-1.0' do
 
@@ -10,6 +11,16 @@ control 'aws-cloudwatch-alarm-1.0' do
   title 'Ensure AWS CloudWatch Alarm has the correct properties.'
 
   describe aws_cloudwatch_alarm(metric_name: aws_cloud_watch_alarm_metric_name, metric_namespace: aws_cloud_watch_log_metric_filter_namespace) do
+    it { should exist }
+    its('alarm_name') { should eq aws_cloud_watch_alarm_name }
+  end
+
+  describe aws_cloudwatch_alarm(metric_name: aws_cloud_watch_alarm_metric_name, metric_namespace: aws_cloud_watch_log_metric_filter_namespace) do
+    it { should exist }
+    its('alarm_name') { should eq aws_cloud_watch_alarm_name }
+  end
+
+  describe aws_cloudwatch_alarm(metric_name: aws_cloud_watch_alarm_metric_name, metric_namespace: aws_cloud_watch_log_metric_filter_namespace, dimensions: aws_cloud_watch_dimensions) do
     it { should exist }
     its('alarm_name') { should eq aws_cloud_watch_alarm_name }
   end

--- a/test/integration/verify/controls/aws_cloudwatch_alarm.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_alarm.rb
@@ -1,10 +1,11 @@
 title 'Test single AWS CloudWatch Alarm'
 
+aws_cloud_watch_alarm_name_with_dimensions = attribute(:aws_cloud_watch_alarm_name_with_dimensions, default: '', description: 'The AWS CloudWatch Alarm.')
+aws_cloud_watch_alarm_metric_name_with_dimensions = attribute(:aws_cloud_watch_alarm_metric_name_with_dimensions, default: '', description: 'The AWS CloudWatch Alarm metric.')
+aws_cloud_watch_log_metric_filter_namespace_with_dimensions = attribute(:aws_cloud_watch_log_metric_filter_namespace_with_dimensions, default: '', description: 'The AWS CloudWatch namespace.')
 aws_cloud_watch_alarm_name = attribute(:aws_cloud_watch_alarm_name, default: '', description: 'The AWS CloudWatch Alarm.')
 aws_cloud_watch_alarm_metric_name = attribute(:aws_cloud_watch_alarm_metric_name, default: '', description: 'The AWS CloudWatch Alarm metric.')
 aws_cloud_watch_log_metric_filter_namespace = attribute(:aws_cloud_watch_log_metric_filter_namespace, default: '', description: 'The AWS CloudWatch namespace.')
-aws_cloud_watch_dimensions = attribute(:aws_cloud_watch_dimensions, default: [{name:'',value:''}], description: 'The AWS CloudWatch Dimensions.')
-
 control 'aws-cloudwatch-alarm-1.0' do
 
   impact 1.0
@@ -15,14 +16,9 @@ control 'aws-cloudwatch-alarm-1.0' do
     its('alarm_name') { should eq aws_cloud_watch_alarm_name }
   end
 
-  describe aws_cloudwatch_alarm(metric_name: aws_cloud_watch_alarm_metric_name, metric_namespace: aws_cloud_watch_log_metric_filter_namespace) do
+  describe aws_cloudwatch_alarm(metric_name: aws_cloud_watch_alarm_metric_name_with_dimensions, metric_namespace: aws_cloud_watch_log_metric_filter_namespace_with_dimensions, dimensions: [{aws_dimension_name1: 'aws_dimension_value1'}, {aws_dimension_name2: 'aws_dimension_value2'}]) do
     it { should exist }
-    its('alarm_name') { should eq aws_cloud_watch_alarm_name }
-  end
-
-  describe aws_cloudwatch_alarm(metric_name: aws_cloud_watch_alarm_metric_name, metric_namespace: aws_cloud_watch_log_metric_filter_namespace, dimensions: aws_cloud_watch_dimensions) do
-    it { should exist }
-    its('alarm_name') { should eq aws_cloud_watch_alarm_name }
+    its('alarm_name') { should eq aws_cloud_watch_alarm_name_with_dimensions }
   end
 
   describe aws_cloudwatch_alarm(metric_name: 'NotThere', metric_namespace: 'NotThere') do

--- a/test/unit/resources/aws_cloudwatch_alarm_test.rb
+++ b/test/unit/resources/aws_cloudwatch_alarm_test.rb
@@ -122,18 +122,17 @@ end
 
 class AwsCloudwatchAlarmWithDimensionsTest < Minitest::Test
   def setup
-    dimensions = [{name:'Server', value:'Prod'},{name:'Domain', value:'Frankfurt'}]
     data = {}
     data[:method] = :describe_alarms_for_metric
     mock_alarm = {}
     mock_alarm[:alarm_name] = 'alarm-12345678'
     mock_alarm[:metric_name] = 'metric'
     mock_alarm[:namespace] = 'space'
-    mock_alarm[:dimensions] = dimensions
+    mock_alarm[:dimensions] = [{:name=>'Server', :value=>'Prod'},{:name=>'Domain', :value=>'Frankfurt'}]
     mock_alarm[:alarm_actions] = []
     data[:data] = { :metric_alarms => [mock_alarm] }
     data[:client] = Aws::CloudWatch::Client
-    @alarm = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', dimensions: dimensions, client_args: { stub_responses: true }, stub_data: [data])
+    @alarm = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', dimensions: [{:name=>'Server', :value=>'Prod'},{:name=>'Domain', :value=>'Frankfurt'}], client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_alarm_exists

--- a/test/unit/resources/aws_cloudwatch_alarm_test.rb
+++ b/test/unit/resources/aws_cloudwatch_alarm_test.rb
@@ -119,3 +119,44 @@ class AwsCloudwatchAlarmMultipleFailsTest < Minitest::Test
     assert_raises(RuntimeError) { AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', client_args: { stub_responses: true }, stub_data: [@data]) }
   end
 end
+
+class AwsCloudwatchAlarmWithDimensionsTest < Minitest::Test
+  def setup
+    dimensions = [{name:'Server', value:'Prod'},{name:'Domain', value:'Frankfurt'}]
+    data = {}
+    data[:method] = :describe_alarms_for_metric
+    mock_alarm = {}
+    mock_alarm[:alarm_name] = 'alarm-12345678'
+    mock_alarm[:metric_name] = 'metric'
+    mock_alarm[:namespace] = 'space'
+    mock_alarm[:dimensions] = dimensions
+    mock_alarm[:alarm_actions] = []
+    data[:data] = { :metric_alarms => [mock_alarm] }
+    data[:client] = Aws::CloudWatch::Client
+    @alarm = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', dimensions: dimensions, client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_alarm_exists
+    assert @alarm.exists?
+  end
+
+  def test_alarm_name
+    assert_equal(@alarm.alarm_name, 'alarm-12345678')
+  end
+
+  def test_alarm_metric_name
+    assert_equal(@alarm.metric_name, 'metric')
+  end
+
+  def test_alarm_metric_namespace
+    assert_equal(@alarm.metric_namespace, 'space')
+  end
+
+  def test_alarm_dimensions
+    assert_equal(@alarm.dimensions, [{name:'Server', value:'Prod'},{name:'Domain', value:'Frankfurt'}])
+  end
+
+  def test_alarm_actions
+    assert_equal(@alarm.alarm_actions, [])
+  end
+end


### PR DESCRIPTION
### Description

Update to *cloudwatch alarm* resource to include the Dimensions option, enabling the end user to filter their alarms.

### Issues Resolved
#37 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Ross Moles <rmoles@chef.io>