### PR TITLE
Alias 'all' for Security Groups all traffic matcher.

### DIFF
--- a/docs/resources/aws_security_group.md
+++ b/docs/resources/aws_security_group.md
@@ -74,22 +74,26 @@ See also the [AWS documentation on Security Groups](https://docs.aws.amazon.com/
 ## Examples
 
 ##### Test outbound rules
+
     describe aws_security_group(group_name: isolated_servers) do
       its('outbound_rules.last') { should_not include(ip_ranges:['0.0.0.0/0']) }
     end
     
 ##### Test a rule that allows All Traffic
+
     describe aws_security_group(group_name: my_group) do
       it { should allow_in(ipv4_range: ["10.1.2.0/24", "10.3.2.0/24"], protocol: 'all') }
     end
 
 ##### Ensure a SG only allows SSH from a specific range
+
     describe aws_security_group(group_name: linux_servers) do
       it { should allow_in(port: 22, ipv4_range: '10.5.0.0/16') }
       it { should_not allow_in(port: 22, ipv4_range: '0.0.0.0/0') }
     end
 
 ##### Ensure that the careful_updates Security Group may only initiate contact with specific IPs.
+
     describe aws_security_group(group_name: 'careful_updates') do
 
       # If you have two rules, with one CIDR each:
@@ -106,6 +110,7 @@ See also the [AWS documentation on Security Groups](https://docs.aws.amazon.com/
     end
 
 ##### Ensure that the canary_deployments Security Group only allows access from one specific security group id on port 443.
+
     describe aws_security_group(group_name: 'canary_deployments') do
       it { should allow_in_only(port: 443, security_group: "sg-33334444") }
     end

--- a/docs/resources/aws_security_group.md
+++ b/docs/resources/aws_security_group.md
@@ -78,6 +78,11 @@ See also the [AWS documentation on Security Groups](https://docs.aws.amazon.com/
       its('outbound_rules.last') { should_not include(ip_ranges:['0.0.0.0/0']) }
     end
     
+##### Test a rule that allows All Traffic
+    describe aws_security_group(group_name: my_group) do
+      it { should allow_in(ipv4_range: ["10.1.2.0/24", "10.3.2.0/24"], protocol: 'all') }
+    end
+
 ##### Ensure a SG only allows SSH from a specific range
     describe aws_security_group(group_name: linux_servers) do
       it { should allow_in(port: 22, ipv4_range: '10.5.0.0/16') }

--- a/libraries/aws_security_group.rb
+++ b/libraries/aws_security_group.rb
@@ -211,7 +211,7 @@ class AwsSecurityGroup < AwsResourceBase
     return true unless criteria.key?(:protocol)
     prot = criteria[:protocol]
     # We provide a "fluency alias" for -1 (any).
-    prot = '-1' if prot == 'any'
+    prot = '-1' if prot == 'any' or prot.casecmp?('all')
 
     rule[:ip_protocol] == prot
   end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -81,6 +81,7 @@ variable "aws_rds_db_storage_type" {}
 variable "aws_security_group_alpha" {}
 variable "aws_security_group_beta" {}
 variable "aws_security_group_gamma" {}
+variable "aws_security_group_zeta" {}
 variable "aws_security_group_omega" {}
 variable "aws_sqs_queue_name" {}
 variable "aws_sns_topic_no_subscription" {}
@@ -461,6 +462,13 @@ resource "aws_security_group" "gamma" {
   vpc_id      = "${data.aws_vpc.default.id}"
 }
 
+resource "aws_security_group" "zeta" {
+  count       = "${var.aws_enable_creation}"
+  name        = "${var.aws_security_group_zeta}"
+  description = "SG zeta"
+  vpc_id      = "${data.aws_vpc.default.id}"
+}
+
 // Note this gets created in a new VPC and with no rules defined
 resource "aws_security_group" "omega" {
   count       = "${var.aws_enable_creation}"
@@ -587,6 +595,32 @@ resource "aws_security_group_rule" "gamma_ssh_in_alfa" {
   protocol                 = "tcp"
   source_security_group_id = "${aws_security_group.alpha.id}"
   security_group_id        = "${aws_security_group.gamma.id}"
+}
+
+resource "aws_security_group_rule" "zeta_all_ports_in" {
+  count                    = "${var.aws_enable_creation}"
+  type                     = "ingress"
+  from_port                = "0"
+  to_port                  = "65535"
+  protocol                 = "all"
+  cidr_blocks = [
+    "0.0.0.0/0",
+  ]
+
+  security_group_id        = "${aws_security_group.zeta.id}"
+}
+
+resource "aws_security_group_rule" "zeta_all_ports_out" {
+  count                    = "${var.aws_enable_creation}"
+  type                     = "egress"
+  from_port                = "0"
+  to_port                  = "65535"
+  protocol                 = "all"
+  cidr_blocks = [
+    "0.0.0.0/0",
+  ]
+
+  security_group_id        = "${aws_security_group.zeta.id}"
 }
 
 resource "aws_db_instance" "db_rds" {

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -110,6 +110,10 @@ output "aws_security_group_gamma_id" {
   value = "${aws_security_group.gamma.*.id}"
 }
 
+output "aws_security_group_zeta_id" {
+  value = "${aws_security_group.zeta.*.id}"
+}
+
 output "aws_security_group_omega_id" {
   value = "${aws_security_group.omega.*.id}"
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -91,6 +91,7 @@ module AWSInspecConfig
       aws_security_group_alpha: "aws-security-group-alpha-#{add_random_string}",
       aws_security_group_beta: "aws-security-group-beta-#{add_random_string}",
       aws_security_group_gamma: "aws-security-group-gamma-#{add_random_string}",
+      aws_security_group_zeta: "aws-security-group-zeta-#{add_random_string}",
       aws_security_group_omega: "aws-security-group-omega-#{add_random_string}",
       aws_sqs_queue_name: "aws-sqs-queue-#{add_random_string}",
       aws_sns_topic_no_subscription: "aws-sns-topic-no-subscription-#{add_random_string}",

--- a/test/integration/verify/controls/aws_security_group.rb
+++ b/test/integration/verify/controls/aws_security_group.rb
@@ -9,9 +9,10 @@ aws_security_group_beta_id = attribute(:aws_security_group_beta_id, default: '',
 aws_security_group_beta = attribute(:aws_security_group_beta, default: '', description: 'AWS Security Group name.')
 aws_security_group_gamma_id = attribute(:aws_security_group_gamma_id, default: '', description: 'AWS Security Group ID.')
 aws_security_group_gamma = attribute(:aws_security_group_gamma, default: '', description: 'AWS Security Group name.')
+aws_security_group_zeta_id = attribute(:aws_security_group_zeta_id, default: '', description: 'AWS Security Group ID.')
+aws_security_group_zeta = attribute(:aws_security_group_zeta, default: '', description: 'AWS Security Group name.')
 aws_security_group_omega_id = attribute(:aws_security_group_omega_id, default: '', description: 'AWS Security Group ID.')
 aws_security_group_omega = attribute(:aws_security_group_omega, default: '', description: 'AWS Security Group name.')
-
 
 control 'aws-security-group-1.0' do
 
@@ -94,6 +95,14 @@ control 'aws-security-group-1.0' do
   describe aws_security_group(aws_security_group_gamma_id) do
     it { should allow_in_only(port: 22, security_group: aws_security_group_alpha_id) }
     its('group_name') { should eq aws_security_group_gamma }
+  end
+
+  describe aws_security_group(aws_security_group_zeta_id) do
+    its('group_name') { should eq aws_security_group_zeta }
+    it { should allow_in(ipv4_range: "0.0.0.0/0", protocol: 'any') }
+    it { should allow_in(ipv4_range: "0.0.0.0/0", protocol: 'all') }
+    it { should allow_out(ipv4_range: "0.0.0.0/0", protocol: 'any') }
+    it { should allow_out(ipv4_range: "0.0.0.0/0", protocol: 'all') }
   end
 
 end


### PR DESCRIPTION
### Description

Alias 'all' for Security Groups all traffic matcher.

### Issues Resolved

https://github.com/inspec/inspec-aws/issues/89

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
