### PR TITLE
Removed github_changelog_generator in order to get buildkite green.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'aws-sdk-sqs', '~> 1'
 gem 'rubocop', '~> 0.64.0', require: false
 
 group :development do
-  gem 'github_changelog_generator'
   gem 'rake'
   gem 'minitest'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -114,16 +114,3 @@ namespace :tf do
   end
 
 end
-
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed.
-# use `rake changelog to=1.2.0`
-begin
-  v = ENV['to']
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
-  end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
-end


### PR DESCRIPTION
github_changelog_generator depends on activesupport without any
version specifier limits. The latest version of activesupport requires
ruby 2.5+ so this fails on ruby 2.4. But we shouldn't be using this
gem anymore as expeditor does this for us so it seems like an easy win
to just nuke it.

Signed-off-by: Ryan Davis <zenspider@chef.io>