### PR TITLE
criteria hash keys are atoms instead of strings.

### DIFF
--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -82,7 +82,7 @@ class AwsIamPolicy < AwsResourceBase
       notactions = s[:NotAction] || []
       effect     = s[:Effect]
       resource   = s[:Resource]
-      statement_match = true if (criteria['NotAction'].nil? ? actions.include?(criteria['Action']) : notactions.include?(criteria['NotAction'])) && effect.eql?(criteria['Effect']) && resource.eql?(criteria['Resource'])
+      statement_match = true if (criteria[:NotAction].nil? ? actions.include?(criteria[:Action]) : notactions.include?(criteria[:NotAction])) && effect.eql?(criteria[:Effect]) && resource.eql?(criteria[:Resource])
     end
     statement_match
   end


### PR DESCRIPTION
Updated all criteria has lookups to use atoms.

Signed-off-by: Johnny5 <djgoku@gmail.com>

### Description

`aws_iam_policy` resource `has_statement?` was failing. It was failing because the criteria lookup was using strings instead of atoms to access the criteria has values.
### Issues Resolved

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
