### PR TITLE
Extend aws_subnets

### DIFF
--- a/docs/resources/aws_subnets.md
+++ b/docs/resources/aws_subnets.md
@@ -29,14 +29,15 @@ See also the [AWS documentation on Subnets](https://docs.aws.amazon.com/vpc/late
 
 ## Properties
 
-|Property           | Description|
-| ---               | --- |
-|subnet_ids         | The name of the auto scaling launch configuration associated with the auto scaling group |
-|vpc_ids            | An integer indicating the maximum number of instances in the auto scaling group |
-|cidr_blocks        | An integer indicating the minimum number of instances in the auto scaling group |
-|availability_zone  | The availability zone this subnet is part of. |
-|states             | An array of strings corresponding to the subnet IDs associated with the auto scaling group |
-|entries            | Provides access to the raw results of the query, which can be treated as an array of hashes. |
+|Property                | Description|
+| ---                    | --- |
+|subnet_ids              | The name of the auto scaling launch configuration associated with the auto scaling group |
+|vpc_ids                 | An integer indicating the maximum number of instances in the auto scaling group |
+|cidr_blocks             | An integer indicating the minimum number of instances in the auto scaling group |
+|availability_zone       | The availability zone this subnet is part of. |
+|map_public_ip_on_launch | A boolean indicating if a public IP is automatically mapped to instances launched in this subnet. |
+|states                  | An array of strings corresponding to the subnet IDs associated with the auto scaling group |
+|entries                 | Provides access to the raw results of the query, which can be treated as an array of hashes. |
 
 ## Examples
 

--- a/docs/resources/aws_subnets.md
+++ b/docs/resources/aws_subnets.md
@@ -34,6 +34,7 @@ See also the [AWS documentation on Subnets](https://docs.aws.amazon.com/vpc/late
 |subnet_ids         | The name of the auto scaling launch configuration associated with the auto scaling group |
 |vpc_ids            | An integer indicating the maximum number of instances in the auto scaling group |
 |cidr_blocks        | An integer indicating the minimum number of instances in the auto scaling group |
+|availability_zone  | The availability zone this subnet is part of. |
 |states             | An array of strings corresponding to the subnet IDs associated with the auto scaling group |
 |entries            | Provides access to the raw results of the query, which can be treated as an array of hashes. |
 

--- a/libraries/aws_subnets.rb
+++ b/libraries/aws_subnets.rb
@@ -19,6 +19,7 @@ class AwsSubnets < AwsResourceBase
   FilterTable.create
              .register_column(:availability_zone,       field: :availability_zone)
              .register_column(:cidr_blocks,             field: :cidr_block)
+             .register_column(:map_public_ip_on_launch, field: :map_public_ip_on_launch)
              .register_column(:states,                  field: :state)
              .register_column(:subnet_ids,              field: :subnet_id)
              .register_column(:vpc_ids,                 field: :vpc_id)
@@ -40,6 +41,7 @@ class AwsSubnets < AwsResourceBase
       subnet_rows += [{
         availability_zone:       subnet[:availability_zone],
         cidr_block:              subnet[:cidr_block],
+        map_public_ip_on_launch: subnet[:map_public_ip_on_launch],
         state:                   subnet[:state],
         subnet_id:               subnet[:subnet_id],
         vpc_id:                  subnet[:vpc_id],

--- a/libraries/aws_subnets.rb
+++ b/libraries/aws_subnets.rb
@@ -17,10 +17,11 @@ class AwsSubnets < AwsResourceBase
   attr_reader :table
 
   FilterTable.create
-             .register_column(:cidr_blocks, field: :cidr_block)
-             .register_column(:vpc_ids,     field: :vpc_id)
-             .register_column(:subnet_ids,  field: :subnet_id)
-             .register_column(:states,      field: :state)
+             .register_column(:availability_zone,       field: :availability_zone)
+             .register_column(:cidr_blocks,             field: :cidr_block)
+             .register_column(:states,                  field: :state)
+             .register_column(:subnet_ids,              field: :subnet_id)
+             .register_column(:vpc_ids,                 field: :vpc_id)
              .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
@@ -36,10 +37,13 @@ class AwsSubnets < AwsResourceBase
     end
     return [] if !@subnets || @subnets.empty?
     @subnets.each do |subnet|
-      subnet_rows+=[{ subnet_id: subnet[:subnet_id],
-                      vpc_id: subnet[:vpc_id],
-                      cidr_block: subnet[:cidr_block],
-                      state: subnet[:state] }]
+      subnet_rows += [{
+        availability_zone:       subnet[:availability_zone],
+        cidr_block:              subnet[:cidr_block],
+        state:                   subnet[:state],
+        subnet_id:               subnet[:subnet_id],
+        vpc_id:                  subnet[:vpc_id],
+      }]
     end
     @table = subnet_rows
   end

--- a/test/unit/resources/aws_subnets_test.rb
+++ b/test/unit/resources/aws_subnets_test.rb
@@ -58,11 +58,23 @@ class AwsSubnetsHappyPathTest < Minitest::Test
     assert_equal(@subnets.states, ['available'])
   end
 
+  def test_subnets_availability_zone
+    assert_equal(@subnets.availability_zone, ['us-east-1a'])
+  end
+
   def test_subnets_filtering_not_there
     refute @subnets.where(:subnet_id => 'bad').exist?
   end
 
   def test_subnets_filtering_there
     assert @subnets.where(:subnet_id => 'subnet-12345678').exist?
+  end
+
+  def test_subnets_filtering_availability_zone_not_there
+    refute @subnets.where(:availability_zone => 'eu-central-1a').exist?
+  end
+
+  def test_subnets_filtering_availability_zone_there
+    assert @subnets.where(:availability_zone => 'us-east-1a').exist?
   end
 end

--- a/test/unit/resources/aws_subnets_test.rb
+++ b/test/unit/resources/aws_subnets_test.rb
@@ -62,6 +62,10 @@ class AwsSubnetsHappyPathTest < Minitest::Test
     assert_equal(@subnets.availability_zone, ['us-east-1a'])
   end
 
+  def test_subnets_map_public_ip_on_launch
+    assert_equal(@subnets.map_public_ip_on_launch, [true])
+  end
+
   def test_subnets_filtering_not_there
     refute @subnets.where(:subnet_id => 'bad').exist?
   end
@@ -76,5 +80,13 @@ class AwsSubnetsHappyPathTest < Minitest::Test
 
   def test_subnets_filtering_availability_zone_there
     assert @subnets.where(:availability_zone => 'us-east-1a').exist?
+  end
+
+  def test_subnets_filtering_map_public_ip_not_there
+    refute @subnets.where(:map_public_ip_on_launch => false).exist?
+  end
+
+  def test_subnets_filtering_map_public_ip_here
+    assert @subnets.where(:map_public_ip_on_launch => true).exist?
   end
 end


### PR DESCRIPTION
### Description

This imports back (some of) the filters and attributes that were missing from the origin `aws_subnets` resource from InSpec core.

There's a lot of magic happening behind the scene so I'm not sure if it's the best way to do it.

Also, I'm not sure how much of this should be imported in the singular `aws_subnet` resource.
Note that the `aws_subnet` resource has a `mapping_public_ip_on_launch` attribute instead of `map_public_ip_on_launch`, I'm not sure why.

### Issues Resolved

This fixes #146.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
