### PR TITLE
Add aws_dhcp_options resource

### DIFF
--- a/docs/resources/aws_dhcp_options.md
+++ b/docs/resources/aws_dhcp_options.md
@@ -11,11 +11,11 @@ Use the `aws_dhcp_options` InSpec audit resource to test properties of a single 
 
 Ensure that an `aws_dhcp_options` exists
 
-    describe aws_alb('dopt-0123456789abcdefg') do
+    describe aws_dhcp_options('dopt-0123456789abcdefg') do
       it { should exist }
     end
 
-    describe aws_alb(dhcp_options_id: 'dopt-0123456789abcdefg') do
+    describe aws_dhcp_options(dhcp_options_id: 'dopt-0123456789abcdefg') do
       it { should exist }
     end
 
@@ -33,11 +33,13 @@ See also the [AWS documentation on EC2](https://docs.aws.amazon.com/AWSEC2/lates
 | Property | Description |
 | --- | --- |
 | dhcp_configurations | The list of dhcp configurations |
+| domain_name_servers | The list of domain name servers in the dhcp configuration |
+| ntp_servers | The list of ntp servers in the dhcp configuration |
 | tags | The tags of the DHCP Options. |
 
 
 ##### Test tags on the DHCP Options
-    describe aws_alb('dopt-0123456789abcdefg') do
+    describe aws_dhcp_options('dopt-0123456789abcdefg') do
       its('tags') { should include(:Environment => 'env-name',
                                    :Name => 'dhcp-options-name')}
     end

--- a/docs/resources/aws_dhcp_options.md
+++ b/docs/resources/aws_dhcp_options.md
@@ -1,0 +1,49 @@
+---
+title: About the aws_dhcp_options Resource
+platform: aws
+---
+
+# aws\_dhcp\_options
+
+Use the `aws_dhcp_options` InSpec audit resource to test properties of a single AWS DHCP Options.
+
+## Syntax
+
+Ensure that an `aws_dhcp_options` exists
+
+    describe aws_alb('dopt-0123456789abcdefg') do
+      it { should exist }
+    end
+
+    describe aws_alb(dhcp_options_id: 'dopt-0123456789abcdefg') do
+      it { should exist }
+    end
+
+#### Parameters
+
+##### dhcp\_options\_id _(required)_
+
+This resource accepts a single parameter, the DHCP Options ID which uniquely identifies the DHCP Options.
+This can be passed either as a string or as a `dhcp_options_id: 'value'` key-value entry in a hash.
+
+See also the [AWS documentation on EC2](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeDhcpOptions.html).
+
+## Properties
+
+| Property | Description |
+| --- | --- |
+| dhcp_configurations | The list of dhcp configurations |
+| tags | The tags of the DHCP Options. |
+
+
+##### Test tags on the DHCP Options
+    describe aws_alb('dopt-0123456789abcdefg') do
+      its('tags') { should include(:Environment => 'env-name',
+                                   :Name => 'dhcp-options-name')}
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ec2:DescribeDhcpOptions` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon EC2](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonec2.html).

--- a/libraries/aws_dhcp_options.rb
+++ b/libraries/aws_dhcp_options.rb
@@ -26,7 +26,7 @@ class AwsDhcpOptions < AwsResourceBase
   end
 
   def exists?
-    !@dhcp_options.nil? && !@dhcp_options.empty?
+    !@dhcp_options.empty?
   end
 
   def domain_name_servers
@@ -45,7 +45,7 @@ class AwsDhcpOptions < AwsResourceBase
 
   def _dhcp_config(key)
     config = @dhcp_options[:dhcp_configurations].select { |c| c[:key] == key }
-    return [] unless !config.empty?
+    return [] if config.empty?
     config[0][:values].map { |v| v[:value] }
   end
 end

--- a/libraries/aws_dhcp_options.rb
+++ b/libraries/aws_dhcp_options.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsDhcpOptions < AwsResourceBase
+  name 'aws_dhcp_options'
+  desc 'Verifies settings for an AWS DHCP Options'
+
+  def initialize(opts = {})
+    opts = { dhcp_options_id: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: [:dhcp_options_id])
+
+    if !opts[:dhcp_options_id].is_a?(String) || opts[:dhcp_options_id] !~ /^dopt\-([0-9a-f]{8})|(^dopt\-[0-9a-f]{17})$/
+      raise ArgumentError, "#{@__resource_name__}: `dhcp_options_id` #{opts[:dhcp_options_id]} is invalid, must be a string in the format of 'dopt-' followed by 8 or 17 hexadecimal characters."
+    end
+
+    @display_name = opts[:dhcp_options_id]
+    filter = { name: 'dhcp-options-id', values: [opts[:dhcp_options_id]] }
+
+    catch_aws_errors do
+      resp = @aws.compute_client.describe_dhcp_options({ filters: [filter] })
+      @dhcp_options = resp.dhcp_options[0].to_h
+      create_resource_methods(@dhcp_options)
+    end
+  end
+
+  def exists?
+    !@dhcp_options.nil? && !@dhcp_options.empty?
+  end
+
+  def domain_name_servers
+    _dhcp_config('domain-name-servers')
+  end
+
+  def ntp_servers
+    _dhcp_config('ntp-servers')
+  end
+
+  def to_s
+    opts.key?(:aws_region) ? "DHCP Options #{@display_name} in #{opts[:aws_region]}" : "DHCP Options #{@display_name}"
+  end
+
+  private
+
+  def _dhcp_config(key)
+    config = @dhcp_options[:dhcp_configurations].select { |c| c[:key] == key }
+    return [] unless !config.empty?
+    config[0][:values].map { |v| v[:value] }
+  end
+end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -147,8 +147,8 @@ resource "aws_vpc_dhcp_options" "inspec_dopt" {
 
 resource "aws_vpc_dhcp_options_association" "inspec_vpc_dopt_assoc" {
   count           = var.aws_enable_creation
-  vpc_id          = aws_vpc.inspec_vpc.id
-  dhcp_options_id = aws_vpc_dhcp_options.inspec_dopt.id
+  vpc_id          = aws_vpc.inspec_vpc[0].id
+  dhcp_options_id = aws_vpc_dhcp_options.inspec_dopt[0].id
 }
 
 resource "aws_subnet" "inspec_subnet" {

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -108,6 +108,7 @@ variable "aws_vm_size" {}
 variable "aws_vpc_cidr_block" {}
 variable "aws_vpc_instance_tenancy" {}
 variable "aws_vpc_name" {}
+variable "aws_vpc_dhcp_options_name" {}
 variable "aws_route_53_zone" {}
 
 provider "aws" {
@@ -132,6 +133,22 @@ resource "aws_vpc" "inspec_vpc" {
   tags = {
     Name = var.aws_vpc_name
   }
+}
+
+resource "aws_vpc_dhcp_options" "inspec_dopt" {
+  count               = var.aws_enable_creation
+  domain_name_servers = ["AmazonProvidedDNS"]
+  ntp_servers         = ["127.0.0.1"]
+
+  tags = {
+    Name = var.aws_vpc_dhcp_options_name
+  }
+}
+
+resource "aws_vpc_dhcp_options_association" "inspec_vpc_dopt_assoc" {
+  count           = var.aws_enable_creation
+  vpc_id          = aws_vpc.inspec_vpc.id
+  dhcp_options_id = aws_vpc_dhcp_options.inspec_dopt.id
 }
 
 resource "aws_subnet" "inspec_subnet" {

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -6,7 +6,7 @@ output "aws_vpc_id" {
   value = aws_vpc.inspec_vpc.0.id
 }
 
-output "aws_vpc_dhcp_options_id" {
+output "aws_vpc_dhcp_inspec_dopt_options_id" {
   value = aws_vpc_dhcp_options.inspec_dopt.0.id
 }
 

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -6,10 +6,6 @@ output "aws_vpc_id" {
   value = aws_vpc.inspec_vpc.0.id
 }
 
-output "aws_vpc_dhcp_inspec_dopt_options_id" {
-  value = aws_vpc_dhcp_options.inspec_dopt.0.id
-}
-
 output "aws_default_vpc_id" {
   value = data.aws_vpc.default.id
 }
@@ -23,7 +19,7 @@ output "aws_ec2_ami_id" {
 }
 
 output "aws_vpc_dhcp_options_id" {
-  value = aws_vpc.inspec_vpc.0.dhcp_options_id
+  value = aws_vpc_dhcp_options.inspec_dopt.0.id
 }
 
 output "aws_subnet_id" {

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -6,6 +6,10 @@ output "aws_vpc_id" {
   value = aws_vpc.inspec_vpc.0.id
 }
 
+output "aws_vpc_dhcp_options_id" {
+  value = aws_vpc_dhcp_options.inspec_dopt.0.id
+}
+
 output "aws_default_vpc_id" {
   value = data.aws_vpc.default.id
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -152,6 +152,7 @@ module AWSInspecConfig
       aws_vpc_cidr_block: '10.0.0.0/27', # i.e. 32 IP addresses
       aws_vpc_instance_tenancy: 'dedicated',
       aws_vpc_name: 'inspec-aws-vpc',
+      aws_vpc_dhcp_options_name: 'inspec-aws-dopt',
       # Simple flag to disable creation of resources (useful when prototyping new ones in isolation)
       aws_enable_creation: 1,
       # Flag to optionally disable creation/controls for configuration recorder (only 1 per AWS region allowed)
@@ -167,7 +168,7 @@ module AWSInspecConfig
       # Some controls make use of the gcloud command and grep to discover live data to then test against.
       # Only test execution is affected by this flag, resource creation via terraform is unaffected.
       # Default behaviour is for this to be disabled, enable by changing the below flag.
-      aws_enable_cli_calls: 0, 
+      aws_enable_cli_calls: 0,
       aws_route_53_zone: "aws-route53-zone-#{add_random_string}"
   }
 

--- a/test/integration/verify/controls/aws_dhcp_options.rb
+++ b/test/integration/verify/controls/aws_dhcp_options.rb
@@ -1,0 +1,28 @@
+title 'Test single AWS DHCP Options'
+
+aws_vpc_dhcp_options_id = attribute(:aws_vpc_dhcp_options_id, default: '', description: 'The AWS DHCP Options ID.')
+aws_vpc_dhcp_options_name = attribute(:aws_vpc_dhcp_options_name, default: '', description: 'The AWS DHCP Options Name.')
+aws_vpc_id = attribute(:aws_vpc_id, default: '', description: 'The AWS VPC ID.')
+
+control 'aws-dhcp-options-1.0' do
+
+  impact 1.0
+  title 'Ensure AWS DHCP Options has the correct properties.'
+
+  describe aws_dhcp_options(dhcp_options_id:  aws_vpc_dhcp_options_id) do
+    it { should exist }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
+    its ('domain_name_servers') { should include('AmazonProvidedDNS') }
+    its ('ntp_servers') { should include('127.0.0.1') }
+    its ('tags') { should include('Name' => aws_vpc_dhcp_options_name) }
+  end
+
+  describe aws_dhcp_options(aws_vpc_dhcp_options_id) do
+    it { should exist }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
+  end
+
+  describe aws_vpc(vpc_id: aws_vpc_id) do
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
+  end
+end

--- a/test/integration/verify/controls/aws_dhcp_options.rb
+++ b/test/integration/verify/controls/aws_dhcp_options.rb
@@ -1,6 +1,6 @@
 title 'Test single AWS DHCP Options'
 
-aws_vpc_dhcp_options_id = attribute(:aws_vpc_dhcp_options_id, default: '', description: 'The AWS DHCP Options ID.')
+aws_vpc_dhcp_inspec_dopt_options_id = attribute(:aws_vpc_dhcp_inspec_dopt_options_id, default: '', description: 'The AWS DHCP Options ID.')
 aws_vpc_dhcp_options_name = attribute(:aws_vpc_dhcp_options_name, default: '', description: 'The AWS DHCP Options Name.')
 aws_vpc_id = attribute(:aws_vpc_id, default: '', description: 'The AWS VPC ID.')
 
@@ -9,20 +9,20 @@ control 'aws-dhcp-options-1.0' do
   impact 1.0
   title 'Ensure AWS DHCP Options has the correct properties.'
 
-  describe aws_dhcp_options(dhcp_options_id:  aws_vpc_dhcp_options_id) do
+  describe aws_dhcp_options(dhcp_options_id:  aws_vpc_dhcp_inspec_dopt_options_id) do
     it { should exist }
-    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_inspec_dopt_options_id }
     its ('domain_name_servers') { should include('AmazonProvidedDNS') }
     its ('ntp_servers') { should include('127.0.0.1') }
     its ('tags') { should include('Name' => aws_vpc_dhcp_options_name) }
   end
 
-  describe aws_dhcp_options(aws_vpc_dhcp_options_id) do
+  describe aws_dhcp_options(aws_vpc_dhcp_inspec_dopt_options_id) do
     it { should exist }
-    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_inspec_dopt_options_id }
   end
 
   describe aws_vpc(vpc_id: aws_vpc_id) do
-    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_inspec_dopt_options_id }
   end
 end

--- a/test/integration/verify/controls/aws_dhcp_options.rb
+++ b/test/integration/verify/controls/aws_dhcp_options.rb
@@ -1,6 +1,6 @@
 title 'Test single AWS DHCP Options'
 
-aws_vpc_dhcp_inspec_dopt_options_id = attribute(:aws_vpc_dhcp_inspec_dopt_options_id, default: '', description: 'The AWS DHCP Options ID.')
+aws_vpc_dhcp_options_id = attribute(:aws_vpc_dhcp_options_id, default: '', description: 'The AWS DHCP Options ID.')
 aws_vpc_dhcp_options_name = attribute(:aws_vpc_dhcp_options_name, default: '', description: 'The AWS DHCP Options Name.')
 aws_vpc_id = attribute(:aws_vpc_id, default: '', description: 'The AWS VPC ID.')
 
@@ -9,20 +9,20 @@ control 'aws-dhcp-options-1.0' do
   impact 1.0
   title 'Ensure AWS DHCP Options has the correct properties.'
 
-  describe aws_dhcp_options(dhcp_options_id:  aws_vpc_dhcp_inspec_dopt_options_id) do
+  describe aws_dhcp_options(dhcp_options_id:  aws_vpc_dhcp_options_id) do
     it { should exist }
-    its ('dhcp_options_id') { should eq aws_vpc_dhcp_inspec_dopt_options_id }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
     its ('domain_name_servers') { should include('AmazonProvidedDNS') }
     its ('ntp_servers') { should include('127.0.0.1') }
     its ('tags') { should include('Name' => aws_vpc_dhcp_options_name) }
   end
 
-  describe aws_dhcp_options(aws_vpc_dhcp_inspec_dopt_options_id) do
+  describe aws_dhcp_options(aws_vpc_dhcp_options_id) do
     it { should exist }
-    its ('dhcp_options_id') { should eq aws_vpc_dhcp_inspec_dopt_options_id }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
   end
 
   describe aws_vpc(vpc_id: aws_vpc_id) do
-    its ('dhcp_options_id') { should eq aws_vpc_dhcp_inspec_dopt_options_id }
+    its ('dhcp_options_id') { should eq aws_vpc_dhcp_options_id }
   end
 end

--- a/test/unit/resources/aws_dhcp_options_test.rb
+++ b/test/unit/resources/aws_dhcp_options_test.rb
@@ -1,0 +1,94 @@
+require 'helper'
+require 'aws_dhcp_options'
+require 'aws-sdk-core'
+
+class AwsDhcpOptionsConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsDhcpOptions.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_scalar_invalid_args
+    assert_raises(ArgumentError) { AwsDhcpOptions.new('rubbish') }
+  end
+
+  def test_accepts_dopt_as_hash_eight_sign
+    AwsDhcpOptions.new(dhcp_options_id: 'dopt-1234abcd', client_args: { stub_responses: true })
+  end
+
+  def test_accepts_dopt_id_as_hash
+    AwsDhcpOptions.new(dhcp_options_id: 'dopt-abcd123454321dcba', client_args: { stub_responses: true })
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsDhcpOptions.new(rubbish: 99) }
+  end
+
+  def test_rejects_invalid_ec2_id
+    assert_raises(ArgumentError) { AwsDhcpOptions.new(dhcp_options_id: 'dopt-not-allowed') }
+  end
+
+  def test_rejects_empty_name
+    assert_raises(ArgumentError) { AwsDhcpOptions.new(dhcp_options_id: '') }
+  end
+
+  def test_dopt_non_existing
+    refute AwsDhcpOptions.new(dhcp_options_id: 'dopt-1234abcd', client_args: { stub_responses: true }).exists?
+  end
+end
+
+class AwsDhcpOptionsConstructorIdTest < Minitest::Test
+  def setup
+    data = {}
+    data[:method] = :describe_dhcp_options
+    data[:data] = {
+      :dhcp_options => [
+        {
+          :dhcp_configurations => [
+            {
+              :key => 'domain-name-servers',
+              :values => [
+                {
+                  :value => 'AmazonProvidedDNS'
+                }
+              ]
+            },
+            {
+              :key => 'ntp-servers',
+              :values => [
+                {
+                  :value => '169.254.169.123'
+                }
+              ]
+            }
+          ],
+          :dhcp_options_id => 'dopt-00b5186ddefdb50bf',
+          :tags => [
+            {
+              :key => 'Name',
+              :value => 'aws-inspec-dopt'
+            }
+          ]
+        }
+      ]
+    }
+    data[:client] = Aws::EC2::Client
+    @dopt = AwsDhcpOptions.new(dhcp_options_id: 'dopt-00b5186ddefdb50bf', client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_dhcp_options_id
+    assert_equal(@dopt.dhcp_options_id, 'dopt-00b5186ddefdb50bf')
+  end
+
+  def test_ec2_exists
+    assert @dopt.exists?
+  end
+
+  def test_dhcp_domain_name_servers
+    assert_equal(@dopt.domain_name_servers, ['AmazonProvidedDNS'])
+  end
+
+  def test_dhcp_ntp_servers
+    assert_equal(@dopt.ntp_servers, ['169.254.169.123'])
+  end
+end


### PR DESCRIPTION
Signed-off-by: Robert Bruce <robert.bruce@crimsonmacaw.com>

### Description

This change adds the aws_dhcp_options as an available resource

### Issues Resolved

None, adding additional functionality!

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
