### PR TITLE
Fix documentation wrt Name tag of ec2 instances

### DIFF
--- a/docs/resources/aws_ec2_instance.md
+++ b/docs/resources/aws_ec2_instance.md
@@ -30,7 +30,7 @@ This can be passed either as a string or as an `instance_id: 'value'` key-value 
 
 ##### name _(required if `instance_id` not provided)_
 
-If you have a `name` tag applied to the EC2 instance, this can be used to lookup the instance.
+If you have a `Name` tag applied to the EC2 instance, this can be used to lookup the instance.
 This must be passed as a `name: 'value'` key-value entry in a hash.
 
 ## Properties


### PR DESCRIPTION
Name tags in aws are case sensitive and the code searches for 'Name'

Signed-off-by: Rudy Gevaert <rudy.gevaert@gmail.com>
