### PR TITLE
Fix for Issue #157 and #10

### DIFF
--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -72,13 +72,11 @@ class AwsIamPolicy < AwsResourceBase
   end
 
   def attached_to_user?(username)
-    !!@attached_users.nil?
-    @attached_users.include?(username)
+    !@attached_users.nil? && @attached_users.include?(username)
   end
 
   def attached_to_role?(rolename)
-    !!@attached_roles.nil?
-    @attached_roles.include?(rolename)
+    !@attached_roles.nil? && @attached_roles.include?(rolename)
   end
 
   def exists?

--- a/libraries/aws_iam_policy.rb
+++ b/libraries/aws_iam_policy.rb
@@ -71,6 +71,16 @@ class AwsIamPolicy < AwsResourceBase
     @attached_roles  = resp.policy_roles.map(&:role_name)
   end
 
+  def attached_to_user?(username)
+    !!@attached_users.nil?
+    @attached_users.include?(username)
+  end
+
+  def attached_to_role?(rolename)
+    !!@attached_roles.nil?
+    @attached_roles.include?(rolename)
+  end
+
   def exists?
     !@arn.nil?
   end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1178,6 +1178,12 @@ resource "aws_iam_role_policy_attachment" "attach_generic_policy_to_role_1" {
   policy_arn = aws_iam_policy.aws_attached_policy_1[0].arn
 }
 
+resource "aws_iam_user_policy_attachment" "attach_generic_policy_to_user_1" {
+  count      = var.aws_enable_creation
+  user       = aws_iam_user.iam_user[0].name
+  policy_arn = aws_iam_policy.aws_attached_policy_1[0].arn
+}
+
 resource "aws_sqs_queue" "aws_sqs_queue_1" {
   count = var.aws_enable_creation
   name = var.aws_sqs_queue_name

--- a/test/integration/verify/controls/aws_iam_policy.rb
+++ b/test/integration/verify/controls/aws_iam_policy.rb
@@ -1,40 +1,40 @@
 title 'Test single AWS Iam Policy'
 
-  aws_iam_policy_arn = attribute(:aws_iam_policy_arn, default: '', description: 'The AWS Iam Policy arn.')
-  aws_iam_policy_name = attribute(:aws_iam_policy_name, default: '', description: 'The AWS Iam Policy name.')
-  aws_iam_attached_policy_name = attribute(:aws_iam_attached_policy_name, default: '', description: 'The AWS Iam Attached Policy name.')
-  aws_iam_user_name = attribute(:aws_iam_user_name, default: '', description: 'The Attached AWS Iam Username.')
-  aws_iam_role_generic_name = attribute(:aws_iam_role_generic_name, default: '', description: 'The AWS Iam Role.')
+aws_iam_policy_arn = attribute(:aws_iam_policy_arn, default: '', description: 'The AWS Iam Policy arn.')
+aws_iam_policy_name = attribute(:aws_iam_policy_name, default: '', description: 'The AWS Iam Policy name.')
+aws_iam_attached_policy_name = attribute(:aws_iam_attached_policy_name, default: '', description: 'The AWS Iam Attached Policy name.')
+aws_iam_user_name = attribute(:aws_iam_user_name, default: '', description: 'The Attached AWS Iam Username.')
+aws_iam_role_generic_name = attribute(:aws_iam_role_generic_name, default: '', description: 'The AWS Iam Role.')
 
-  control 'aws-iam-policy-1.0' do
+control 'aws-iam-policy-1.0' do
 
-    impact 1.0
-    title 'Ensure AWS Iam Policy has the correct properties.'
+  impact 1.0
+  title 'Ensure AWS Iam Policy has the correct properties.'
 
-    describe aws_iam_policy(policy_arn: aws_iam_policy_arn) do
-      it           { should exist }
-      its ('arn')  { should eq aws_iam_policy_arn }
-    end
-
-    describe aws_iam_policy(policy_name: 'DoesNotExist') do
-      it           { should_not exist }
-    end
-
-    # policy_name param used to maintain consistency with old implementation
-    describe aws_iam_policy(policy_name: aws_iam_policy_name) do
-      it           { should exist }
-      its ('arn')  { should eq aws_iam_policy_arn }
-      it { should_not have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => '*') }
-      it { should have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => 'ec2:Describe*') }
-      it { should have_statement('Effect' => 'Allow', 'Resource' => 'arn:aws:s3:::*', 'NotAction' => 's3:DeleteBucket') }
-      its('statement_count') { should > 1 }
-    end
-
-    describe aws_iam_policy(policy_name: aws_iam_attached_policy_name) do
-      it { should be_attached_to_user(aws_iam_user_name) }
-      it { should be_attached_to_role(aws_iam_role_generic_name) }
-      it { should_not be_attached_to_user("fake-user") }
-      it { should_not be_attached_to_role("fake-role") }
-    end
-
+  describe aws_iam_policy(policy_arn: aws_iam_policy_arn) do
+    it           { should exist }
+    its ('arn')  { should eq aws_iam_policy_arn }
   end
+
+  describe aws_iam_policy(policy_name: 'DoesNotExist') do
+    it           { should_not exist }
+  end
+
+  # policy_name param used to maintain consistency with old implementation
+  describe aws_iam_policy(policy_name: aws_iam_policy_name) do
+    it           { should exist }
+    its ('arn')  { should eq aws_iam_policy_arn }
+    it { should_not have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => '*') }
+    it { should have_statement('Effect' => 'Allow', 'Resource' => '*', 'Action' => 'ec2:Describe*') }
+    it { should have_statement('Effect' => 'Allow', 'Resource' => 'arn:aws:s3:::*', 'NotAction' => 's3:DeleteBucket') }
+    its('statement_count') { should > 1 }
+  end
+
+  describe aws_iam_policy(policy_name: aws_iam_attached_policy_name) do
+    it { should be_attached_to_user(aws_iam_user_name) }
+    it { should be_attached_to_role(aws_iam_role_generic_name) }
+    it { should_not be_attached_to_user("fake-user") }
+    it { should_not be_attached_to_role("fake-role") }
+  end
+
+end

--- a/test/integration/verify/controls/aws_iam_policy.rb
+++ b/test/integration/verify/controls/aws_iam_policy.rb
@@ -33,6 +33,8 @@ title 'Test single AWS Iam Policy'
     describe aws_iam_policy(policy_name: aws_iam_attached_policy_name) do
       it { should be_attached_to_user(aws_iam_user_name) }
       it { should be_attached_to_role(aws_iam_role_generic_name) }
+      it { should_not be_attached_to_user("fake-user") }
+      it { should_not be_attached_to_role("fake-role") }
     end
 
   end

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -36,6 +36,14 @@ class AwsIamPolicyTest < Minitest::Test
     assert_equal(@policy.arn, @mock_policy[:arn])
   end
 
+  def test_attached_username
+    assert @policy.attached_to_user?((@mock_policy[:username]))
+  end
+
+  def test_attached_role
+    assert @policy.attached_to_role?((@mock_policy[:rolename]))
+  end
+
   def test_attachment_count
     assert_equal(@policy.attachment_count, @mock_policy[:attachment_count])
   end
@@ -57,14 +65,19 @@ class AwsIamPolicyTest < Minitest::Test
   end
 
   def test_policy_attached_roles
-    assert_equal(@policy.attached_roles, @mock_policy[:attached_roles])
+    assert_equal(@policy.attached_roles.first, @mock_policy[:attached_roles].first[:role_name])
   end
 
-  def test_policy_attached_users
-    assert_equal(@policy.attached_users, @mock_policy[:attached_users])
+  def test_policy_attached_user
+    assert_equal(@policy.attached_users.first, @mock_policy[:attached_users].first[:user_name])
+  end
+
+  def test_statement_count
+    assert_equal(@policy.statement_count, 2)
   end
 
   def test_exists
     assert @policy.exists?
   end
+
 end

--- a/test/unit/resources/mock/iam/aws_iam_policy_mock.rb
+++ b/test/unit/resources/mock/iam/aws_iam_policy_mock.rb
@@ -10,15 +10,21 @@ class AwsIamPolicyMock < AwsBaseResourceMock
     @policy_required[:policy_name] = @aws.any_string
     @policy_required[:policy_id] = @aws.any_id
 
-    @policy_document = {}
-    @policy_document[:document] = @aws.any_string
-    @policy_document[:version_id] = "v5"
-    @policy_document[:is_default_version] = true
+    @policy_version = {}
+    @policy_version[:document] = "%7B%0A%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22Action%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%22ec2%3ADescribe%2A%22%0A%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22NotAction%22%3A%20%22s3%3ADeleteBucket%22%2C%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%22arn%3Aaws%3As3%3A%3A%3A%2A%22%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D%0A"
+    @policy_version[:version_id] = "v5"
+    @policy_version[:is_default_version] = true
+
+    @policy_document = Hash[@policy_version]
 
     @policy = Hash[@policy_required]
     @policy[:attached_groups] = []
-    @policy[:attached_roles] = []
-    @policy[:attached_users] = []
+    @policy[:attached_roles] = [{:role_name=>"test-role"}]
+    @policy[:attached_users] = [{:user_name=>"test-user"}]
+
+    @policy[:username] = "test-user"
+    @policy[:rolename] = "test-role"
+    @policy[:policy_document] = [@policy_document]
 
   end
 


### PR DESCRIPTION
Signed-off-by: Dylan Martin <dmartin@chef.io>

### Description

Changes add updates to the aws_iam_policy resource:

- Missing methods attached_to_user and attached_to_role added to libraries/aws_iam_policy.rb
- Mock Policy updated to include more realistic properties for attached users, roles and the policy document
- Role definition added to aws.tf terraform resource file
- Unit and Integration tests implemented for these changes

### Issues Resolved

Resolved Issue #157 and #10 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
