### PR TITLE
aws_sqs_queues urls attribute

### DIFF
--- a/docs/resources/aws_sqs_queues.md
+++ b/docs/resources/aws_sqs_queues.md
@@ -15,8 +15,6 @@ Use the `aws_sqs_queues` InSpec audit resource to test properties of some or  al
 
 #### Parameters
 
-##### queue_url _(required)_
-
 This resource does not expect any parameters.
 
 See also the [AWS documentation on SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html).

--- a/docs/resources/aws_sqs_queues.md
+++ b/docs/resources/aws_sqs_queues.md
@@ -1,0 +1,66 @@
+---
+title: About the aws_sqs_queues Resource
+---
+
+# aws\_sqs\_queues
+
+Use the `aws_sqs_queues` InSpec audit resource to test properties of some or  all AWS Simple Queue Service queues.
+
+## Syntax
+
+    describe aws_sqs_queues() do
+      it { should exist }
+    end
+
+
+#### Parameters
+
+##### queue_url _(required)_
+
+This resource does not expect any parameters.
+
+See also the [AWS documentation on SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html).
+
+## Properties
+
+|Property                             | Description|
+| ---                                 | --- |
+|arns                                 | The ARNs of the SQS Queues. |
+|is_fifo_queues                       | A boolean value indicate if queues are a FIFO queues |
+|visibility_timeouts                  | An integer indicating the visibility timeout of the message in seconds |
+|maximum_message_sizes                | An integer indicating the maximum message size in bytes |
+|message_retention_periods            | An integer indicating the maximum retention period for a message in seconds |
+|delay_seconds                        | An integer indicating the delay in seconds for the queues |
+|receive_message_wait_timeout_seconds | An integer indicating the number of seconds an attempt to recieve a message will wait before returning |
+|content_based_deduplications         | A boolean value indicate if content based dedcuplication is enabled or not |
+
+## Examples
+
+##### Ensure that a queue exists and has a visibility timeout of 300 seconds
+    describe aws_sqs_queues.where(queue_url: 'https://sqs.ap-southeast-2.amazonaws.com/1212121/MyQueue') do
+      it { should exist }
+      its('visibility_timeout') { should be 300 }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_sqs_queues() do
+      it { should exist }
+    end
+
+    describe aws_sqs_queues() do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `sqs:GetQueueAttributes` action with Effect set to Allow.
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-using-identity-based-policies.html).

--- a/libraries/aws_sqs_queues.rb
+++ b/libraries/aws_sqs_queues.rb
@@ -15,7 +15,7 @@ class AwsSqsQueues < AwsResourceBase
 
   FilterTable.create
              .register_column(:arns,                                  field: :arn)
-             .register_column(:queue_url,                             field: :queue_url)
+             .register_column(:queue_urls,                            field: :queue_url)
              .register_column(:is_fifo_queues,                        field: :is_fifo_queue)
              .register_column(:visibility_timeouts,                   field: :visibility_timeout)
              .register_column(:maximum_message_sizes,                 field: :maximum_message_size)

--- a/libraries/aws_sqs_queues.rb
+++ b/libraries/aws_sqs_queues.rb
@@ -15,6 +15,7 @@ class AwsSqsQueues < AwsResourceBase
 
   FilterTable.create
              .register_column(:arns,                                  field: :arn)
+             .register_column(:queue_url,                             field: :queue_url)
              .register_column(:is_fifo_queues,                        field: :is_fifo_queue)
              .register_column(:visibility_timeouts,                   field: :visibility_timeout)
              .register_column(:maximum_message_sizes,                 field: :maximum_message_size)
@@ -38,6 +39,7 @@ class AwsSqsQueues < AwsResourceBase
       response.queue_urls.each do |url|
         queue_attributes = @aws.sqs_client.get_queue_attributes(queue_url: url, attribute_names: ['All']).attributes
         queue_rows += [{ arn:                  queue_attributes['QueueArn'],
+                         queue_url:            url,
                          attachment_count:     queue_attributes['VisibilityTimeout'].to_i,
                          default_version_id:   queue_attributes['MaximumMessageSize'].to_i,
                          policy_name:          queue_attributes['MessageRetentionPeriod'].to_i,


### PR DESCRIPTION
Signed-off-by: Arpan Patel <patelarpan06@gmail.com>

### Description

This change added queue_urls attribute to aws_sqs_urls so that user can iterate through each queues easily... 

[Issue #121 ](https://github.com/inspec/inspec-aws/issues/121)
