### PR TITLE
Support for tags checks in aws_eks_cluster resource

### DIFF
--- a/docs/resources/aws_eks_cluster.md
+++ b/docs/resources/aws_eks_cluster.md
@@ -49,6 +49,7 @@ See also the [AWS documentation on EKS Clusters](https://docs.aws.amazon.com/eks
 |active                  | Boolean indicating whether or not the state of the cluster is ACTIVE. |
 |failed                  | Boolean indicating whether or not the state of the cluster is FAILED. |
 |deleting                | Boolean indicating whether or not the state of the cluster is DELETING. |
+|tags                | Cluster tags |
            
 ## Examples
 

--- a/docs/resources/aws_eks_cluster.md
+++ b/docs/resources/aws_eks_cluster.md
@@ -49,7 +49,7 @@ See also the [AWS documentation on EKS Clusters](https://docs.aws.amazon.com/eks
 |active                  | Boolean indicating whether or not the state of the cluster is ACTIVE. |
 |failed                  | Boolean indicating whether or not the state of the cluster is FAILED. |
 |deleting                | Boolean indicating whether or not the state of the cluster is DELETING. |
-|tags                | Cluster tags |
+|tags                    | Cluster tags |
            
 ## Examples
 

--- a/libraries/aws_eks_cluster.rb
+++ b/libraries/aws_eks_cluster.rb
@@ -15,7 +15,7 @@ class AwsEksCluster < AwsResourceBase
   attr_reader :version, :arn, :certificate_authority, :name,
               :status, :endpoint, :subnets_count, :subnet_ids, :security_group_ids,
               :created_at, :role_arn, :vpc_id, :security_groups_count, :creating,
-              :active, :failed, :deleting
+              :active, :failed, :deleting, :tags
 
   def initialize(opts = {})
     opts = { cluster_name: opts } if opts.is_a?(String)
@@ -42,6 +42,7 @@ class AwsEksCluster < AwsResourceBase
       @failed                = resp[:status] == 'FAILED'
       @creating              = resp[:status] == 'CREATING'
       @deleting              = resp[:status] == 'DELETING'
+      @tags                  = resp[:tags]
     end
   end
 

--- a/test/unit/resources/aws_eks_cluster_test.rb
+++ b/test/unit/resources/aws_eks_cluster_test.rb
@@ -86,4 +86,8 @@ class AwsEksClusterTest < Minitest::Test
   def test_eks_deleting
     assert !@eks.deleting
   end
+
+  def test_eks_tags
+    assert_equal(@eks.tags, @mock_eks[:cluster][:tags])
+  end
 end

--- a/test/unit/resources/mock/iam/aws_eks_cluster_mock.rb
+++ b/test/unit/resources/mock/iam/aws_eks_cluster_mock.rb
@@ -14,6 +14,7 @@ class AwsEksClusterMock < AwsBaseResourceMock
                    certificate_authority: {},
                    name: "mock-cluster",
                    status: 'CREATING',
+                   tags: {},
                    endpoint: @aws.any_string,
                    created_at: @aws.any_date,
                    role_arn: @aws.any_arn,


### PR DESCRIPTION
Signed-off-by: vsuzdaltsev <suzdaltsev_v@mail.ru>

### Description
Add .tag method to aws_eks_cluster resource which allows to compare existing eks tags with given patterns

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
