### PR TITLE
Fix a typo in cloudwatch_log_group control

### DIFF
--- a/test/integration/verify/controls/aws_cloudwatch_log_group.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_log_group.rb
@@ -1,16 +1,16 @@
 title 'Test single AWS CloudWatch Log Group'
 
-aws_cloudwatch_log_group_name = attribute(:aws_cloudwatch_log_group_name, default: '', description: 'The AWS DHCP Options ID.')
+aws_cloud_watch_log_group_name = attribute(:aws_cloud_watch_log_group_name, default: '', description: 'The AWS DHCP Options ID.')
 
 control 'aws-cloudwatch-log-group1.0' do
 
   impact 1.0
   title 'Ensure AWS Cloudwatch Log Group has the correct properties.'
 
-  describe aws_cloudwatch_log_group(log_group_name:  aws_cloudwatch_log_group_name) do
+  describe aws_cloudwatch_log_group(log_group_name:  aws_cloud_watch_log_group_name) do
     it { should exist }
     its('retention_in_days') { should eq 7 }
     its('kms_key_id') { should eq nil }
-    its('tags') { should include('Name' => aws_cloudwatch_log_group_name)}
+    its('tags') { should include('Name' => aws_cloud_watch_log_group_name)}
   end
 end


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

Fix a typo in an attribute name failing the CI integration tests.

### Issues Resolved

https://www.bananaskippy.com/job/InSpec%20AWS%20Infrastructure%20Testing/job/master/401/consoleFull

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
