### PR TITLE
Add `scope` and `only_attached` filters to aws_iam_policies

### DIFF
--- a/docs/resources/aws_iam_policies.md
+++ b/docs/resources/aws_iam_policies.md
@@ -17,7 +17,16 @@ Use the `aws_iam_policies` InSpec audit resource to test properties of a collect
     
 #### Parameters
 
-This resource does not expect any parameters.
+##### only_attached _(optional)_
+
+This resource allows filtering by only_attached.
+When `OnlyAttached` is `true`, the returned list contains only the policies that are attached to an IAM user, group, or role. When `OnlyAttached` is `false`, or when the parameter is not included, all policies are returned.
+
+
+##### scope _(optional)_
+
+This resource allows filtering by scope.
+To list only AWS managed policies, set `Scope` to `AWS`. To list only the customer managed policies in your AWS account, set `Scope` to `Local`. If scope is not supplied `ALL` policies are returned.
 
 See also the [AWS documentation on IAM Policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html).
 

--- a/libraries/aws_iam_policies.rb
+++ b/libraries/aws_iam_policies.rb
@@ -26,7 +26,14 @@ class AwsIamPolicies < AwsResourceBase
 
   def initialize(opts = {})
     super(opts)
-    validate_parameters
+    validate_parameters(allow: %i(only_attached scope))
+    @only_attached = opts[:only_attached]
+    @scope         = opts[:scope]
+    @path_prefix   = opts[:path_prefix]
+    @parameters = {}
+    @parameters[:only_attached] = @only_attached if @only_attached
+    @parameters[:scope]         = @scope         if @scope
+    @parameters[:path_prefix]   = @path_prefix   if @path_prefix
     @table = fetch_data
   end
 
@@ -35,19 +42,20 @@ class AwsIamPolicies < AwsResourceBase
     pagination_options = {}
     catch_aws_errors do
       loop do
-        response = @aws.iam_client.list_policies(pagination_options)
+        response = @aws.iam_client.list_policies(@parameters, pagination_options) unless @parameters.empty?
+        response = @aws.iam_client.list_policies(pagination_options) if @parameters.empty?
         return [] if !response || response.empty?
         response.policies.each do |p|
           criteria = { policy_arn: p.arn }
           policy_entity = @aws.iam_client.list_entities_for_policy(criteria)
-          iam_policy_rows += [{ arn:                  p.arn,
-                                attachment_count:     p.attachment_count,
-                                default_version_id:   p.default_version_id,
-                                policy_name:          p.policy_name,
-                                policy_id:            p.policy_id,
-                                attached_groups:      policy_entity.policy_groups.map(&:group_name),
-                                attached_roles:       policy_entity.policy_roles.map(&:role_name),
-                                attached_users:       policy_entity.policy_users.map(&:user_name) }]
+          iam_policy_rows += [{ arn:                p.arn,
+                                attachment_count:   p.attachment_count,
+                                default_version_id: p.default_version_id,
+                                policy_name:        p.policy_name,
+                                policy_id:          p.policy_id,
+                                attached_groups:    policy_entity.policy_groups.map(&:group_name),
+                                attached_roles:     policy_entity.policy_roles.map(&:role_name),
+                                attached_users:     policy_entity.policy_users.map(&:user_name) }]
         end
         break unless response.is_truncated
         break unless response.marker

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1107,7 +1107,7 @@ resource "aws_iam_user_group_membership" "aws_iam_user_group_membership_1" {
 }
 
 resource "aws_iam_policy" "aws_policy_1" {
-  count       = 1
+  count       = "${var.aws_enable_creation}"
   name        = "${var.aws_iam_policy_name}"
   path        = "/"
   description = "Test policy"
@@ -1134,7 +1134,7 @@ EOF
 }
 
 resource "aws_iam_policy" "aws_attached_policy_1" {
-  count       = 1
+  count       = "${var.aws_enable_creation}"
   name        = "${var.aws_iam_attached_policy_name}"
   path        = "/"
   description = "Test policy"
@@ -1161,7 +1161,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test-attach" {
-  count      = 1
+  count      = "${var.aws_enable_creation}"
   role       = "${aws_iam_role.aws_role_generic.name}"
   policy_arn = "${aws_iam_policy.aws_attached_policy_1.arn}"
 }
@@ -1206,13 +1206,13 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSClusterPolicy" {
-  count      = 1
+  count      = "${var.aws_enable_creation}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
   role       = "${aws_iam_role.aws_eks_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSServicePolicy" {
-  count      = 1
+  count      = "${var.aws_enable_creation}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
   role       = "${aws_iam_role.aws_eks_role.name}"
 }

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -72,6 +72,7 @@ variable "aws_iam_user_name" {}
 variable "aws_iam_user_policy_name" {}
 variable "aws_internet_gateway_name" {}
 variable "aws_iam_policy_name" {}
+variable "aws_iam_attached_policy_name" {}
 variable "aws_key_description_disabled" {}
 variable "aws_key_description_enabled" {}
 variable "aws_launch_configuration_name" {}
@@ -1106,7 +1107,7 @@ resource "aws_iam_user_group_membership" "aws_iam_user_group_membership_1" {
 }
 
 resource "aws_iam_policy" "aws_policy_1" {
-  count       = "${var.aws_enable_creation}"
+  count       = 1
   name        = "${var.aws_iam_policy_name}"
   path        = "/"
   description = "Test policy"
@@ -1130,6 +1131,39 @@ resource "aws_iam_policy" "aws_policy_1" {
   ]
 }
 EOF
+}
+
+resource "aws_iam_policy" "aws_attached_policy_1" {
+  count       = 1
+  name        = "${var.aws_iam_attached_policy_name}"
+  path        = "/"
+  description = "Test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "NotAction": "s3:DeleteBucket",
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test-attach" {
+  count      = 1
+  role       = "${aws_iam_role.aws_role_generic.name}"
+  policy_arn = "${aws_iam_policy.aws_attached_policy_1.arn}"
 }
 
 resource "aws_sqs_queue" "aws_sqs_queue_1" {
@@ -1172,13 +1206,13 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSClusterPolicy" {
-  count      = "${var.aws_enable_creation}"
+  count      = 1
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
   role       = "${aws_iam_role.aws_eks_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSServicePolicy" {
-  count      = "${var.aws_enable_creation}"
+  count      = 1
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
   role       = "${aws_iam_role.aws_eks_role.name}"
 }

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -170,6 +170,10 @@ output "aws_iam_policy_arn" {
   value = "${aws_iam_policy.aws_policy_1.*.arn}"
 }
 
+output "aws_iam_attached_policy_arn" {
+  value = "${aws_iam_policy.aws_attached_policy_1.*.arn}"
+}
+
 output "aws_sqs_queue_arn" {
   value = "${aws_sqs_queue.aws_sqs_queue_1.*.arn}"
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -119,6 +119,7 @@ module AWSInspecConfig
       aws_iam_role_generic_name: "aws-iam-role-#{add_random_string}",
       aws_iam_policy_arn: "aws-iam-policy-arn-#{add_random_string}",
       aws_iam_policy_name: "aws-iam-policy-name-#{add_random_string}",
+      aws_iam_attached_policy_name: "aws-iam-policy-name-#{add_random_string}",
       aws_key_description_disabled: 'InSpec KMS Key Test Disabled',
       aws_key_description_enabled: 'InSpec KMS Key Test Enabled',
       aws_launch_configuration_name: "aws-launch-configuration-name-#{add_random_string}",

--- a/test/integration/verify/controls/aws_iam_policies.rb
+++ b/test/integration/verify/controls/aws_iam_policies.rb
@@ -1,6 +1,7 @@
 title 'Test a collection of AWS Iam Policies'
 
 aws_iam_policy_arn = attribute(:aws_iam_policy_arn, default: '', description: 'The AWS Iam Policy arn.')
+aws_iam_attached_policy_arn = attribute(:aws_iam_attached_policy_arn, default: '', description: 'The AWS Iam Policy arn.')
 
 control 'aws-iam-policies-1.0' do
 
@@ -10,5 +11,15 @@ control 'aws-iam-policies-1.0' do
   describe aws_iam_policies do
     it            { should exist }
     its ('arns')  { should include aws_iam_policy_arn }
+  end
+
+  describe aws_iam_policies(scope: 'Local') do
+    it            { should exist }
+    its ('arns')  { should include aws_iam_policy_arn }
+  end
+
+  describe aws_iam_policies(only_attached: 'true') do
+    it            { should exist }
+    its ('arns')  { should include aws_iam_attached_policy_arn }
   end
 end

--- a/test/integration/verify/controls/aws_iam_policies.rb
+++ b/test/integration/verify/controls/aws_iam_policies.rb
@@ -18,6 +18,11 @@ control 'aws-iam-policies-1.0' do
     its ('arns')  { should include aws_iam_policy_arn }
   end
 
+  describe aws_iam_policies(scope: 'AWS') do
+    it            { should exist }
+    its ('arns')  { should_not include aws_iam_attached_policy_arn }
+  end
+
   describe aws_iam_policies(only_attached: 'true') do
     it            { should exist }
     its ('arns')  { should include aws_iam_attached_policy_arn }


### PR DESCRIPTION
### Description

Add support for `scope` and `only_attached` filters to aws_iam_policies.

### Issues Resolved

Fixes #40 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [ ] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>