### PR TITLE
Missing name var in aws inspec config

### DIFF
--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1858,7 +1858,7 @@ resource "aws_nat_gateway" "inspec_test" {
 }
 
 resource "aws_ssm_parameter" "ssm_param_secret" {
-  count       = 1
+  count       = var.aws_enable_creation
   name        = var.aws_ssm_parameter_name
   description = "The parameter description"
   type        = "SecureString"

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -173,6 +173,7 @@ module AWSInspecConfig
       aws_security_group_zeta: "aws-security-group-zeta-#{add_random_string}",
       aws_security_group_omega: "aws-security-group-omega-#{add_random_string}",
       aws_security_group_lb: "aws-security-group-lb-#{add_random_string}",
+      aws_ssm_parameter_name: "parameter-name-#{add_random_string}",
       aws_sqs_queue_name: "aws-sqs-queue-#{add_random_string}",
       aws_sns_topic_no_subscription: "aws-sns-topic-no-subscription-#{add_random_string}",
       aws_sns_topic_subscription_sqs: "aws-sns-topic-subscription-sqs-#{add_random_string}",


### PR DESCRIPTION
Signed-off-by: Sam Scott <sscott@chef.io>

### Description
Updated aws.tf and aws_inspec_config with small fixes

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
