### PR TITLE
fix policy tf to use 0.12 syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5
 MAINTAINER Chef Software, Inc. <docker@chef.io>
 
-ARG TF_VERSION=0.11.10
+ARG TF_VERSION=0.12.3
 
 COPY Gemfile .
 RUN bundle install

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1143,8 +1143,8 @@ EOF
 }
 
 resource "aws_iam_policy" "aws_attached_policy_1" {
-  count       = "${var.aws_enable_creation}"
-  name        = "${var.aws_iam_attached_policy_name}"
+  count       = var.aws_enable_creation
+  name        = var.aws_iam_attached_policy_name
   path        = "/"
   description = "Test policy"
 
@@ -1170,9 +1170,9 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test-attach" {
-  count      = "${var.aws_enable_creation}"
-  role       = "${aws_iam_role.aws_role_generic.name}"
-  policy_arn = "${aws_iam_policy.aws_attached_policy_1.arn}"
+  count      = var.aws_enable_creation
+  role       = aws_iam_role.aws_role_generic[0].name
+  policy_arn = aws_iam_policy.aws_attached_policy_1[0].arn
 }
 
 resource "aws_sqs_queue" "aws_sqs_queue_1" {


### PR DESCRIPTION
Signed-off-by: Darren Murray <dmurray@chef.io>

### Description

Update newly added tf to use the 0.12 syntax

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
