### PR TITLE
Fix quoting on inspec.yml

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -6,4 +6,4 @@ copyright: spaterson@chef.io,russell.seymour@turtlesystems.co.uk
 copyright_email: spaterson@chef.io,russell.seymour@turtlesystems.co.uk
 version: 1.0.0
 license: Apache-2.0
-inspec_version: >= 4.7.3
+inspec_version: '>= 4.7.3'


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

Must quote `>=` in YAML, apparently.