### PR TITLE
Remove travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-cache: bundler
-
-rvm:
-  - 2.6.3
-
-bundler_args: --without integration
-script: bundle exec rake


### PR DESCRIPTION
This will remove the redundant Travis CI and bring parity with the azure resource pack
Signed-off-by: Ross Moles <rmoles@chef.io>
