### PR TITLE
Use AWS t3 EC2 instances instead of t2

### DIFF
--- a/docs/resources/aws_launch_configuration.md
+++ b/docs/resources/aws_launch_configuration.md
@@ -54,7 +54,7 @@ See also the [AWS documentation on Launch Configurations](https://docs.aws.amazo
 
 ##### Test the instance type used in a Launch Config
     describe aws_launch_configuration('my-config') do
-      its('instance_type') { should eq 't2.micro'}
+      its('instance_type') { should eq 't3.micro'}
     end
 
 ##### Ensure a Launch Config is associated with the right IAM Profile

--- a/docs/resources/aws_rds_instance.md
+++ b/docs/resources/aws_rds_instance.md
@@ -53,7 +53,7 @@ For a comprehensive list of properties available to test on an RDS Instance see 
 ##### Test the instance type and master username
     describe aws_rds_instance(db_instance_identifier: 'awsrds123') do
       its ('master_username')   { should eq 'db-maintain' }
-      its ('db_instance_class') { should eq 'db.t2.micro' }
+      its ('db_instance_class') { should eq 'db.t3.micro' }
     end
 
 ## Matchers

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -654,7 +654,7 @@ resource "aws_db_instance" "db_rds" {
   storage_type         = var.aws_rds_db_storage_type
   engine               = var.aws_rds_db_engine
   engine_version       = var.aws_rds_db_engine_version
-  instance_class       = "db.t2.small"
+  instance_class       = "db.t3.small"
   identifier           = var.aws_rds_db_identifier
   name                 = var.aws_rds_db_name
   username             = var.aws_rds_db_master_user
@@ -1346,7 +1346,7 @@ resource "aws_launch_configuration" "as_conf" {
   count         = var.aws_enable_creation
   name          = var.aws_launch_configuration_name
   image_id      = data.aws_ami.aws_vm_config.id
-  instance_type = "t2.micro"
+  instance_type = "t3.micro"
   spot_price    = "0.1"
   user_data     = "#!/bin/bash"
 }
@@ -1504,12 +1504,12 @@ resource "aws_rds_cluster_instance" "instance1" {
   apply_immediately  = true
   cluster_identifier = aws_rds_cluster.rds_cluster.0.cluster_identifier
   identifier         = "instance1"
-  instance_class     = "db.t2.small"
+  instance_class     = "db.t3.small"
 }
 
 resource "aws_rds_cluster_instance" "instance2" {
   apply_immediately  = true
   cluster_identifier = aws_rds_cluster.rds_cluster.0.cluster_identifier
   identifier         = "instance2"
-  instance_class     = "db.t2.small"
+  instance_class     = "db.t3.small"
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -148,7 +148,7 @@ module AWSInspecConfig
       aws_subnet_name: 'inspec-aws-subnet',
       aws_vm_image_filter: 'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*',
       aws_vm_name: "aws-inspec-linux-ubuntu-#{add_random_string}",
-      aws_vm_size: 't2.micro',
+      aws_vm_size: 't3.micro',
       aws_vpc_cidr_block: '10.0.0.0/27', # i.e. 32 IP addresses
       aws_vpc_instance_tenancy: 'dedicated',
       aws_vpc_name: 'inspec-aws-vpc',

--- a/test/integration/verify/controls/aws_rds_instance.rb
+++ b/test/integration/verify/controls/aws_rds_instance.rb
@@ -23,7 +23,7 @@ control 'aws-rds-instance-1.0' do
     its ('storage_type') { should eq aws_rds_db_storage_type }
     its ('master_username') { should eq aws_rds_db_master_user }
     its ('allocated_storage') { should eq 10 }
-    its ('db_instance_class') { should eq 'db.t2.small' }
+    its ('db_instance_class') { should eq 'db.t3.small' }
     its ('tags') { should include('Name' => aws_rds_db_name)}
   end
 

--- a/test/unit/resources/aws_ec2_instance_test.rb
+++ b/test/unit/resources/aws_ec2_instance_test.rb
@@ -80,7 +80,7 @@ class AwsEc2InstanceHappyPathTest < Minitest::Test
     mock_ec2[:ami_launch_index] = 0
     mock_ec2[:image_id] = 'ami-024279d2324df257e'
     mock_ec2[:instance_id] = 'i-00b5186ddefdb50bf'
-    mock_ec2[:instance_type] = 't2.micro'
+    mock_ec2[:instance_type] = 't3.micro'
     mock_ec2[:private_dns_name] = 'ip-172-31-22-166.eu-west-2.compute.internal'
     mock_ec2[:private_ip_address] = '172.31.22.166'
     mock_ec2[:public_dns_name] = 'ec2-18-130-227-47.eu-west-2.compute.amazonaws.com'
@@ -171,7 +171,7 @@ class AwsEc2InstanceHappyPathTest < Minitest::Test
   end
 
   def test_ec2_instance_type
-    assert_equal(@ec2.instance_type, 't2.micro')
+    assert_equal(@ec2.instance_type, 't3.micro')
   end
 
   def test_ec2_private_dns_name

--- a/test/unit/resources/aws_ec2_instances_test.rb
+++ b/test/unit/resources/aws_ec2_instances_test.rb
@@ -23,7 +23,7 @@ class AwsEc2InstancesHappyPathTest < Minitest::Test
     data = {}
     data[:method] = :describe_instances
     mock_ec2 = {}
-    mock_ec2[:instance_type] = 't2.micro'
+    mock_ec2[:instance_type] = 't3.micro'
     mock_ec2[:instance_id] = 'i-00b5186ddefdb50bf'
     mock_ec2[:subnet_id] = 'subnet-9fe303e5'
     mock_ec2[:vpc_id] = 'vpc-1ea06476'
@@ -49,7 +49,7 @@ class AwsEc2InstancesHappyPathTest < Minitest::Test
   end
 
   def test_instances_types
-    assert_equal(@instances.instance_types, ['t2.micro'])
+    assert_equal(@instances.instance_types, ['t3.micro'])
   end
 
   def test_instances_filtering_not_there
@@ -67,12 +67,12 @@ class AwsEc2InstancesMultipleTest < Minitest::Test
     data = {}
     data[:method] = :describe_instances
     mock_ec2 = {}
-    mock_ec2[:instance_type] = 't2.micro'
+    mock_ec2[:instance_type] = 't3.micro'
     mock_ec2[:instance_id] = 'i-00b5186ddefdb50bf'
     mock_ec2[:subnet_id] = 'subnet-9fe303e5'
     mock_ec2[:vpc_id] = 'vpc-1ea06476'
     another_ec2 = {}
-    another_ec2[:instance_type] = 't2.micro'
+    another_ec2[:instance_type] = 't3.micro'
     another_ec2[:instance_id] = 'i-00b5186ddefdb50bg'
     another_ec2[:subnet_id] = 'subnet-9fe303e5'
     another_ec2[:vpc_id] = 'vpc-1ea06476'

--- a/test/unit/resources/aws_rds_instance_test.rb
+++ b/test/unit/resources/aws_rds_instance_test.rb
@@ -37,7 +37,7 @@ class AwsRdsInstanceTest < Minitest::Test
     mock_rds = {}
     mock_rds[:db_instance_identifier] = 'rds-12345678'
     mock_rds[:allocated_storage] = 100
-    mock_rds[:db_instance_class] = 'db.t2.micro'
+    mock_rds[:db_instance_class] = 'db.t3.micro'
     mock_rds[:engine] = 'mysql'
     mock_rds[:engine_version] = '1.2.3'
     mock_rds[:master_username] = 'starlord'
@@ -60,7 +60,7 @@ class AwsRdsInstanceTest < Minitest::Test
   end
 
   def test_rds_class
-    assert_equal(@rds.db_instance_class, 'db.t2.micro')
+    assert_equal(@rds.db_instance_class, 'db.t3.micro')
   end
 
   def test_rds_engine


### PR DESCRIPTION
Update to make use of the t3 EC2 instances
Signed-off-by: Ross Moles <rmoles@chef.io>

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
