### PR TITLE
Add aws_cloudwatch_log_group resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This resouce pack allows the testing of the following AWS resources. If a resour
 - [aws_cloudtrail_trail](docs/resources/aws_cloudtrail_trail.md)
 - [aws_cloudtrail_trails](docs/resources/aws_cloudtrail_trails.md)
 - [aws_cloudwatch_alarm](docs/resources/aws_cloudwatch_alarm.md)
+- [aws_cloudwatch_log_group](docs/resources/aws_cloudwatch_log_group.md)
 - [aws_cloudwatch_log_metric_filter](docs/resources/aws_cloudwatch_log_metric_filter.md)
 - [aws_config_delivery_channel](docs/resources/aws_config_delivery_channel.md)
 - [aws_config_recorder](docs/resources/aws_config_recorder.md)

--- a/docs/resources/aws_cloudwatch_log_group.md
+++ b/docs/resources/aws_cloudwatch_log_group.md
@@ -1,0 +1,50 @@
+---
+title: About the aws_cloudwatch_log_group Resource
+platform: aws
+---
+
+# aws\_cloudwatch\_log\_group
+
+Use the `aws_cloudwatch_log_group` InSpec audit resource to test properties of a single AWS CloudWatch Log Group.
+
+## Syntax
+
+Ensure that an `aws_cloudwatch_log_group` exists
+
+    describe aws_cloudwatch_log_group('my_log_group') do
+      it { should exist }
+    end
+
+    describe aws_cloudwatch_log_group(log_group_name: 'my_log_group') do
+      it { should exist }
+    end
+
+#### Parameters
+
+##### log\_group\_name _(required)_
+
+This resource accepts a single parameter, the log group name which uniquely identifies the CloudWatch Log Group.
+This can be passed either as a string or as a `log_group_name: 'value'` key-value entry in a hash.
+
+See also the [AWS documentation on CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html).
+
+## Properties
+
+| Property | Description |
+| --- | --- |
+| retention_in_days | The number of days to retain the log events in the specified log group |
+| kms_key_id | The Amazon Resource Name (ARN) of the CMK to use when encrypting log data |
+| tags | The tags for the log group. |
+
+
+##### Test tags on the CloudWatch Log Group
+    describe aws_cloudwatch_log_group('my_log_group') do
+      its('tags') { should include(:Environment => 'env-name',
+                                   :Name => 'my_log_group')}
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `logs:DescribeLogGroups` and `logs:ListTagsLogGroup` actions with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon CloudWatch Logs](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazoncloudwatchlogs.html).

--- a/libraries/aws_cloudwatch_log_group.rb
+++ b/libraries/aws_cloudwatch_log_group.rb
@@ -20,7 +20,7 @@ class AwsCloudWatchLogGroup < AwsResourceBase
     @log_group_name = opts[:log_group_name]
 
     catch_aws_errors do
-      resp = @aws.cloudwatchlogs_client.describe_log_groups({log_group_name_prefix: @log_group_name})
+      resp = @aws.cloudwatchlogs_client.describe_log_groups({ log_group_name_prefix: @log_group_name })
       @log_groups = resp.log_groups
     end
 
@@ -32,7 +32,7 @@ class AwsCloudWatchLogGroup < AwsResourceBase
     @kms_key_id = @log_groups.first.kms_key_id
 
     catch_aws_errors do
-      resp = @aws.cloudwatchlogs_client.list_tags_log_group({log_group_name: @log_group_name})
+      resp = @aws.cloudwatchlogs_client.list_tags_log_group({ log_group_name: @log_group_name })
       @tags = resp.tags
     end
   end

--- a/libraries/aws_cloudwatch_log_group.rb
+++ b/libraries/aws_cloudwatch_log_group.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsCloudWatchLogGroup < AwsResourceBase
+  name 'aws_cloudwatch_log_group'
+  desc 'Verifies settings for an AWS CloudWatch Log Group'
+
+  attr_reader :log_group_name, :retention_in_days, :kms_key_id
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters(required: [:log_group_name])
+
+    @log_group_name = opts[:log_group_name]
+
+    catch_aws_errors do
+      resp = @aws.cloudwatch_client.describe_log_groups({log_group_name_prefix: @log_group_name})
+      @log_groups = resp.log_groups
+    end
+
+    return false if @log_groups.empty?
+
+    raise "Found multiple CloudWatch Log Groups. The following matched: #{@log_groups.join(', ')}.  Try to restrict your resource criteria." if @log_groups.count > 1
+
+    @retention_in_days = @log_groups.first.retention_in_days
+    @kms_key_id = @log_groups.first.kms_key_id
+  end
+
+  def exists?
+    !@log_groups.empty?
+  end
+
+  def to_s
+    "CloudWatch Log Group #{@log_group_name}"
+  end
+end

--- a/libraries/aws_cloudwatch_log_group.rb
+++ b/libraries/aws_cloudwatch_log_group.rb
@@ -6,7 +6,7 @@ class AwsCloudWatchLogGroup < AwsResourceBase
   name 'aws_cloudwatch_log_group'
   desc 'Verifies settings for an AWS CloudWatch Log Group'
 
-  attr_reader :log_group_name, :retention_in_days, :kms_key_id
+  attr_reader :log_group_name, :retention_in_days, :kms_key_id, :tags
 
   def initialize(opts = {})
     super(opts)
@@ -25,6 +25,11 @@ class AwsCloudWatchLogGroup < AwsResourceBase
 
     @retention_in_days = @log_groups.first.retention_in_days
     @kms_key_id = @log_groups.first.kms_key_id
+
+    catch_aws_errors do
+      resp = @aws.cloudwatch_client.list_tags_log_group({log_group_name: @log_group_name})
+      @tags = resp.tags
+    end
   end
 
   def exists?

--- a/libraries/aws_cloudwatch_log_group.rb
+++ b/libraries/aws_cloudwatch_log_group.rb
@@ -9,8 +9,13 @@ class AwsCloudWatchLogGroup < AwsResourceBase
   attr_reader :log_group_name, :retention_in_days, :kms_key_id, :tags
 
   def initialize(opts = {})
+    opts = { log_group_name: opts } if opts.is_a?(String)
     super(opts)
     validate_parameters(required: [:log_group_name])
+
+    if !opts[:log_group_name].is_a?(String)
+      raise ArgumentError, "#{@__resource_name__}: `log_group_name` #{opts[:log_group_name]} is invalid, must be a string."
+    end
 
     @log_group_name = opts[:log_group_name]
 

--- a/libraries/aws_cloudwatch_log_group.rb
+++ b/libraries/aws_cloudwatch_log_group.rb
@@ -15,7 +15,7 @@ class AwsCloudWatchLogGroup < AwsResourceBase
     @log_group_name = opts[:log_group_name]
 
     catch_aws_errors do
-      resp = @aws.cloudwatch_client.describe_log_groups({log_group_name_prefix: @log_group_name})
+      resp = @aws.cloudwatchlogs_client.describe_log_groups({log_group_name_prefix: @log_group_name})
       @log_groups = resp.log_groups
     end
 
@@ -27,7 +27,7 @@ class AwsCloudWatchLogGroup < AwsResourceBase
     @kms_key_id = @log_groups.first.kms_key_id
 
     catch_aws_errors do
-      resp = @aws.cloudwatch_client.list_tags_log_group({log_group_name: @log_group_name})
+      resp = @aws.cloudwatchlogs_client.list_tags_log_group({log_group_name: @log_group_name})
       @tags = resp.tags
     end
   end

--- a/libraries/aws_cloudwatch_log_group.rb
+++ b/libraries/aws_cloudwatch_log_group.rb
@@ -6,7 +6,7 @@ class AwsCloudWatchLogGroup < AwsResourceBase
   name 'aws_cloudwatch_log_group'
   desc 'Verifies settings for an AWS CloudWatch Log Group'
 
-  attr_reader :log_group_name, :retention_in_days, :kms_key_id, :tags
+  attr_reader :log_group_name, :retention_in_days, :metric_filter_count, :kms_key_id, :tags
 
   def initialize(opts = {})
     opts = { log_group_name: opts } if opts.is_a?(String)
@@ -29,6 +29,7 @@ class AwsCloudWatchLogGroup < AwsResourceBase
     raise "Found multiple CloudWatch Log Groups. The following matched: #{@log_groups.join(', ')}.  Try to restrict your resource criteria." if @log_groups.count > 1
 
     @retention_in_days = @log_groups.first.retention_in_days
+    @metric_filter_count = @log_groups.first.metric_filter_count
     @kms_key_id = @log_groups.first.kms_key_id
 
     catch_aws_errors do

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -32,6 +32,7 @@ variable "aws_cloud_watch_alarm_metric_name" {}
 variable "aws_cloud_watch_alarm_name" {}
 variable "aws_cloud_watch_alarm_name_with_dimensions" {}
 variable "aws_cloud_watch_alarm_metric_name_with_dimensions" {}
+variable "aws_cloud_watch_log_group_name" {}
 variable "aws_cloud_watch_log_metric_filter_namespace_with_dimensions" {}
 variable "aws_cloud_watch_log_metric_filter_log_group_name" {}
 variable "aws_cloud_watch_log_metric_filter_metric_name" {}
@@ -938,6 +939,16 @@ resource "aws_cloudtrail" "trail_2" {
 }
 
 # Cloudwatch
+resource "aws_cloudwatch_log_group" "log_group" {
+  count             = var.aws_enable_creation
+  name              = var.aws_cloudwatch_log_group_name
+  retention_in_days = 7
+
+  tags = {
+    Name = var.aws_cloudwatch_log_group_name
+  }
+}
+
 resource "aws_cloudwatch_log_metric_filter" "log_metric_filter" {
   count          = var.aws_enable_creation
   name           = var.aws_cloud_watch_log_metric_filter_name

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -134,6 +134,10 @@ output "aws_cloud_trail_key_arn" {
   value = aws_kms_key.trail_1_key.0.arn
 }
 
+output "aws_cloudwatch_log_group_name" {
+  value = aws_cloudwatch_log_group.log_group.name
+}
+
 output "aws_cloud_trail_cloud_watch_logs_group_arn" {
   value = aws_cloudwatch_log_group.trail_1_log_group.0.arn
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -80,6 +80,7 @@ module AWSInspecConfig
       aws_cloud_watch_alarm_name: "aws-cloudwatch-alarm-#{add_random_string}",
       aws_cloud_watch_alarm_metric_name_with_dimensions: 'aws_cloudwatch_alarm_metric_1',
       aws_cloud_watch_alarm_name_with_dimensions: "aws-cloudwatch-alarm-#{add_random_string}",
+      aws_cloud_watch_log_group_name: "aws_cloudwatch_log_#{add_random_string}",
       aws_cloud_watch_log_metric_filter_namespace_with_dimensions: "aws_lmf_namespace_#{add_random_string}",
       aws_cloud_watch_log_metric_filter_log_group_name: "aws_lmf_log_group_name_#{add_random_string}",
       aws_cloud_watch_log_metric_filter_metric_name: "aws_lmf_metric_name_#{add_random_string}",

--- a/test/integration/verify/controls/aws_cloudwatch_log_group.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_log_group.rb
@@ -1,0 +1,16 @@
+title 'Test single AWS CloudWatch Log Group'
+
+aws_cloudwatch_log_group_name = attribute(:aws_cloudwatch_log_group_name, default: '', description: 'The AWS DHCP Options ID.')
+
+control 'aws-cloudwatch-log-group1.0' do
+
+  impact 1.0
+  title 'Ensure AWS Cloudwatch Log Group has the correct properties.'
+
+  describe aws_cloudwatch_log_group(log_group_name:  aws_cloudwatch_log_group_name) do
+    it { should exist }
+    its('retention_in_days') { should eq 7 }
+    its('kms_key_id') { should eq nil }
+    its('tags') { should include('Name' => aws_cloudwatch_log_group_name)}
+  end
+end

--- a/test/unit/resources/aws_cloudwatch_log_group_test.rb
+++ b/test/unit/resources/aws_cloudwatch_log_group_test.rb
@@ -1,0 +1,166 @@
+require 'helper'
+require 'aws_cloudwatch_log_group'
+require 'aws-sdk-core'
+
+class AwsCloudWatchLogGroupContructorTest < Minitest::Test
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsCloudWatchLogGroup.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsCloudWatchLogGroup.new(rubbish: 99) }
+  end
+
+  def test_rejects_empty_name
+    assert_raises(ArgumentError) { AwsCloudWatchLogGroup.new(log_group_name: '') }
+  end
+
+  def test_log_group_non_existing
+    refute AwsCloudWatchLogGroup.new(log_group_name: 'my_log_group', client_args: { stub_responses: true }).exists?
+  end
+end
+
+class AwsCloudWatchLogGroupConstructorSingleMatchTest < Minitest::Test
+  def setup
+    data = {}
+    data[:method] = :describe_log_groups
+    data[:data] = {
+      :log_groups => [
+        {
+          :log_group_name => 'my_log_group',
+          :creation_time => 1522855542366,
+          :metric_filter_count => 0,
+          :arn => 'arn:aws:logs:eu-west-1:111111111111:log-group:my_log_group:*',
+          :stored_bytes => 0,
+        }
+      ]
+    }
+
+    data[:client] = Aws::CloudWatchLogs::Client
+
+    tags_data = {}
+    tags_data[:method] = :list_tags_log_group
+    tags_data[:data] = {
+      :tags => {}
+    }
+    tags_data[:client] = Aws::CloudWatchLogs::Client
+    @log_group = AwsCloudWatchLogGroup.new(log_group_name: 'my_log_group', client_args: { stub_responses: true }, stub_data: [data, tags_data])
+  end
+
+  def test_log_group_exists
+    assert @log_group.exists?
+  end
+
+  def test_log_group_name
+    assert_equal(@log_group.log_group_name, 'my_log_group')
+  end
+
+  def test_log_group_empty_retention_in_days
+    assert_nil(@log_group.retention_in_days)
+  end
+
+  def test_log_group_empty_kms_key_id
+    assert_nil(@log_group.kms_key_id)
+  end
+
+  def test_log_group_metric_filter_count
+    assert_equal(@log_group.metric_filter_count, 0)
+  end
+
+  def test_log_group_tags
+    assert_equal(@log_group.tags, {})
+  end
+end
+
+class AwsCloudWatchLogGroupConstructorWithExtraTest < Minitest::Test
+  def setup
+    data = {}
+    data[:method] = :describe_log_groups
+    data[:data] = {
+      :log_groups => [
+        {
+          :log_group_name => 'my_log_group_with_extra',
+          :creation_time => 1522855542366,
+          :metric_filter_count => 10,
+          :arn => 'arn:aws:logs:eu-west-1:111111111111:log-group:my_log_group_with_extra:*',
+          :stored_bytes => 0,
+          :kms_key_id => 'arn:aws:kms:eu-west-1:111111111111:key/3c1a99bf-4d52-467f-914e-b96a1416ad4e',
+          :retention_in_days => 7
+        }
+      ]
+    }
+
+    data[:client] = Aws::CloudWatchLogs::Client
+
+    tags_data = {}
+    tags_data[:method] = :list_tags_log_group
+    tags_data[:data] = {
+      :tags => {
+        'tag1' => 'value1',
+        'tag2' => 'value2'
+      }
+    }
+    tags_data[:client] = Aws::CloudWatchLogs::Client
+    @log_group = AwsCloudWatchLogGroup.new(log_group_name: 'my_log_group_with_extra', client_args: { stub_responses: true }, stub_data: [data, tags_data])
+  end
+
+  def test_log_group_exists
+    assert @log_group.exists?
+  end
+
+  def test_log_group_name
+    assert_equal(@log_group.log_group_name, 'my_log_group_with_extra')
+  end
+
+  def test_log_group_empty_retention_in_days
+    assert_equal(@log_group.retention_in_days, 7)
+  end
+
+  def test_log_group_empty_kms_key_id
+    assert_equal(@log_group.kms_key_id, 'arn:aws:kms:eu-west-1:111111111111:key/3c1a99bf-4d52-467f-914e-b96a1416ad4e')
+  end
+
+  def test_log_group_metric_filter_count
+    assert_equal(@log_group.metric_filter_count, 10)
+  end
+
+  def test_log_group_tags
+    assert_equal(@log_group.tags, {
+      'tag1' => 'value1',
+      'tag2' => 'value2'
+    })
+  end
+end
+
+class AwsCloudWatchLogGroupConstructorMultipleFound < Minitest::Test
+  def setup
+    @data = {}
+    @data[:method] = :describe_log_groups
+    @data[:data] = {
+      :log_groups => [
+        {
+          :log_group_name => 'my_log_group',
+          :creation_time => 1522855542366,
+          :metric_filter_count => 0,
+          :arn => 'arn:aws:logs:eu-west-1:111111111111:log-group:my_log_group:*',
+          :stored_bytes => 0,
+        },
+        {
+          :log_group_name => 'my_log_group_with_extra',
+          :creation_time => 1522855542366,
+          :metric_filter_count => 10,
+          :arn => 'arn:aws:logs:eu-west-1:111111111111:log-group:my_log_group_with_extra:*',
+          :stored_bytes => 0,
+          :kms_key_id => 'arn:aws:kms:eu-west-1:111111111111:key/3c1a99bf-4d52-467f-914e-b96a1416ad4e',
+          :retention_in_days => 7
+        }
+      ]
+    }
+
+    @data[:client] = Aws::CloudWatchLogs::Client
+  end
+
+  def test_multiple_log_groups_returned_fails
+    assert_raises(RuntimeError) { AwsCloudWatchLogGroup.new(log_group_name: 'my_log_group', client_args: { stub_responses: true }, stub_data: [@data]) }
+  end
+end


### PR DESCRIPTION
### Description

Adds support for the aws_cloudwatch_log_group resource

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [x] `rake lint` passes - for newly created (existing code does not pass)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Tests have not been ran, as there is just far too much to execute; they could do with breaking down or be controllable beyond `var.aws_enable_creation`