### PR TITLE
Wildcard optional outputs

### DIFF
--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -151,11 +151,11 @@ output "aws_cloud_trail_open_arn" {
 }
 
 output "aws_config_recorder_role_arn" {
-  value = aws_iam_role.role_for_config_recorder.0.arn
+  value = aws_iam_role.role_for_config_recorder.*.arn
 }
 
 output "aws_delivery_channel_sns_topic_arn" {
-  value = aws_sns_topic.sns_topic_for_delivery_channel.0.arn
+  value = aws_sns_topic.sns_topic_for_delivery_channel.*.arn
 }
 
 output "aws_vpc_flow_log_id" {


### PR DESCRIPTION
This is to avoid errors when running the terraform plan action:
```
Error: Invalid index

  on outputs.tf line 154, in output "aws_config_recorder_role_arn":
 154:   value = aws_iam_role.role_for_config_recorder.0.arn
    |----------------
    | aws_iam_role.role_for_config_recorder is empty tuple

The given key does not identify an element in this collection value.


Error: Invalid index

  on outputs.tf line 158, in output "aws_delivery_channel_sns_topic_arn":
 158:   value = aws_sns_topic.sns_topic_for_delivery_channel.0.arn
    |----------------
    | aws_sns_topic.sns_topic_for_delivery_channel is empty tuple
```
Signed-off-by: Ross Moles <rmoles@chef.io>

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
