### PR TITLE
Add has_secure_transport_enabled? method for aws_s3_bucket

### DIFF
--- a/docs/resources/aws_s3_bucket.md
+++ b/docs/resources/aws_s3_bucket.md
@@ -90,6 +90,11 @@ See also the [AWS documentation on S3 Buckets](https://docs.aws.amazon.com/Amazo
             end
         end
 
+##### Check if a bucket has a bucket policy that requires requests to use HTTPS
+      describe aws_s3_bucket('test_bucket') do
+        it { should have_secure_transport_enabled }
+      end
+
 ## Matchers
 
 This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
@@ -123,6 +128,12 @@ The `have_default_encryption_enabled` matcher tests if default encryption is ena
 The `have_versioning_enabled` matcher tests if versioning is enabled for the s3 bucket.
 
    it { should have_versioning_enabled }
+
+#### have\_secure\_transport\_enabled
+
+The `have_secure_transport_enabled` matcher tests if a bucket policy that explicitly denies requests via HTTP is enabled for the s3 bucket.
+
+   it { should have_secure_transport_enabled }
 
 ## AWS Permissions
 

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -85,6 +85,10 @@ class AwsS3Bucket < AwsResourceBase
     end
   end
 
+  def has_secure_transport_enabled?
+    bucket_policy.any? { |s| s.effect == 'Deny' && s.condition == { 'Bool' => { 'aws:SecureTransport'=>'false' } } }
+  end
+
   # below is to preserve the original 'unsupported' function but isn't used in the above
   def bucket_policy
     @bucket_policy ||= fetch_bucket_policy

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -470,6 +470,17 @@ resource "aws_s3_bucket_policy" "allow_public" {
       "Principal": "*",
       "Action": "s3:GetObject",
       "Resource": "arn:aws:s3:::${aws_s3_bucket.bucket_public[0].id}/*"
+    },
+    {
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": "arn:aws:s3:::${aws_s3_bucket.bucket_public[0].id}/*",
+        "Condition": {
+            "Bool": {
+                "aws:SecureTransport": "false"
+            }
+        }
     }
   ]
 }

--- a/test/integration/verify/controls/aws_s3_bucket.rb
+++ b/test/integration/verify/controls/aws_s3_bucket.rb
@@ -23,6 +23,7 @@ control 'aws-s3-bucket-1.0' do
     its('tags')   { should include('Environment' => 'Dev',
                                    'Name' => aws_bucket_public_name)}
     it            { should be_public }
+    it            { should have_secure_transport_enabled }
   end
 
   describe aws_s3_bucket(aws_bucket_public_name) do
@@ -40,6 +41,7 @@ control 'aws-s3-bucket-1.0' do
   describe aws_s3_bucket(bucket_name: aws_bucket_private_name) do
     it { should exist }
     it { should_not be_public }
+    it { should_not have_secure_transport_enabled }
   end
 
   describe aws_s3_bucket(bucket_name: aws_bucket_auth_name) do

--- a/test/unit/resources/aws_s3_bucket_test.rb
+++ b/test/unit/resources/aws_s3_bucket_test.rb
@@ -75,6 +75,17 @@ class AwsS3BucketPublicTest < Minitest::Test
       "Principal": "*",
       "Action": "s3:GetObject",
       "Resource": "arn:aws:s3:::bucket-12345/*"
+    },
+    {
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": "arn:aws:s3:::bucket-12345/*",
+        "Condition": {
+            "Bool": {
+                "aws:SecureTransport": "false"
+            }
+        }
     }
   ]
 }
@@ -139,6 +150,10 @@ EOP
   def test_property_bucket_policy_public
     allow_all = @bucket.bucket_policy.select { |s| s.effect == 'Allow' && s.principal == '*' }
     assert_equal(1, allow_all.count)
+  end
+
+  def test_has_default_encryption_enabled_positive
+    assert(@bucket.has_secure_transport_enabled?)
   end
 end
 
@@ -246,6 +261,9 @@ EOP
     assert_equal(0, allow_all.count)
   end
 
+  def test_has_default_encryption_enabled_positive
+    refute(@bucket.has_secure_transport_enabled?)
+  end
 end
 
 class AwsS3BucketAuthUsersTest < Minitest::Test


### PR DESCRIPTION
### Description

I need to check that an S3 bucket policy contains a statement that denies HTTP connections to a bucket. The easiest way I can see is adding a method to `aws_s3_bucket`, which I've done and tested locally. 

The required policy statement is:
```json
      {
      "Effect": "Deny",
      "Principal": "*",
      "Action": "*",
      "Resource": "arn:aws:s3:::example-bucket/*",
      "Condition": {
        "Bool": {
          "aws:SecureTransport": "false"
        }
      }
```
as documented here: https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html

I've added unit and integration tests for the change.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
