### PR TITLE
Add retry_limit and retry_backoff client config options to aws_backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,13 @@ Note that InSpec AWS assumes full compatibility with the underlying AWS SDK and 
 In certain cases AWS may implement rate limiting. In order to mitigate this issue the `Retry Limit` and `Retry Backoff` can be set in two ways:
 
 #### 1) Environment Variables
-Setting `AWS_RETRY_LIMIT` and `AWS_RETRY_BACKOFF` environment variables will be implemented at session level
+Setting `AWS_RETRY_LIMIT` and `AWS_RETRY_BACKOFF` environment variables will be implemented at session level.
 
 ```bash
-export AWS_RETRY_LIMIT=5
-export AWS_RETRY_BACKOFF=5
+   export AWS_RETRY_LMIIT=5
+   export aws_retry_limit=5
 ```
+_Note environment variables are case insensitive._
 
 #### 2) Inspec Control
 Inspec AWS resources now support setting the Retry Limit and Retry Backoff at control level as shown below.
@@ -253,7 +254,7 @@ Inspec AWS resources now support setting the Retry Limit and Retry Backoff at co
 
  #####The `aws_retry_limit` and `aws_retry_backoff` precedence:
    1. Set at Inspec control level.
-   2. Set at `.envrc`/ Environment variable level.
+   2. Set at Environment level.
 
 [Retry Limit and Retry Backoff documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/timeout-duration.html)
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Note that InSpec AWS assumes full compatibility with the underlying AWS SDK and 
 ### `aws_retry_limit` and `aws_retry_backoff`
 
 In certain cases AWS may implement rate limiting. In order to mitigate this issue the `Retry Limit` and `Retry Backoff` can be set in two ways:
+
 #### 1) Environment Variables
 Setting `AWS_RETRY_LIMIT` and `AWS_RETRY_BACKOFF` environment variables will be implemented at session level
 
@@ -239,8 +240,9 @@ Setting `AWS_RETRY_LIMIT` and `AWS_RETRY_BACKOFF` environment variables will be 
 export AWS_RETRY_LIMIT=5
 export AWS_RETRY_BACKOFF=5
 ```
+
 #### 2) Inspec Control
-Certain Inspec AWS resources may support setting the Retry Limit and Retry Backoff as shown below.
+Inspec AWS resources now support setting the Retry Limit and Retry Backoff at control level as shown below.
 
 ```
   describe aws_config_recorder(recorder_name: aws_config_recorder_name, aws_retry_limit=5, aws_retry_backoff=5) do
@@ -249,7 +251,9 @@ Certain Inspec AWS resources may support setting the Retry Limit and Retry Backo
   end
 ```
 
-_NB. Check the AWS Inspec Resource Documentation to verify if this is supported._
+ #####The `aws_retry_limit` and `aws_retry_backoff` precedence:
+   1. Set at Inspec control level.
+   2. Set at `.envrc`/ Environment variable level.
 
 [Retry Limit and Retry Backoff documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/timeout-duration.html)
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,30 @@ end
 
 Note that InSpec AWS assumes full compatibility with the underlying AWS SDK and unsupported operations will cause failures.  Therefore, depending on the external provider implementation your mileage may vary!
 
+### `aws_retry_limit` and `aws_retry_backoff`
+
+In certain cases AWS may implement rate limiting. In order to mitigate this issue the `Retry Limit` and `Retry Backoff` can be set in two ways:
+#### 1) Environment Variables
+Setting `AWS_RETRY_LIMIT` and `AWS_RETRY_BACKOFF` environment variables will be implemented at session level
+
+```bash
+export AWS_RETRY_LIMIT=5
+export AWS_RETRY_BACKOFF=5
+```
+#### 2) Inspec Control
+Certain Inspec AWS resources may support setting the Retry Limit and Retry Backoff as shown below.
+
+```
+  describe aws_config_recorder(recorder_name: aws_config_recorder_name, aws_retry_limit=5, aws_retry_backoff=5) do
+    it { should exist }
+    its('recorder_name') { should eq aws_config_recorder_name }
+  end
+```
+
+_NB. Check the AWS Inspec Resource Documentation to verify if this is supported._
+
+[Retry Limit and Retry Backoff documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/timeout-duration.html)
+
 
 ## Environment and Setup Notes
 
@@ -244,7 +268,7 @@ gem 'inspec', :git => 'https://github.com/inspec/inspec.git', :branch => 'sp/rem
 ```
 
 The branched InSpec version has all AWS components removed.  
-The branched Train version is upgraded to SDK version 3 to avoid the above conflict.  
+The branched Train version is upgraded to SDK version 3 to avoid the above conflict.
 
 ### Running a Sample Profile Using Docker
 

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -152,7 +152,7 @@ class AwsResourceBase < Inspec.resource(1)
       if opts[:retry_limit]
         client_args[:client_args][:retry_limit] = opts[:aws_retry_limit].to_i
       elsif ENV['AWS_RETRY_LIMIT'] || ENV['aws_retry_limit']
-        client_args[:client_args][:retry_limit] = ENV['AWS_RETRY_LIMIT'].to_i  || ENV['aws_retry_limit'].to_i
+        client_args[:client_args][:retry_limit] = ENV['AWS_RETRY_LIMIT'].to_i || ENV['aws_retry_limit'].to_i
       end
       # below allows each resource to optionally and conveniently set retry_backoff
       if opts[:retry_backoff]

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -148,6 +148,19 @@ class AwsResourceBase < Inspec.resource(1)
       client_args[:client_args][:region] = opts[:aws_region] if opts[:aws_region]
       # below allows each resource to optionally and conveniently set an endpoint
       client_args[:client_args][:endpoint] = opts[:aws_endpoint] if opts[:aws_endpoint]
+      # below allows each resource to optionally and conveniently set max_retries
+      if opts[:retry_limit]
+        client_args[:client_args][:retry_limit] = opts[:aws_retry_limit].to_i
+      elsif ENV['AWS_RETRY_LIMIT'] || ENV['aws_retry_limit']
+        client_args[:client_args][:retry_limit] = ENV['AWS_RETRY_LIMIT'].to_i  || ENV['aws_retry_limit'].to_i
+      end
+      # below allows each resource to optionally and conveniently set retry_backoff
+      if opts[:retry_backoff]
+        client_args[:client_args][:retry_backoff] = "lambda { |c| sleep(#{opts[:aws_retry_backoff]}) }"
+      elsif ENV['AWS_RETRY_BACKOFF'] || ENV['aws_retry_backoff']
+        client_args[:client_args][:retry_backoff] = "lambda { |c| sleep(#{ENV['AWS_RETRY_BACKOFF']}) }" if ENV['AWS_RETRY_BACKOFF']
+        client_args[:client_args][:retry_backoff] = "lambda { |c| sleep(#{ENV['aws_retry_backoff']}) }" if ENV['aws_retry_backoff']
+      end
       # this catches the stub_data true option for unit testing - and others that could be useful for consumers
       client_args[:client_args].update(opts[:client_args]) if opts[:client_args]
     end


### PR DESCRIPTION
Signed-off-by: Ross Moles <rmoles@chef.io>

### Description

Add retry_limit and retry_backoff client config options to aws_backend.
This can be set by an ENV variable or through a specific control.

### Issues Resolved

Fixes #83 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>