### PR TITLE
Improve has_statement? method

### DIFF
--- a/docs/resources/aws_iam_policy.md
+++ b/docs/resources/aws_iam_policy.md
@@ -134,10 +134,10 @@ Examines the list of statements contained in the policy and passes if at least o
 
 Please note the following about the behavior of `have_statement`:
 * `Action`, `Sid`, and `Resource` allow using a regular expression as the search critera instead of a string literal.
-* it does not support wildcard expansion; to check for a wildcard value, check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and the test checks for `Action: "s3:PutObject"`, the test _will not match_. You must write an additional test checking for the wildcard case.
-* it supports searching list values. For example, if a statement contains a list of 3 resources, and a `have_statement` test specifes _one_ of those resources, it will match.
+* It does not support wildcard expansion; to check for a wildcard value, check for it explicitly. For example, if the policy includes a statement with `"Action": "s3:*"` and the test checks for `Action: "s3:PutObject"`, the test _will not match_. You must write an additional test checking for the wildcard case.
+* It supports searching list values. For example, if a statement contains a list of 3 resources, and a `have_statement` test specifes _one_ of those resources, it will match.
 * `Action` and `Resource` allow using a list of string literals or regular expressions in a test, in which case _all_ must match on the _same_ statement for the test to match. Order is ignored.
-* it does not support the `[Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal)` or `Conditional` key, or any of `NotAction`, `Not[Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal)`, or `NotResource`.
+* It does not support the [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html), [NotPrincipal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html) or [Condition](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html).
 
 Examples:
 

--- a/test/integration/verify/controls/aws_iam_policy.rb
+++ b/test/integration/verify/controls/aws_iam_policy.rb
@@ -1,10 +1,10 @@
 title 'Test single AWS Iam Policy'
 
-aws_iam_policy_arn = attribute(:aws_iam_policy_arn, default: '', description: 'The AWS Iam Policy arn.')
-aws_iam_policy_name = attribute(:aws_iam_policy_name, default: '', description: 'The AWS Iam Policy name.')
-aws_iam_attached_policy_name = attribute(:aws_iam_attached_policy_name, default: '', description: 'The AWS Iam Attached Policy name.')
-aws_iam_user_name = attribute(:aws_iam_user_name, default: '', description: 'The Attached AWS Iam Username.')
-aws_iam_role_generic_name = attribute(:aws_iam_role_generic_name, default: '', description: 'The AWS Iam Role.')
+aws_iam_policy_arn = attribute(:aws_iam_policy_arn, value: '', description: 'The AWS Iam Policy arn.')
+aws_iam_policy_name = attribute(:aws_iam_policy_name, value: '', description: 'The AWS Iam Policy name.')
+aws_iam_attached_policy_name = attribute(:aws_iam_attached_policy_name, value: '', description: 'The AWS Iam Attached Policy name.')
+aws_iam_user_name = attribute(:aws_iam_user_name, value: '', description: 'The Attached AWS Iam Username.')
+aws_iam_role_generic_name = attribute(:aws_iam_role_generic_name, value: '', description: 'The AWS Iam Role.')
 
 control 'aws-iam-policy-1.0' do
 
@@ -35,6 +35,8 @@ control 'aws-iam-policy-1.0' do
     it { should be_attached_to_role(aws_iam_role_generic_name) }
     it { should_not be_attached_to_user("fake-user") }
     it { should_not be_attached_to_role("fake-role") }
+    # Test Action in an array
+    it { should have_statement(Action: ["ec2:Describe*"]) }
   end
 
 end

--- a/test/unit/resources/aws_iam_policy_test.rb
+++ b/test/unit/resources/aws_iam_policy_test.rb
@@ -88,23 +88,31 @@ class AwsIamPolicyTest < Minitest::Test
     assert @policy.has_statement?(Action: "ec2:Describe*")
   end
 
-  def test_statment_contains_action_existing_with_effect
+  def test_statement_contains_action_array
+    assert @policy.has_statement?(Action: ["ec2:Describe*"])
+  end
+
+  def test_statement_contains_not_allowed_item
+    assert_raises(ArgumentError) { @policy.has_statement?(Condition: 'Some condition') }
+  end
+
+  def test_statement_contains_action_existing_with_effect
     assert @policy.has_statement?(Action: "ec2:Describe*", Effect: "Allow")
   end
 
-  def test_statment_contains_action_existing_with_effect_and_resource
+  def test_statement_contains_action_existing_with_effect_and_resource
     assert @policy.has_statement?(Action: "ec2:Describe*", Effect: "Allow", Resource: "*")
   end
 
-  def test_statment_contains_not_action
+  def test_statement_contains_not_action
     assert @policy.has_statement?(NotAction: "s3:DeleteBucket")
   end
 
-  def test_statment_contains_not_action_existing_with_effect
+  def test_statement_contains_not_action_existing_with_effect
     assert @policy.has_statement?(NotAction: "s3:DeleteBucket", Effect: "Allow")
   end
 
-  def test_statment_contains_without_not_action
+  def test_statement_contains_without_not_action
     assert @policy.has_statement?(Effect: "Allow", Resource: "arn:aws:s3:::*")
   end
 
@@ -116,7 +124,7 @@ class AwsIamPolicyTest < Minitest::Test
     refute @policy.has_statement?(Action: "s3:DeleteBucket", Effect: "Allow", Resource: "arn:aws:s3:::*")
   end
 
-  def test_statment_contains_all_resources
+  def test_statement_contains_all_resources
     assert @policy.has_statement?(Resource: "*")
   end
 


### PR DESCRIPTION
Improve `has_statement?` method

Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

- Allow providing Actions in an array
- Validate statement items prior to looking for a match

### Issues Resolved

Fixes #225 
Fixes #226 

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
