### PR TITLE
Resolves #126 Expose global secondary indexes on aws_dynamodb_table

### DIFF
--- a/docs/resources/aws_dynamodb_table.md
+++ b/docs/resources/aws_dynamodb_table.md
@@ -33,7 +33,7 @@ The table name used by this DynamoDb Table. This must be passed as a `table_name
 |item\_count                  | The number of entries in the  DynamoDb Table. |
 |attributes                   | An array of attributes that describe the key schema for the table and indexes. This is returned as a hash. Each entry is composed of: `attribute_name` - The name of this key attribute. `attribute_type` - The datatype of the attribute : `B` - Boolean, `N` - Number, `S` - string|
 |key\_schema                  | Specifies the attributes that make up the primary key for a table or an index. This is returned as a hash. The attributes in KeySchema must also be defined in the Attributes array. Each element in the KeySchemaElement array is composed of: `attribute_name` - The name of this key attribute. `key_type` - The role that the key attribute will assume: `HASH` - partition key, `RANGE` - sort key|
-|secondary\_global\_table     | This will only be populated if a global secondary table has been referenced on the selected table. This will return a hash of values with a prefix of `global_sec_indexes` for each key. eg. `global_sec_indexes_table_name`  |
+|global\_secondary\_indexes   | A list of global secondary indexes if there is any referenced on the selected table. |
 
 ## Examples
 
@@ -54,6 +54,17 @@ The table name used by this DynamoDb Table. This must be passed as a `table_name
       its('key_schema') { should include({:attribute_name =>'table_field', :key_type =>'HASH'}) }
     end
 
+##### Ensure DynamoDb Table has the correct global secondary indexes set
+    aws_dynamodb_table(table_name: 'table-name').global_secondary_indexes.each do |global_sec_idx|
+      describe global_sec_idx do
+        its('index_name') { should eq 'TitleIndex' }
+        its('index_status') { should eq 'ACTIVE' }
+        its('key_schema') { should include({:attribute_name =>'Title', :key_type =>'HASH'}) }
+        its('provisioned_throughput.write_capacity_units') { should cmp 10 }
+        its('provisioned_throughput.read_capacity_units') { should cmp 10 }
+        its('projection.projection_type') { should eq 'INCLUDE' }
+      end
+    end
 
 ## Matchers
 

--- a/libraries/aws_dynamodb_table.rb
+++ b/libraries/aws_dynamodb_table.rb
@@ -13,7 +13,7 @@ class AwsDynamoDbTable < AwsResourceBase
   "
 
   attr_reader :table_name, :table_status, :creation_date, :number_of_decreases_today,
-              :write_capacity_units, :read_capacity_units, :item_count, :table_arn, :attributes, :key_schema
+              :write_capacity_units, :read_capacity_units, :item_count, :table_arn, :attributes, :key_schema, :global_secondary_indexes
 
   def initialize(opts = {})
     opts = { table_name: opts } if opts.is_a?(String)
@@ -21,14 +21,12 @@ class AwsDynamoDbTable < AwsResourceBase
     validate_parameters(required: [:table_name])
 
     catch_aws_errors do
-
       begin
         resp = @aws.dynamodb_client.describe_table(table_name: opts[:table_name])
         return nil if resp[0].nil? || resp[0].empty?
       rescue Aws::DynamoDB::Errors::ResourceNotFoundException
         return
       end
-
       @dynamodb_table = resp[0]
       @table_name                = @dynamodb_table[:table_name]
       @table_status              = @dynamodb_table[:table_status]
@@ -40,21 +38,28 @@ class AwsDynamoDbTable < AwsResourceBase
       @item_count                = @dynamodb_table[:item_count]
       @attributes                = []
       @key_schema                = []
-      @secondary_global_table    = {}
+      @global_secondary_indexes  = []
 
       @dynamodb_table[:attribute_definitions]&.map { |attr|
         @attributes.push({ 'attribute_name': attr.attribute_name,
                            'attribute_type': attr.attribute_type })
       }
-
       @dynamodb_table[:key_schema]&.map { |key|
         @key_schema.push({ 'attribute_name': key.attribute_name,
                            'key_type':       key.key_type })
       }
 
       if @dynamodb_table[:global_secondary_indexes]
-        @secondary_global_table = flatten_hash(@dynamodb_table[:global_secondary_indexes][0].to_h)
-        create_resource_methods(@secondary_global_table)
+        gsi = { global_secondary_indexes: @dynamodb_table[:global_secondary_indexes] }
+        create_resource_methods(gsi)
+        global_secondary_indexes.each do |idx|
+          idx.define_singleton_method(:to_s) do
+            "AWS Dynamodb Global Secondary Index #{idx.item[:index_name]}"
+          end
+          idx.define_singleton_method(:key_schema) do
+            idx.item[:key_schema].map { |attr| { 'attribute_name': attr[:attribute_name], 'key_type': attr[:key_type] } }
+          end
+        end
       end
     end
   end
@@ -65,13 +70,5 @@ class AwsDynamoDbTable < AwsResourceBase
 
   def to_s
     "AWS Dynamodb table #{@table_name}"
-  end
-
-  private
-
-  def flatten_hash(param)
-    param.each_pair.reduce({}) do |a, (k, v)|
-      v.is_a?(Hash) ? a.merge(flatten_hash(v)) : a.merge("global_sec_indexes_#{k}".to_sym => v)
-    end
   end
 end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -978,11 +978,11 @@ resource "aws_cloudtrail" "trail_2" {
 # Cloudwatch
 resource "aws_cloudwatch_log_group" "log_group" {
   count             = var.aws_enable_creation
-  name              = var.aws_cloudwatch_log_group_name
+  name              = var.aws_cloud_watch_log_group_name
   retention_in_days = 7
 
   tags = {
-    Name = var.aws_cloudwatch_log_group_name
+    Name = var.aws_cloud_watch_log_group_name
   }
 }
 

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -134,8 +134,8 @@ output "aws_cloud_trail_key_arn" {
   value = aws_kms_key.trail_1_key.0.arn
 }
 
-output "aws_cloudwatch_log_group_name" {
-  value = aws_cloudwatch_log_group.log_group.name
+output "aws_cloud_watch_log_group_name" {
+  value = aws_cloudwatch_log_group.log_group.0.name
 }
 
 output "aws_cloud_trail_cloud_watch_logs_group_arn" {

--- a/test/integration/verify/controls/aws_dynamodb_table.rb
+++ b/test/integration/verify/controls/aws_dynamodb_table.rb
@@ -1,7 +1,7 @@
 title 'Test single AWS CloudWatch Alarm'
 
-aws_dynamodb_table_name = attribute(:aws_dynamodb_table_name, default: '', description: 'The AWS Dynamodb Table name.')
-aws_dynamodb_table_arn = attribute(:aws_dynamodb_table_arn, default: '', description: 'The AWS Dynamodb Table arn.')
+aws_dynamodb_table_name = attribute(:aws_dynamodb_table_name, value: '', description: 'The AWS Dynamodb Table name.')
+aws_dynamodb_table_arn = attribute(:aws_dynamodb_table_arn, value: '', description: 'The AWS Dynamodb Table arn.')
 
 control 'aws-dynamodb-table-1.0' do
 
@@ -23,11 +23,20 @@ control 'aws-dynamodb-table-1.0' do
     its('attributes')                    { should include({:attribute_name =>'UserId', :attribute_type =>'S'}) }
     its('key_schema')                    { should include({:attribute_name =>'UserId', :key_type =>'HASH'}) }
     its('key_schema')                    { should include({:attribute_name =>'Title', :key_type =>'RANGE'}) }
-    its('global_sec_indexes_index_name') { should eq 'TitleIndex' }
+  end
+
+  aws_dynamodb_table(table_name: aws_dynamodb_table_name).global_secondary_indexes.each do |global_sec_idx|
+    describe global_sec_idx do
+      its('index_name') { should eq 'TitleIndex' }
+      its('index_status') { should eq 'ACTIVE' }
+      its('key_schema') { should include({:attribute_name =>'Title', :key_type =>'HASH'}) }
+      its('provisioned_throughput.write_capacity_units') { should cmp 10 }
+      its('provisioned_throughput.read_capacity_units') { should cmp 10 }
+      its('projection.projection_type') { should eq 'INCLUDE' }
+    end
   end
 
   describe aws_dynamodb_table(table_name: 'NotThere') do
     it { should_not exist }
   end
-
 end


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

Expose global secondary indexes on `aws_dynamodb_table`.
Example:
```ruby
aws_dynamodb_table(table_name: 'table-name').global_secondary_indexes.each do |global_sec_idx|
      describe global_sec_idx do
        its('index_name') { should eq 'TitleIndex' }
        its('index_status') { should eq 'ACTIVE' }
        its('key_schema') { should include({:attribute_name =>'Title', :key_type =>'HASH'}) }
        its('provisioned_throughput.write_capacity_units') { should cmp 10 }
        its('provisioned_throughput.read_capacity_units') { should cmp 10 }
        its('projection.projection_type') { should eq 'INCLUDE' }
      end
end
```


### Issues Resolved

Resolves #126 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
