### PR TITLE
SSM Compliance Summary

### DIFF
--- a/docs/resources/aws_ssm_activation.md
+++ b/docs/resources/aws_ssm_activation.md
@@ -1,0 +1,76 @@
+---
+title: About the aws_ssm_activation Resource
+platform: aws
+---
+
+# aws\_ssm\_activation
+
+Use the `aws_ssm_activation` InSpec audit resource to test properties of a ssm activation.
+
+## Syntax
+
+ An `aws_ssm_activation` resource block uses the parameter to select a ssm activation.
+
+    describe aws_ssm_activation(name: 'ssm-activation-name-1234') do
+      it { should exist }
+    end
+
+
+#### Parameters
+
+##### name _(required)_
+
+This resource accepts a single parameter, the SSM Activation Name.
+This can be passed either as a string or as a `name: 'value'` key-value entry in a hash.
+
+See also the [AWS documentation on SSM Activations](https://docs.aws.amazon.com/systems-manager/latest/userguide/activations.html).
+
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|activation\_id               | Provides  ID created by Systems Manager when you submitted the activation. |
+|created\_date                | Provides the date the activation was created. |
+|default\_instance\_name      | Provides the name for the managed instance when it is created. |
+|description                  | Provides a user defined description of the activation. |
+|expiration\_date             | Provides the date when this activation can no longer be used to register managed instances. |
+|expired                      | Whether or not the activation is expired. |
+|iam\_role                    | Provides the Amazon Identity and Access Management (IAM) role to assign to the managed instance. |
+|registration\_limit          | Provides the maximum number of managed instances that can be registered with this activation. |
+|registrations\_count         | Provides the number of managed instances already registered with this activation. |
+|tags                         | Provides the tags assigned to the activation. |
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Activation.html)
+
+## Examples
+
+##### Check the Name of a SSM Activation
+
+    describe aws_ssm_activation(name: 'ssm-activation-name-1234') do
+      its('name')  { should eq 'ssm-activation-name-1234' }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_activation(name: 'ssm-activation-name-1234') do
+      it { should exist }
+    end
+
+    describe aws_ssm_activation(name: 'ssm-activation-name-6789') do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:DescribeActivations` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_activations.md
+++ b/docs/resources/aws_ssm_activations.md
@@ -1,0 +1,70 @@
+---
+title: About the aws_ssm_activations Resource
+platform: aws
+---
+
+# aws\_ssm\_activations
+
+Use the `aws_ssm_activations` InSpec audit resource to test properties of a collection of AWS SSM Activations.
+
+## Syntax
+
+ Ensure you have exactly 3 activations
+
+    describe aws_ssm_activations do
+      its('names.count') { should cmp 3 }
+    end
+    
+#### Parameters
+
+This resource does not expect any parameters.
+
+See also the [AWS documentation on SSM](https://docs.aws.amazon.com/systems-manager/?id=docs_gateway).
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|activation\_ids              | Provides  ID created by Systems Manager when you submitted the activation. |
+|created\_dates               | Provides the date the activation was created. |
+|default\_instance\_names     | Provides the name for the managed instance when it is created. |
+|descriptions                 | Provides a user defined description of the activation. |
+|expiration\_dates            | Provides the date when this activation can no longer be used to register managed instances. |
+|expired                      | Whether or not the activation is expired. |
+|iam\_roles                   | Provides the Amazon Identity and Access Management (IAM) role to assign to the managed instance. |
+|registration\_limits         | Provides the maximum number of managed instances that can be registered with this activation. |
+|registrations\_count         | Provides the number of managed instances already registered with this activation. |
+|tags                         | Provides the tags assigned to the activation. |
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Activation.html)
+
+## Examples
+
+##### Ensure an Activation ID of a SSM Activation exists
+    describe aws_ssm_activations do
+      its('activation_ids') { should include 'activation-id' }
+    end
+
+## Matchers
+
+For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_activations.where( <property>: <value> ) do
+      it { should exist }
+    end
+
+    describe aws_ssm_activations.where( <property>: <value> ) do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:DescribeActivations` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_association.md
+++ b/docs/resources/aws_ssm_association.md
@@ -1,0 +1,76 @@
+---
+title: About the aws_ssm_association Resource
+platform: aws
+---
+
+# aws\_ssm\_association
+
+Use the `aws_ssm_association` InSpec audit resource to test properties of a ssm association.
+
+## Syntax
+
+ An `aws_ssm_association` resource block uses the parameter to select a ssm association.
+
+    describe aws_ssm_association(association_id: 'association-id-1234') do
+      it { should exist }
+    end
+
+
+#### Parameters
+
+##### association_id _(required)_
+
+This resource accepts a single parameter, the SSM Association ID.
+This can be passed either as a string or as a `association_id: 'value'` key-value entry in a hash.
+
+See also the [AWS documentation on SSM Associations](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-state-assoc.html).
+
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|association\_id              | Provides the ID of the association. |
+|association\_name            | Provides the name of the association. |
+|association\_version         | Provides the version of the association. |
+|document\_version            | Provides the document version used in the association. |
+|instance\_id                 | Provides the id of the instance. |
+|last\_execution\_date        | The date on which the association was last run. |
+|name                         | The name of the Systems Manager document. |
+|overview                     | Provides information about the association. |
+|schedule\_expression         | A cron expression that specifies a schedule when the association runs. |
+|targets                      | Provides the instances targeted by the request to create an association. |
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Association.html)
+
+## Examples
+
+##### Check the Name of a SSM Association
+
+    describe aws_ssm_association(association_id: 'association-id-1234') do
+      its('name')  { should eq 'association-name-1234' }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_association(association_id: 'association-id-1234') do
+      it { should exist }
+    end
+
+    describe aws_ssm_association(association_id: 'association-id-6789') do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:DescribeAssociation` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_associations.md
+++ b/docs/resources/aws_ssm_associations.md
@@ -1,0 +1,70 @@
+---
+title: About the aws_ssm_associations Resource
+platform: aws
+---
+
+# aws\_ssm\_associations
+
+Use the `aws_ssm_associations` InSpec audit resource to test properties of a collection of AWS SSM Associations.
+
+## Syntax
+
+ Ensure you have exactly 3 associations
+
+    describe aws_ssm_associations do
+      its('names.count') { should cmp 3 }
+    end
+    
+#### Parameters
+
+This resource does not expect any parameters.
+
+See also the [AWS documentation on SSM](https://docs.aws.amazon.com/systems-manager/?id=docs_gateway).
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|association\_ids             | Provides the ID of the association. |
+|association\_names           | Provides the name of the association. |
+|association\_versions        | Provides the version of the association. |
+|document\_versions           | Provides the document version used in the association. |
+|instance\_ids                | Provides the id of the instance. |
+|last\_execution\_dates       | The date on which the association was last run. |
+|names                        | The name of the Systems Manager document. |
+|overviews                    | Provides information about the association. |
+|schedule\_expressions        | A cron expression that specifies a schedule when the association runs. |
+|targets                      | Provides the instances targeted by the request to create an association. |
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Association.html)
+
+## Examples
+
+##### Ensure an Association ID of a SSM Association exists
+    describe aws_ssm_associations do
+      its('association_ids') { should include 'association-id' }
+    end
+
+## Matchers
+
+For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_associations.where( <property>: <value> ) do
+      it { should exist }
+    end
+
+    describe aws_ssm_associations.where( <property>: <value> ) do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:ListAssociations` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_document.md
+++ b/docs/resources/aws_ssm_document.md
@@ -1,0 +1,89 @@
+---
+title: About the aws_ssm_document Resource
+platform: aws
+---
+
+# aws\_ssm\_document
+
+Use the `aws_ssm_document` InSpec audit resource to test properties of a ssm document.
+
+## Syntax
+
+ An `aws_ssm_document` resource block uses the parameter to select a ssm document.
+
+    describe aws_ssm_document(name: 'document-name-1234') do
+      it { should exist }
+    end
+
+
+#### Parameters
+
+##### name _(required)_
+
+This resource accepts a single parameter, the SSM Document Name.
+This can be passed either as a string or as a `name: 'value'` key-value entry in a hash.
+
+See also the [AWS documentation on SSM Documents](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html).
+
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|sha\_1                       | Provides the SHA1 hash of the document, which you can use for verification. |
+|hash                         | Provides the Sha256 or Sha1 hash created by the system when the document was created. |
+|hash\_type                   | Provides the hash type of the document. Valid values include Sha256 or Sha1. |
+|name                         | Provides the name of the Systems Manager document. |
+|version\_name                | Provides the version of the artifact associated with the document. |
+|owner                        | Provides the AWS user account that created the document. |
+|created\_date                | Provides the date when the document was created. |
+|status                       | Provides the status of the Systems Manager document. |
+|status\_information          | Provides a message returned by AWS Systems Manager that explains the Status value. |
+|document\_version            | Provides the document version. |
+|description                  | Provides a description of the document. |
+|parameters                   | Provides a description of the parameters for a document. |
+|platform\_types              | Provides the list of OS platforms compatible with this Systems Manager document. |
+|document\_type               | Provides the type of the document. |
+|schema\_version              | Provides the schema version. |
+|latest\_version              | Provides the latest version of the document. |
+|default\_version             | Provides the default version. |
+|document\_format             | Provides the document format, either JSON or YAML. |
+|target\_type                 | The target type which defines the kinds of resources the document can run on. |
+|tags                         | Provides the tags, or metadata, that have been applied to the document. |
+|attachments\_information     | Provides details about the document attachments, including names, locations, sizes, and so on. |
+|requires                     | Provides a list of SSM documents required by a document. |
+
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DocumentDescription.html)
+
+## Examples
+
+##### Check the Name of a SSM Document
+
+    describe aws_ssm_document(name: 'document-name-1234') do
+      its('name')  { should eq 'document-name-1234' }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_document(name: 'document-name-1234') do
+      it { should exist }
+    end
+
+    describe aws_ssm_document(name: 'document-name-6789') do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:DescribeDocument` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_documents.md
+++ b/docs/resources/aws_ssm_documents.md
@@ -1,0 +1,69 @@
+---
+title: About the aws_ssm_documents Resource
+platform: aws
+---
+
+# aws\_ssm\_documents
+
+Use the `aws_ssm_documents` InSpec audit resource to test properties of a collection of AWS SSM Compliance Items.
+
+## Syntax
+
+ Ensure you have exactly 3 documents
+
+    describe aws_ssm_documents do
+      its('names.count') { should cmp 3 }
+    end
+    
+#### Parameters
+
+This resource does not expect any parameters.
+
+See also the [AWS documentation on SSM](https://docs.aws.amazon.com/systems-manager/?id=docs_gateway).
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|names                        | Provides the name of the Systems Manager document. |
+|owners                       | Provides the AWS user account that created the document. |
+|platform\_types              | Provides the list of OS platforms compatible with this Systems Manager document. |
+|document\_versions           | Provides the document version. |
+|document\_types              | Provides the type of the document. |
+|schema\_versions             | Provides the schema version. |
+|document\_formats            | Provides the document format, either JSON or YAML. |
+|target\_types                | The target type which defines the kinds of resources the document can run on. |
+|tags                         | Provides the tags, or metadata, that have been applied to the document. |
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DocumentDescription.html).
+
+## Examples
+
+##### Ensure a Name of a SSM Document exists
+    describe aws_ssm_documents do
+      its('names') { should include 'document-name' }
+    end
+
+## Matchers
+
+For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_documents.where( <property>: <value> ) do
+      it { should exist }
+    end
+
+    describe aws_ssm_documents.where( <property>: <value> ) do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:ListDocuments` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_resource_compliance_summaries.md
+++ b/docs/resources/aws_ssm_resource_compliance_summaries.md
@@ -1,0 +1,62 @@
+---
+title: About the aws_ssm_compliance_summaries Resource
+platform: aws
+---
+
+# aws\_ssm\_compliance\_summaries
+
+Use the `aws_ssm_compliance_summaries` InSpec audit resource to test properties of a collection of AWS SSM compliance summaries.
+
+## Syntax
+
+ Ensure you have exactly 3 SSM Compliance Summary Types
+
+    describe aws_ssm_compliance_summaries do
+      its('compliance_types.count') { should cmp 3 }
+    end
+    
+#### Parameters
+
+This resource does not expect any parameters.
+
+See also the [AWS documentation on SSM](https://docs.aws.amazon.com/systems-manager/?id=docs_gateway).
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|compliant_count              | Provides the total number of resources that are compliant. |
+|severity_summary             | Provides a summary of the compliance severity by compliance type. |
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CompliantSummary.html)
+
+## Examples
+
+##### Ensure Compliance Type of a SSM Compliance Summary exists
+    describe aws_ssm_compliance_summaries do
+      its('compliance_type') { should include 'ssm-compliance-type' }
+    end
+
+## Matchers
+
+For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_compliance_summaries.where( <property>: <value> ) do
+      it { should exist }
+    end
+
+    describe aws_ssm_compliance_summaries.where( <property>: <value> ) do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:ListComplianceSummaries` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_resource_compliance_summaries.md
+++ b/docs/resources/aws_ssm_resource_compliance_summaries.md
@@ -1,17 +1,17 @@
 ---
-title: About the aws_ssm_compliance_summaries Resource
+title: About the aws_ssm_resource_compliance_summaries Resource
 platform: aws
 ---
 
-# aws\_ssm\_compliance\_summaries
+# aws\_ssm\_resource\_compliance\_summaries
 
-Use the `aws_ssm_compliance_summaries` InSpec audit resource to test properties of a collection of AWS SSM compliance summaries.
+Use the `aws_ssm_resource_compliance_summaries` InSpec audit resource to test properties of a collection of AWS SSM compliance summaries.
 
 ## Syntax
 
- Ensure you have exactly 3 SSM Compliance Summary Types
+ Ensure you have exactly 3 SSM Resource Compliance Summary Types
 
-    describe aws_ssm_compliance_summaries do
+    describe aws_ssm_resource_compliance_summaries do
       its('compliance_types.count') { should cmp 3 }
     end
     
@@ -25,15 +25,21 @@ See also the [AWS documentation on SSM](https://docs.aws.amazon.com/systems-mana
 
 |Property                     | Description|
 | ---                         | --- |
-|compliant_count              | Provides the total number of resources that are compliant. |
-|severity_summary             | Provides a summary of the compliance severity by compliance type. |
+|compliance_types             | Provides the compliance type. |
+|compliant_summaries          | Provides a list of items that are compliant for the resource. |
+|execution_summaries          | Provides information about the execution |
+|non_compliant_summaries      | Provides a list of items that aren't compliant for the resource. |
+|overall_severity             | Provides the highest severity item found for the resource. |
+|resource_ids                 | Provides the resource id. |
+|resource_types               | Provides the resource type. |
+|status                       | Provides the compliance status for the resource. |
 
-For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CompliantSummary.html)
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ResourceComplianceSummaryItem.html)
 
 ## Examples
 
-##### Ensure Compliance Type of a SSM Compliance Summary exists
-    describe aws_ssm_compliance_summaries do
+##### Ensure Compliance Type of a SSM Resource Compliance Summary exists
+    describe aws_ssm_resource_compliance_summaries do
       its('compliance_type') { should include 'ssm-compliance-type' }
     end
 
@@ -47,16 +53,16 @@ The control will pass if the describe returns at least one result.
 
 Use `should_not` to test the entity should not exist.
 
-    describe aws_ssm_compliance_summaries.where( <property>: <value> ) do
+    describe aws_ssm_resource_compliance_summaries.where( <property>: <value> ) do
       it { should exist }
     end
 
-    describe aws_ssm_compliance_summaries.where( <property>: <value> ) do
+    describe aws_ssm_resource_compliance_summaries.where( <property>: <value> ) do
       it { should_not exist }
     end
 
 ## AWS Permissions
 
-Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:ListComplianceSummaries` action with Effect set to Allow.
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:ListResourceComplianceSummaries` action with Effect set to Allow.
 
 You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/docs/resources/aws_ssm_resource_compliance_summary.md
+++ b/docs/resources/aws_ssm_resource_compliance_summary.md
@@ -1,0 +1,93 @@
+---
+title: About the aws_ssm_resource_compliance_summary Resource
+platform: aws
+---
+
+# aws\_ssm\_resource\_compliance\_summary
+
+Use the `aws_ssm_resource_compliance_summary` InSpec audit resource to test properties of a ssm resource compliance summary.
+
+## Syntax
+
+ An `aws_ssm_resource_compliance_summary` resource block uses the parameter to select a ssm resource compliance summary.
+
+    describe aws_ssm_resource_compliance_summary(resource_id: 'resource-id-1234') do
+      it { should exist }
+    end
+
+
+#### Parameters
+
+##### resource_id _(required)_
+
+This resource accepts a single parameter, the SSM Resource ID.
+This can be passed either as a string or as a `resource_id: 'value'` key-value entry in a hash.
+
+See also the [AWS documentation on SSM Resource Compliance Summary](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-compliance-about.html#compliance-view-results).
+
+
+## Properties
+
+|Property                     | Description|
+| ---                         | --- |
+|compliance_type              | Provides the compliance type. |
+|compliant_summary            | Provides a list of items that are compliant for the resource. |
+|execution_summary            | Provides information about the execution |
+|non_compliant_summary        | Provides a list of items that aren't compliant for the resource. |
+|overall_severity             | Provides the highest severity item found for the resource. |
+|resource_id                  | Provides the resource id. |
+|resource_type                | Provides the resource type. |
+|status                       | Provides the compliance status for the resource. |
+|compliance\_item             | |
+|compliance\_type             | Provides the compliance type of the compliance item. |
+|details                      | Provides details of the compliance item. |
+|execution\_summary           | Provides an execution summary for the compliance item. |
+|id                           | Provides the ID of the compliance item. |
+|resource\_id                 | Provides an ID for the resource. For a managed instance, this is the instance ID. |
+|resource\_type               | Provides the type of resource. Currently only ManagedInstance is supported. |
+|severity                     | Provides the severity of the compliance item. |
+|status                       | Provides the status of the compliance item. |
+|title                        | Provides the title for the compliance item. |
+
+For a comprehensive list of properties available, see [the API reference documentation](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ResourceComplianceSummaryItem.html)
+
+## Examples
+
+##### Check the Status of a SSM Resource Compliance Summary
+
+    describe aws_ssm_resource_compliance_summary(resource_id: 'resource-id-1234', status: 'status-1234') do
+      it { should exist }
+      its('resource_id')    { should include resource_id }
+      its('status')         { should include 'status-1234' }
+    end
+    
+##### Return specific Compliance type for a SSM Resource Compliance Summary
+   
+    describe aws_ssm_resource_compliance_summary(resource_id: 'resource-id-1234', compliance_type: 'compliance-type-1234') do
+      it { should exist }
+      its('resource_id')      { should include resource_id }
+      its('compliance_type')  { should include 'compliance-type-1234' }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+#### exist
+
+The control will pass if the describe returns at least one result.
+
+Use `should_not` to test the entity should not exist.
+
+    describe aws_ssm_resource_compliance_summary(resource_id: 'resource-id-1234') do
+      it { should exist }
+    end
+
+    describe aws_ssm_resource_compliance_summary(resource_id: 'resource-id-6789') do
+      it { should_not exist }
+    end
+
+## AWS Permissions
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `ssm:ListResourceComplianceSummaries` action with Effect set to Allow.
+
+You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html).

--- a/libraries/aws_ssm_activation.rb
+++ b/libraries/aws_ssm_activation.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmActivation < AwsResourceBase
+  name 'aws_ssm_activation'
+  desc 'Verifies settings for a SSM Activation'
+
+  example "
+    describe aws_ssm_activation(activation_id: 'activation-id') do
+      it { should exist }
+    end
+  "
+
+  def initialize(opts = {})
+    opts = { activation_id: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: [:activation_id])
+    @display_name = opts[:activation_id]
+
+    catch_aws_errors do
+      filter = { filter_key: 'ActivationIds', filter_values: [opts[:activation_id]] }
+      resp = @aws.ssm_client.describe_activations({ filters: [filter] })
+      if resp.activation_list.first.nil?
+        empty_response_warn
+      else
+        @activation = resp.activation_list[0].to_h
+        create_resource_methods(@activation)
+      end
+    end
+  end
+
+  def exists?
+    !failed_resource?
+  end
+
+  def to_s
+    "SSM Activation ID #{@display_name}"
+  end
+
+  def name
+    name if exists?
+  end
+end

--- a/libraries/aws_ssm_activations.rb
+++ b/libraries/aws_ssm_activations.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmActivations < AwsResourceBase
+  name 'aws_ssm_activations'
+  desc 'Verifies settings for a SSM Activation in bulk'
+  example '
+    describe aws_ssm_activations do
+      it { should exist }
+    end
+  '
+
+  attr_reader :table, :api_response
+
+  FilterTable.create
+             .register_column(:activation_ids,         field: :activation_id)
+             .register_column(:default_instance_names, field: :default_instance_name)
+             .register_column(:iam_roles,              field: :iam_role)
+             .register_column(:registration_limits,    field: :registration_limit)
+             .register_column(:registrations_count,    field: :registrations_count)
+             .register_column(:expiration_dates,       field: :expiration_date)
+             .register_column(:expired,                field: :expired)
+             .register_column(:created_dates,          field: :created_date)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters
+    @table = fetch_data
+  end
+
+  def fetch_data
+    ssm_activation_rows = []
+    pagination_options = {}
+    loop do
+      catch_aws_errors do
+        @api_response = @aws.ssm_client.describe_activations(pagination_options)
+      end
+      return [] if !api_response || api_response.empty?
+
+      api_response.activation_list.each do |ssm_activation|
+        ssm_activation_rows += [{ activation_id:         ssm_activation.activation_id,
+                                  default_instance_name: ssm_activation.default_instance_name,
+                                  iam_role:              ssm_activation.iam_role,
+                                  registration_limit:    ssm_activation.registration_limit,
+                                  registrations_count:   ssm_activation.registrations_count,
+                                  expiration_date:       ssm_activation.expiration_date,
+                                  expired:               ssm_activation.expired,
+                                  created_date:          ssm_activation.created_date }]
+      end
+      break unless api_response.next_token
+      pagination_options = { next_token: api_response.next_token }
+    end
+    @table = ssm_activation_rows
+  end
+end

--- a/libraries/aws_ssm_association.rb
+++ b/libraries/aws_ssm_association.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmAssociation < AwsResourceBase
+  name 'aws_ssm_association'
+  desc 'Verifies settings for a SSM Association'
+
+  example "
+    describe aws_ssm_association(association_id: 'association-id') do
+      it { should exist }
+    end
+  "
+
+  def initialize(opts = {})
+    opts = { association_id: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: [:association_id])
+    @display_name = opts[:association_id]
+    catch_aws_errors do
+      resp = @aws.ssm_client.describe_association({ association_id: opts[:association_id] })
+      if resp.association_description.nil?
+        empty_response_warn
+      else
+        @association = resp.association_description.to_h
+        create_resource_methods(@association)
+      end
+    end
+  end
+
+  def exists?
+    !failed_resource?
+  end
+
+  def to_s
+    "SSM Association ID #{@display_name}"
+  end
+
+  def name
+    name if exists?
+  end
+end

--- a/libraries/aws_ssm_associations.rb
+++ b/libraries/aws_ssm_associations.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmAssociations < AwsResourceBase
+  name 'aws_ssm_associations'
+  desc 'Verifies settings for a SSM Association in bulk'
+  example '
+    describe aws_ssm_associations do
+      it { should exist }
+    end
+  '
+
+  attr_reader :table, :api_response
+
+  FilterTable.create
+             .register_column(:names,                field: :name)
+             .register_column(:association_ids,      field: :association_id)
+             .register_column(:association_versions, field: :association_version)
+             .register_column(:targets,              field: :targets)
+             .register_column(:last_execution_dates, field: :last_execution_date)
+             .register_column(:overviews,            field: :overview)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters
+    @table = fetch_data
+  end
+
+  def fetch_data
+    ssm_association_rows = []
+    pagination_options = {}
+    loop do
+      catch_aws_errors do
+        @api_response = @aws.ssm_client.list_associations(pagination_options)
+      end
+      return [] if !api_response || api_response.empty?
+
+      api_response.associations.each do |ssm_association|
+        ssm_association_rows += [{ name:                ssm_association.name,
+                                   association_id:      ssm_association.association_id,
+                                   association_version: ssm_association.association_version,
+                                   targets:             ssm_association.targets,
+                                   last_execution_date: ssm_association.last_execution_date,
+                                   overview:            ssm_association.overview.to_h }]
+      end
+      break unless api_response.next_token
+      pagination_options = { next_token: api_response.next_token }
+    end
+    @table = ssm_association_rows
+  end
+end

--- a/libraries/aws_ssm_document.rb
+++ b/libraries/aws_ssm_document.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmDocument < AwsResourceBase
+  name 'aws_ssm_document'
+  desc 'Verifies settings for a SSM Document'
+
+  example "
+    describe aws_ssm_document(name: 'document-name') do
+      it { should exist }
+    end
+  "
+
+  def initialize(opts = {})
+    opts = { name: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: [:name])
+    @display_name = opts[:name]
+
+    catch_aws_errors do
+      resp = @aws.ssm_client.describe_document({ name: opts[:name] })
+
+      if resp.document.nil?
+        empty_response_warn
+      else
+        @document = resp.document.to_h
+        @document[:document_hash] = @document.delete(:hash)
+        create_resource_methods(@document)
+      end
+    end
+  end
+
+  def exists?
+    !failed_resource?
+  end
+
+  def to_s
+    "SSM Document Name #{@display_name}"
+  end
+end

--- a/libraries/aws_ssm_documents.rb
+++ b/libraries/aws_ssm_documents.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmDocuments < AwsResourceBase
+  name 'aws_ssm_documents'
+  desc 'Verifies settings for a SSM Document in bulk'
+  example '
+    describe aws_ssm_documents do
+      it { should exist }
+    end
+  '
+
+  attr_reader :table, :api_response
+
+  FilterTable.create
+             .register_column(:names,             field: :name)
+             .register_column(:owners,            field: :owner)
+             .register_column(:platform_types,    field: :platform_types)
+             .register_column(:document_versions, field: :document_version)
+             .register_column(:document_types,    field: :document_type)
+             .register_column(:schema_versions,   field: :schema_version)
+             .register_column(:document_formats,  field: :document_format)
+             .register_column(:target_types,      field: :target_type)
+             .register_column(:tags,              field: :tags)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters
+    @table = fetch_data
+  end
+
+  def fetch_data
+    ssm_document_rows = []
+    pagination_options = {}
+    loop do
+      catch_aws_errors do
+        @api_response = @aws.ssm_client.list_documents(pagination_options)
+      end
+      return [] if !api_response || api_response.empty?
+
+      api_response.document_identifiers.each do |ssm_document|
+        ssm_document_rows += [{ name:             ssm_document.name,
+                                owner:            ssm_document.owner,
+                                platform_types:   ssm_document.platform_types,
+                                document_version: ssm_document.document_version,
+                                document_type:    ssm_document.document_type,
+                                schema_version:   ssm_document.schema_version,
+                                document_format:  ssm_document.document_format,
+                                target_type:      ssm_document.target_type,
+                                tags:             ssm_document.tags }]
+      end
+      break unless api_response.next_token
+      pagination_options = { next_token: api_response.next_token }
+    end
+    @table = ssm_document_rows
+  end
+end

--- a/libraries/aws_ssm_resource_compliance_summaries.rb
+++ b/libraries/aws_ssm_resource_compliance_summaries.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmResourceComplianceSummaries < AwsResourceBase
+  name 'aws_ssm_resource_compliance_summaries'
+  desc 'Verifies settings for a SSM Resource Compliance Summary in bulk'
+  example '
+    describe aws_ssm_resource_compliance_summaries do
+      it { should exist }
+    end
+  '
+
+  attr_reader :table, :api_response
+
+  FilterTable.create
+             .register_column(:compliance_types,        field: :compliance_type)
+             .register_column(:resource_types,          field: :resource_type)
+             .register_column(:resource_ids,            field: :resource_id)
+             .register_column(:status,                  field: :status)
+             .register_column(:overall_severity,        field: :overall_severity)
+             .register_column(:execution_summaries,     field: :execution_summary)
+             .register_column(:compliant_summaries,     field: :compliant_summary)
+             .register_column(:non_compliant_summaries, field: :non_compliant_summary)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    super(opts)
+    validate_parameters
+    @table = fetch_data
+  end
+
+  def fetch_data
+    ssm_resource_compliance_summary_rows = []
+    pagination_options = {}
+    loop do
+      catch_aws_errors do
+        @api_response = @aws.ssm_client.list_resource_compliance_summaries(pagination_options)
+      end
+      return [] if !api_response || api_response.empty?
+
+      api_response.resource_compliance_summary_items.each do |ssm_compliance|
+        ssm_resource_compliance_summary_rows += [{ compliance_type:       ssm_compliance.compliance_type,
+                                                   resource_type:         ssm_compliance.resource_type,
+                                                   resource_id:           ssm_compliance.resource_id,
+                                                   status:                ssm_compliance.status,
+                                                   overall_severity:      ssm_compliance.overall_severity,
+                                                   execution_summary:     ssm_compliance.execution_summary.to_h,
+                                                   compliant_summary:     ssm_compliance.compliant_summary.to_h,
+                                                   non_compliant_summary: ssm_compliance.non_compliant_summary.to_h }]
+      end
+      break unless api_response.next_token
+      pagination_options = { next_token: api_response.next_token }
+    end
+    @table = ssm_resource_compliance_summary_rows
+  end
+end

--- a/libraries/aws_ssm_resource_compliance_summary.rb
+++ b/libraries/aws_ssm_resource_compliance_summary.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsSsmResourceComplianceSummary < AwsResourceBase
+  name 'aws_ssm_resource_compliance_summary'
+  desc 'Verifies settings for a SSM Resource Compliance Summary'
+
+  example "
+    describe aws_ssm_resource_compliance_summary(resource_id: 'resource-id') do
+      it { should exist }
+    end
+  "
+
+  attr_reader :table
+
+  FilterTable.create
+             .register_column(:compliance_type,       field: :compliance_type)
+             .register_column(:resource_type,         field: :resource_type)
+             .register_column(:resource_id,           field: :resource_id)
+             .register_column(:status,                field: :status)
+             .register_column(:overall_severity,      field: :overall_severity)
+             .register_column(:execution_summary,     field: :execution_summary)
+             .register_column(:compliant_summary,     field: :compliant_summary)
+             .register_column(:non_compliant_summary, field: :non_compliant_summary)
+             .register_column(:compliance_item,       field: :compliance_item)
+             .install_filter_methods_on_resource(self, :table)
+
+  def initialize(opts = {})
+    opts = { resource_id: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: [:resource_id], allow: %i(compliance_type status))
+    @display_name = opts[:resource_id]
+
+    catch_aws_errors do
+      @compliance_summaries = return_resource_id_data(compliance_summary_data: @aws.ssm_client.list_resource_compliance_summaries)
+      return if @compliance_summaries.empty?
+
+      @compliance_items = @aws.ssm_client.list_compliance_items({ resource_ids: [opts[:resource_id]] }).to_h[:compliance_items]
+      append_compliance_item
+    end
+
+    @table = return_compliance_summaries
+  end
+
+  def return_resource_id_data(compliance_summary_data:)
+    compliance_array = compliance_summary_data.to_h[:resource_compliance_summary_items]
+    filtered_summary = compliance_array.select { |summary| summary[:resource_id] == opts[:resource_id] }
+    filtered_summary = filtered_summary.select { |summary| summary[:compliance_type] == opts[:compliance_type] } if opts[:compliance_type]
+    filtered_summary = filtered_summary.select { |summary| summary[:status] == opts[:status] } if opts[:status]
+    filtered_summary
+  end
+
+  def append_compliance_item
+    @compliance_summaries.each do |cs|
+      compliance_item = @compliance_items.select { |ci| ci[:compliance_type] == cs[:compliance_type] }.first
+      cs[:compliance_item] = compliance_item
+    end
+  end
+
+  def return_compliance_summaries
+    ssm_resource_compliance_summary_rows = []
+
+    @compliance_summaries.each do |ssm_compliance|
+      ssm_resource_compliance_summary_rows += [{ compliance_type:       ssm_compliance[:compliance_type],
+                                                 resource_type:         ssm_compliance[:resource_type],
+                                                 resource_id:           ssm_compliance[:resource_id],
+                                                 status:                ssm_compliance[:status],
+                                                 overall_severity:      ssm_compliance[:overall_severity],
+                                                 execution_summary:     ssm_compliance[:execution_summary],
+                                                 compliant_summary:     ssm_compliance[:compliant_summary],
+                                                 non_compliant_summary: ssm_compliance[:non_compliant_summary],
+                                                 compliance_item:       ssm_compliance[:compliance_item] }]
+    end
+    @table = ssm_resource_compliance_summary_rows
+  end
+
+  def exists?
+    !failed_resource?
+  end
+
+  def to_s
+    "SSM Resource ID #{@display_name}"
+  end
+
+  def name
+    name if exists?
+  end
+end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -130,6 +130,7 @@ variable "aws_security_group_zeta" {}
 variable "aws_security_group_omega" {}
 variable "aws_security_group_lb" {}
 variable "aws_ssm_parameter_name" {}
+variable "aws_ssm_document_name" {}
 variable "aws_sqs_queue_name" {}
 variable "aws_subnet_ip_address_count" {}
 variable "aws_sns_topic_no_subscription" {}
@@ -1867,4 +1868,30 @@ resource "aws_ssm_parameter" "ssm_param_secret" {
   tags = {
     Environment = "Dev"
   }
+}
+
+resource "aws_ssm_document" "ssm_document_1" {
+  count         = var.aws_enable_creation
+  name          = var.aws_ssm_document_name
+  document_type = "Command"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["ifconfig"]
+          }
+        ]
+      }
+    }
+  }
+DOC
 }

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -253,3 +253,12 @@ output "aws_ssm_parameter_value" {
 output "aws_ssm_parameter_arn" {
   value = aws_ssm_parameter.ssm_param_secret.0.arn
 }
+
+output "aws_ssm_document_name" {
+  value = aws_ssm_document.ssm_document_1.0.name
+}
+
+output "aws_ssm_document_document_type" {
+  value = aws_ssm_document.ssm_document_1.0.document_type
+}
+

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -174,6 +174,7 @@ module AWSInspecConfig
       aws_security_group_omega: "aws-security-group-omega-#{add_random_string}",
       aws_security_group_lb: "aws-security-group-lb-#{add_random_string}",
       aws_ssm_parameter_name: "parameter-name-#{add_random_string}",
+      aws_ssm_document_name: "aws_ssm_document_name_#{add_random_string}",
       aws_sqs_queue_name: "aws-sqs-queue-#{add_random_string}",
       aws_sns_topic_no_subscription: "aws-sns-topic-no-subscription-#{add_random_string}",
       aws_sns_topic_subscription_sqs: "aws-sns-topic-subscription-sqs-#{add_random_string}",

--- a/test/integration/verify/controls/aws_ssm_activation.rb
+++ b/test/integration/verify/controls/aws_ssm_activation.rb
@@ -1,0 +1,11 @@
+title 'Test a single AWS SSM Activation'
+
+control 'aws-ssm-activation-1.0' do
+
+  impact 1.0
+  title 'Ensure AWS SSM Activation has current properties'
+
+  describe aws_ssm_activation(activation_id: '000000') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/verify/controls/aws_ssm_association.rb
+++ b/test/integration/verify/controls/aws_ssm_association.rb
@@ -1,0 +1,11 @@
+title 'Test a single AWS SSM Association'
+
+control 'aws-ssm-association-1.0' do
+
+  impact 1.0
+  title 'Ensure AWS SSM Association has current properties'
+
+  describe aws_ssm_association(association_id: '000000') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/verify/controls/aws_ssm_document.rb
+++ b/test/integration/verify/controls/aws_ssm_document.rb
@@ -1,0 +1,23 @@
+title 'Test a single AWS SSM Document'
+
+aws_ssm_document_name = attribute(:aws_ssm_document_name, default: '', description: 'The AWS SSM Document Name')
+aws_ssm_document_document_type = attribute(:aws_ssm_document_document_type, default: '', description: 'The AWS SSM Document Command')
+
+control 'aws-ssm-document-1.0' do
+
+  impact 1.0
+  title 'Ensure AWS SSM Document has current properties'
+
+  describe aws_ssm_document(name: aws_ssm_document_name) do
+    it { should exist }
+  end
+
+  describe aws_ssm_document(name: aws_ssm_document_name) do
+    its('name')          { should eq aws_ssm_document_name }
+    its('document_type') { should eq aws_ssm_document_document_type }
+  end
+
+  describe aws_ssm_document(name: '000000') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/verify/controls/aws_ssm_documents.rb
+++ b/test/integration/verify/controls/aws_ssm_documents.rb
@@ -1,0 +1,19 @@
+title 'Test AWS SSM Documents in bulk'
+
+aws_ssm_document_name = attribute(:aws_ssm_document_name, default: '', description: 'The AWS SSM Document Name')
+aws_ssm_document_document_type = attribute(:aws_ssm_document_document_type, default: '', description: 'The AWS SSM Document Command')
+
+control 'aws-ssm-documents-1.0' do
+
+  impact 1.0
+  title 'Ensure AWS SSM Document has current properties'
+
+  describe aws_ssm_documents do
+    it { should exist }
+  end
+
+  describe aws_ssm_documents do
+    its('names') { should include aws_ssm_document_name }
+    its('document_types') { should include aws_ssm_document_document_type }
+  end
+end

--- a/test/integration/verify/controls/aws_ssm_resource_compliance_summaries.rb
+++ b/test/integration/verify/controls/aws_ssm_resource_compliance_summaries.rb
@@ -1,0 +1,11 @@
+title 'Test AWS SSM Resource Compliance Summaries in bulk'
+
+control 'aws-ssm-resource-compliance-summaries-1.0' do
+
+  impact 1.0
+  title 'Ensure AWS SSM Resource Compliance Summary has current properties'
+
+  describe aws_ssm_resource_compliance_summaries do
+    it { should_not exist }
+  end
+end

--- a/test/unit/resources/aws_ssm_activation_test.rb
+++ b/test/unit/resources/aws_ssm_activation_test.rb
@@ -1,0 +1,65 @@
+require 'helper'
+require 'aws_ssm_activation'
+require 'aws-sdk-ssm'
+
+class AwsSsmActivationConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsSsmActivation.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_empty_param_arg_not_ok
+    assert_raises(ArgumentError) { AwsSsmActivation.new(name: '', client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsSsmActivation.new(unexpected: 9) }
+  end
+
+end
+
+class AwsSsmActivationSuccessPathTest < Minitest::Test
+  def setup
+    data = {}
+    data[:method] = :describe_activations
+    mock_ssm_activation = {}
+    mock_ssm_activation[:activation_id] = "activation-id-123465434"
+    mock_ssm_activation[:default_instance_name] = "instance-name"
+    mock_ssm_activation[:iam_role] = "iam-role-432"
+    mock_ssm_activation[:registration_limit] = 5
+    mock_ssm_activation[:expiration_date] = Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    mock_ssm_activation[:expired] = false
+    mock_ssm_activation[:created_date] = Time.parse("2013-06-11T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    data[:data] = { activation_list: [mock_ssm_activation] }
+    data[:client] = Aws::SSM::Client
+    @ssm_activation = AwsSsmActivation.new(activation_id: 'activation-id-123465434', client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_ssm_activation_exists
+    assert @ssm_activation.exists?
+  end
+
+  def test_ssm_activation_id
+    assert_equal(@ssm_activation.activation_id, 'activation-id-123465434')
+  end
+
+  def test_ssm_activation_default_instance_name
+    assert_equal(@ssm_activation.default_instance_name, 'instance-name')
+  end
+
+  def test_ssm_activation_iam_role
+    assert_equal(@ssm_activation.iam_role, 'iam-role-432')
+  end
+
+  def test_ssm_activation_expiration_date
+    assert_equal(@ssm_activation.expiration_date, Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+  end
+
+  def test_ssm_activation_expired
+    assert_equal(@ssm_activation.expired, false)
+  end
+
+  def test_ssm_activation_created_date
+    assert_equal(@ssm_activation.created_date, Time.parse("2013-06-11T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+  end
+end

--- a/test/unit/resources/aws_ssm_activations_test.rb
+++ b/test/unit/resources/aws_ssm_activations_test.rb
@@ -1,0 +1,69 @@
+require 'helper'
+require 'aws_ssm_activations'
+require 'aws-sdk-ssm'
+
+class AwsSsmActivationsConstructorTest < Minitest::Test
+
+  def test_empty_params_ok
+    AwsSsmActivations.new(client_args: { stub_responses: true })
+  end
+
+  def test_rejects_other_args
+    assert_raises(ArgumentError) { AwsSsmActivations.new('rubbish') }
+  end
+
+  def test_ssm_parameter_non_existing_for_empty_response
+    refute AwsSsmActivations.new(client_args: { stub_responses: true }).exist?
+  end
+end
+
+class AwsSsmActivationsSuccessPathTest < Minitest::Test
+
+  def setup
+    data = {}
+    data[:method] = :describe_activations
+    mock_ssm_activation = {}
+    mock_ssm_activation[:activation_id] = "activation-id-123465434"
+    mock_ssm_activation[:default_instance_name] = "instance-name"
+    mock_ssm_activation[:iam_role] = "iam-role-432"
+    mock_ssm_activation[:registration_limit] = 5
+    mock_ssm_activation[:expiration_date] = Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    mock_ssm_activation[:expired] = false
+    mock_ssm_activation[:created_date] = Time.parse("2013-06-11T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    data[:data] = { activation_list: [mock_ssm_activation] }
+    data[:client] = Aws::SSM::Client
+    @ssm_activation = AwsSsmActivations.new(client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_ssm_activations
+    assert @ssm_activation.exist?
+  end
+
+  def test_ssm_activation_id
+    assert_equal(@ssm_activation.activation_ids, ['activation-id-123465434'])
+  end
+
+  def test_ssm_activation_default_instance_name
+    assert_equal(@ssm_activation.default_instance_names, ['instance-name'])
+  end
+
+  def test_ssm_activation_iam_role
+    assert_equal(@ssm_activation.iam_roles, ['iam-role-432'])
+  end
+
+  def test_ssm_activation_registration_limit
+    assert_equal(@ssm_activation.registration_limits, [5])
+  end
+
+  def test_ssm_activation_expiration_date
+    assert_equal(@ssm_activation.expiration_dates, [Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")])
+  end
+
+  def test_ssm_activation_expired
+    assert_equal(@ssm_activation.expired, [false])
+  end
+
+  def test_ssm_activation_created_date
+    assert_equal(@ssm_activation.created_dates, [Time.parse("2013-06-11T23:52:02Z2020-06-05T11:30:39.730000+01:00")])
+  end
+end

--- a/test/unit/resources/aws_ssm_association_test.rb
+++ b/test/unit/resources/aws_ssm_association_test.rb
@@ -1,0 +1,63 @@
+require 'helper'
+require 'aws_ssm_association'
+require 'aws-sdk-ssm'
+
+class AwsSsmAssociationConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsSsmAssociation.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_empty_param_arg_not_ok
+    assert_raises(ArgumentError) { AwsSsmAssociation.new(name: '', client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsSsmAssociation.new(unexpected: 9) }
+  end
+
+end
+
+class AwsSsmAssociationSuccessPathTest < Minitest::Test
+  def setup
+    data = {}
+    data[:method] = :describe_association
+    mock_ssm_association = {}
+    mock_ssm_association[:name] = "document-name"
+    mock_ssm_association[:association_version] = "1"
+    mock_ssm_association[:date] = Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    mock_ssm_association[:last_update_association_date] = Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    mock_ssm_association[:overview] = { status: "Success",
+                                        detailed_status: "Success",
+                                        association_status_aggregated_count: {} }
+    mock_ssm_association[:document_version] = "1"
+    mock_ssm_association[:association_id] = "association-id-14325423"
+    mock_ssm_association[:targets] = [{ key: "instanceids",
+                                        values: ["i-52543f43ew234"] }]
+    mock_ssm_association[:last_execution_date] = Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    mock_ssm_association[:last_successful_execution_date] = Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    data[:data] = { association_description: mock_ssm_association }
+    data[:client] = Aws::SSM::Client
+    @ssm_association = AwsSsmAssociation.new(association_id: 'association-id-14325423', client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_ssm_association_exists
+    assert @ssm_association.exists?
+  end
+
+  def test_ssm_association_name
+    assert_equal(@ssm_association.name, 'document-name')
+  end
+
+  def test_ssm_association_id
+    assert_equal(@ssm_association.association_id, "association-id-14325423")
+  end
+
+  def test_ssm_association_version
+    assert_equal(@ssm_association.association_version, "1")
+  end
+
+  def test_ssm_association_last_execution_date
+    assert_equal(@ssm_association.last_execution_date, Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+  end
+end

--- a/test/unit/resources/aws_ssm_associations_test.rb
+++ b/test/unit/resources/aws_ssm_associations_test.rb
@@ -1,0 +1,59 @@
+require 'helper'
+require 'aws_ssm_associations'
+require 'aws-sdk-ssm'
+
+class AwsSsmAssociationsConstructorTest < Minitest::Test
+
+  def test_empty_params_ok
+    AwsSsmAssociations.new(client_args: { stub_responses: true })
+  end
+
+  def test_rejects_other_args
+    assert_raises(ArgumentError) { AwsSsmAssociations.new('rubbish') }
+  end
+
+  def test_ssm_associations_non_existing_for_empty_response
+    refute AwsSsmAssociations.new(client_args: { stub_responses: true }).exist?
+  end
+end
+
+class AwsSsmAssociationsSuccessPathTest < Minitest::Test
+
+  def setup
+    data = {}
+    data[:method] = :list_associations
+    mock_ssm_association = {}
+    mock_ssm_association[:name] = "document-name"
+    mock_ssm_association[:association_id] = "association-id-14325423"
+    mock_ssm_association[:association_version] = "1"
+    mock_ssm_association[:targets] = [{ key: "instanceids",
+                                        values: ["i-52543f43ew234"] }]
+    mock_ssm_association[:last_execution_date] = Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    mock_ssm_association[:overview] = { status: "Success",
+                                        detailed_status: "Success",
+                                        association_status_aggregated_count: {} }
+    data[:data] = { associations: [mock_ssm_association] }
+    data[:client] = Aws::SSM::Client
+    @ssm_association = AwsSsmAssociations.new(client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_ssm_association_exists
+    assert @ssm_association.exists?
+  end
+
+  def test_ssm_association_name
+    assert_equal(@ssm_association.names, ["document-name"])
+  end
+
+  def test_ssm_association_id
+    assert_equal(@ssm_association.association_ids, ["association-id-14325423"])
+  end
+
+  def test_ssm_association_version
+    assert_equal(@ssm_association.association_versions, ["1"])
+  end
+
+  def test_ssm_association_last_execution_date
+    assert_equal(@ssm_association.last_execution_dates, [Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")])
+  end
+end

--- a/test/unit/resources/aws_ssm_document_test.rb
+++ b/test/unit/resources/aws_ssm_document_test.rb
@@ -1,0 +1,77 @@
+require 'helper'
+require 'aws_ssm_document'
+require 'aws-sdk-ssm'
+
+class AwsSsmDocumentConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsSsmDocument.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_empty_param_arg_not_ok
+    assert_raises(ArgumentError) { AwsSsmDocument.new(name: '', client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsSsmDocument.new(unexpected: 9) }
+  end
+
+end
+
+class AwsSsmDocumentSuccessPathTest < Minitest::Test
+  def setup
+    data = {}
+    data[:method] = :describe_document
+    mock_ssm_document = {}
+    mock_ssm_document[:hash] = 'f2b00b4471e7236ddb11654c4e076473f5e493e916f09840abb229d5a07822b1'
+    mock_ssm_document[:hash_type] = 'Sha256'
+    mock_ssm_document[:name] = 'document-name'
+    mock_ssm_document[:owner] = "Amazon"
+    mock_ssm_document[:created_date] = Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")
+    mock_ssm_document[:status] = 'Active'
+    mock_ssm_document[:document_version] = "1"
+    mock_ssm_document[:description] = "Template"
+    mock_ssm_document[:platform_types] = ["Linux"]
+    mock_ssm_document[:document_type] = "Automation"
+    mock_ssm_document[:schema_version] = "0.3"
+    mock_ssm_document[:latest_version] = "1"
+    mock_ssm_document[:default_version] = "1"
+    mock_ssm_document[:document_format] = "YAML"
+    mock_ssm_document[:tags] = []
+    data[:data] = { document: mock_ssm_document }
+    data[:client] = Aws::SSM::Client
+    @ssm_document = AwsSsmDocument.new(name: 'document-name', client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_ssm_document_exists
+    assert @ssm_document.exists?
+  end
+
+  def test_ssm_document_name
+    assert_equal(@ssm_document.name, 'document-name')
+  end
+
+  def test_ssm_document_owner
+    assert_equal(@ssm_document.owner, 'Amazon')
+  end
+
+  def test_ssm_document_platform_types
+    assert_equal(@ssm_document.platform_types, ["Linux"])
+  end
+
+  def test_ssm_document_version
+    assert_equal(@ssm_document.document_version, '1')
+  end
+
+  def test_ssm_document_type
+    assert_equal(@ssm_document.document_type, 'Automation')
+  end
+
+  def test_ssm_document_schema_version
+    assert_equal(@ssm_document.schema_version, '0.3')
+  end
+
+  def test_ssm_document_format
+    assert_equal(@ssm_document.document_format, 'YAML')
+  end
+end

--- a/test/unit/resources/aws_ssm_documents_test.rb
+++ b/test/unit/resources/aws_ssm_documents_test.rb
@@ -1,0 +1,75 @@
+require 'helper'
+require 'aws_ssm_documents'
+require 'aws-sdk-ssm'
+
+class AwsSsmDocumentsConstructorTest < Minitest::Test
+
+  def test_empty_params_ok
+    AwsSsmDocuments.new(client_args: { stub_responses: true })
+  end
+
+  def test_rejects_other_args
+    assert_raises(ArgumentError) { AwsSsmDocuments.new('rubbish') }
+  end
+
+  def test_ssm_parameter_non_existing_for_empty_response
+    refute AwsSsmDocuments.new(client_args: { stub_responses: true }).exist?
+  end
+end
+
+class AwsSsmDocumentsSuccessPathTest < Minitest::Test
+
+  def setup
+    data = {}
+    data[:method] = :list_documents
+    mock_ssm_document = {}
+    mock_ssm_document[:name] = "document-name"
+    mock_ssm_document[:owner] = "Amazon"
+    mock_ssm_document[:platform_types] = ["Linux"]
+    mock_ssm_document[:document_version] = "1"
+    mock_ssm_document[:document_type] = "Automation"
+    mock_ssm_document[:schema_version] = "0.3"
+    mock_ssm_document[:document_format] = "YAML"
+    mock_ssm_document[:target_type] = "/AWS::EC2::Volume"
+    mock_ssm_document[:tags] = []
+    data[:data] = { document_identifiers: [mock_ssm_document] }
+    data[:client] = Aws::SSM::Client
+    @ssm_document = AwsSsmDocuments.new(client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_ssm_document_exists
+    assert @ssm_document.exists?
+  end
+
+  def test_ssm_document_name
+    assert_equal(@ssm_document.names, ['document-name'])
+  end
+
+  def test_ssm_document_owner
+    assert_equal(@ssm_document.owners, ['Amazon'])
+  end
+
+  def test_ssm_document_platform_types
+    assert_equal(@ssm_document.platform_types, [['Linux']])
+  end
+
+  def test_ssm_document_version
+    assert_equal(@ssm_document.document_versions, ["1"])
+  end
+
+  def test_ssm_document_type
+    assert_equal(@ssm_document.document_types, ['Automation'])
+  end
+
+  def test_ssm_document_schema_version
+    assert_equal(@ssm_document.schema_versions, ['0.3'])
+  end
+
+  def test_ssm_document_format
+    assert_equal(@ssm_document.document_formats, ['YAML'])
+  end
+
+  def test_ssm_document_target_type
+    assert_equal(@ssm_document.target_types, ['/AWS::EC2::Volume'])
+  end
+end

--- a/test/unit/resources/aws_ssm_resource_compliance_summaries_test.rb
+++ b/test/unit/resources/aws_ssm_resource_compliance_summaries_test.rb
@@ -1,0 +1,60 @@
+require 'helper'
+require 'aws_ssm_resource_compliance_summaries'
+require 'aws-sdk-ssm'
+
+class AwsSsmResourceComplianceSummariesConstructorTest < Minitest::Test
+  def test_rejects_other_args
+    assert_raises(ArgumentError) { AwsSsmResourceComplianceSummaries.new('rubbish') }
+  end
+end
+
+class AwsSsmResourceComplianceSummariesSuccessPathTest < Minitest::Test
+  def setup
+    data = {}
+    data[:method] = :list_resource_compliance_summaries
+    mock_ssm_compliance_items = {}
+    mock_ssm_compliance_items[:compliance_type] = "FleetTotal"
+    mock_ssm_compliance_items[:resource_type] = "ManagedInstance"
+    mock_ssm_compliance_items[:resource_id] = "mi-0432097523634"
+    mock_ssm_compliance_items[:status] = "CRITICAL"
+    mock_ssm_compliance_items[:execution_summary] = { execution_time: Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")}
+    mock_ssm_compliance_items[:compliant_summary] = { compliant_count: 1,
+                                                      severity_summary: { critical_count: 1,
+                                                                          high_count: 0,
+                                                                          medium_count: 0,
+                                                                          low_count: 0,
+                                                                          informational_count: 0,
+                                                                          unspecified_count: 0 } }
+    mock_ssm_compliance_items[:non_compliant_summary] = { non_compliant_count: 1,
+                                                          severity_summary: { critical_count: 0,
+                                                                              high_count: 0,
+                                                                              medium_count: 0,
+                                                                              low_count: 0,
+                                                                              informational_count: 0,
+                                                                              unspecified_count: 0 } }
+    data[:data] = { resource_compliance_summary_items: [mock_ssm_compliance_items] }
+    data[:client] = Aws::SSM::Client
+    @ssm_resource_compliance_items = AwsSsmResourceComplianceSummaries.new(client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def test_ssm_compliance_summary_exists
+    assert @ssm_resource_compliance_items.exists?
+  end
+
+  def test_ssm_compliance_type
+    assert_equal(@ssm_resource_compliance_items.compliance_types, ['FleetTotal'])
+  end
+
+  def test_ssm_resource_type
+    assert_equal(@ssm_resource_compliance_items.resource_types, ['ManagedInstance'])
+  end
+
+  def test_ssm_resource_id
+    assert_equal(@ssm_resource_compliance_items.resource_ids, ['mi-0432097523634'])
+  end
+
+  def test_ssm_status
+    assert_equal(@ssm_resource_compliance_items.status, ['CRITICAL'])
+  end
+end
+

--- a/test/unit/resources/aws_ssm_resource_compliance_summaries_test.rb
+++ b/test/unit/resources/aws_ssm_resource_compliance_summaries_test.rb
@@ -12,27 +12,27 @@ class AwsSsmResourceComplianceSummariesSuccessPathTest < Minitest::Test
   def setup
     data = {}
     data[:method] = :list_resource_compliance_summaries
-    mock_ssm_compliance_items = {}
-    mock_ssm_compliance_items[:compliance_type] = "FleetTotal"
-    mock_ssm_compliance_items[:resource_type] = "ManagedInstance"
-    mock_ssm_compliance_items[:resource_id] = "mi-0432097523634"
-    mock_ssm_compliance_items[:status] = "CRITICAL"
-    mock_ssm_compliance_items[:execution_summary] = { execution_time: Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")}
-    mock_ssm_compliance_items[:compliant_summary] = { compliant_count: 1,
-                                                      severity_summary: { critical_count: 1,
-                                                                          high_count: 0,
-                                                                          medium_count: 0,
-                                                                          low_count: 0,
-                                                                          informational_count: 0,
-                                                                          unspecified_count: 0 } }
-    mock_ssm_compliance_items[:non_compliant_summary] = { non_compliant_count: 1,
-                                                          severity_summary: { critical_count: 0,
-                                                                              high_count: 0,
-                                                                              medium_count: 0,
-                                                                              low_count: 0,
-                                                                              informational_count: 0,
-                                                                              unspecified_count: 0 } }
-    data[:data] = { resource_compliance_summary_items: [mock_ssm_compliance_items] }
+    mock_ssm_compliance_summary = {}
+    mock_ssm_compliance_summary[:compliance_type] = "FleetTotal"
+    mock_ssm_compliance_summary[:resource_type] = "ManagedInstance"
+    mock_ssm_compliance_summary[:resource_id] = "mi-0432097523634"
+    mock_ssm_compliance_summary[:status] = "COMPLIANT"
+    mock_ssm_compliance_summary[:execution_summary] = { execution_time: Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")}
+    mock_ssm_compliance_summary[:compliant_summary] = { compliant_count: 1,
+                                                        severity_summary: { critical_count: 1,
+                                                                            high_count: 0,
+                                                                            medium_count: 0,
+                                                                            low_count: 0,
+                                                                            informational_count: 0,
+                                                                            unspecified_count: 0 } }
+    mock_ssm_compliance_summary[:non_compliant_summary] = { non_compliant_count: 1,
+                                                            severity_summary: { critical_count: 0,
+                                                                                high_count: 0,
+                                                                                medium_count: 0,
+                                                                                low_count: 0,
+                                                                                informational_count: 0,
+                                                                                unspecified_count: 0 } }
+    data[:data] = { resource_compliance_summary_items: [mock_ssm_compliance_summary] }
     data[:client] = Aws::SSM::Client
     @ssm_resource_compliance_items = AwsSsmResourceComplianceSummaries.new(client_args: { stub_responses: true }, stub_data: [data])
   end
@@ -54,7 +54,7 @@ class AwsSsmResourceComplianceSummariesSuccessPathTest < Minitest::Test
   end
 
   def test_ssm_status
-    assert_equal(@ssm_resource_compliance_items.status, ['CRITICAL'])
+    assert_equal(@ssm_resource_compliance_items.status, ['COMPLIANT'])
   end
 end
 

--- a/test/unit/resources/aws_ssm_resource_compliance_summary_test.rb
+++ b/test/unit/resources/aws_ssm_resource_compliance_summary_test.rb
@@ -1,0 +1,100 @@
+require 'helper'
+require 'aws_ssm_resource_compliance_summary'
+require 'aws-sdk-ssm'
+
+class AwsSsmResourceComplianceSummaryConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsSsmResourceComplianceSummary.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_empty_param_arg_not_ok
+    assert_raises(ArgumentError) { AwsSsmResourceComplianceSummary.new(name: '', client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsSsmResourceComplianceSummary.new(unexpected: 9) }
+  end
+
+end
+
+class AwsSsmResourceComplianceSummarySuccessPathTest < Minitest::Test
+  def setup
+    compliance_data = []
+    summary_data = {}
+    summary_data[:method] = :list_resource_compliance_summaries
+    mock_ssm_compliance_summary = {}
+    mock_ssm_compliance_summary[:compliance_type] = "FleetTotal"
+    mock_ssm_compliance_summary[:resource_type] = "ManagedInstance"
+    mock_ssm_compliance_summary[:resource_id] = "mi-0432097523634"
+    mock_ssm_compliance_summary[:status] = "COMPLIANT"
+    mock_ssm_compliance_summary[:execution_summary] = { execution_time: Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")}
+    mock_ssm_compliance_summary[:compliant_summary] = { compliant_count: 1,
+                                                      severity_summary: { critical_count: 1,
+                                                                          high_count: 0,
+                                                                          medium_count: 0,
+                                                                          low_count: 0,
+                                                                          informational_count: 0,
+                                                                          unspecified_count: 0 } }
+    mock_ssm_compliance_summary[:non_compliant_summary] = { non_compliant_count: 1,
+                                                          severity_summary: { critical_count: 0,
+                                                                              high_count: 0,
+                                                                              medium_count: 0,
+                                                                              low_count: 0,
+                                                                              informational_count: 0,
+                                                                              unspecified_count: 0 } }
+    summary_data[:data] = { resource_compliance_summary_items: [mock_ssm_compliance_summary] }
+    summary_data[:client] = Aws::SSM::Client
+    compliance_data += [summary_data]
+
+    item_data = {}
+    item_data[:method] = :list_compliance_items
+    mock_ssm_compliance_items = {}
+    mock_ssm_compliance_items[:compliance_type] = "FleetTotal"
+    mock_ssm_compliance_items[:resource_type] = "ManagedInstance"
+    mock_ssm_compliance_items[:resource_id] = "mi-0432097523634"
+    mock_ssm_compliance_items[:id] = "version_2.0"
+    mock_ssm_compliance_items[:title] = "ScanHost"
+    mock_ssm_compliance_items[:status] = "COMPLIANT"
+    mock_ssm_compliance_items[:severity] = "CRITICAL"
+    mock_ssm_compliance_items[:execution_summary] = { execution_time: Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")}
+    mock_ssm_compliance_items[:details] = {}
+    item_data[:data] = { compliance_items: [mock_ssm_compliance_items] }
+    item_data[:client] = Aws::SSM::Client
+    compliance_data += [item_data]
+
+    @ssm_compliance_summary_items = AwsSsmResourceComplianceSummary.new(resource_id: 'mi-0432097523634', client_args: { stub_responses: true }, stub_data: compliance_data)
+  end
+
+  def test_ssm_compliance_summary
+    assert @ssm_compliance_summary_items.exists?
+  end
+
+  def test_ssm_compliance_summary_compliance_type
+    assert_equal(@ssm_compliance_summary_items.compliance_type, ['FleetTotal'])
+  end
+
+  def test_ssm_compliance_summary_resource_type
+    assert_equal(@ssm_compliance_summary_items.resource_type, ['ManagedInstance'])
+  end
+
+  def test_ssm_compliance_summary_id
+    assert_equal(@ssm_compliance_summary_items.resource_id, ['mi-0432097523634'])
+  end
+
+  def test_ssm_compliance_summary_status
+    assert_equal(@ssm_compliance_summary_items.status, ['COMPLIANT'])
+  end
+
+  def test_ssm_compliance_item_title
+    assert_equal(@ssm_compliance_summary_items.compliance_item.first[:title], 'ScanHost')
+  end
+
+  def test_ssm_compliance_item_severity
+    assert_equal(@ssm_compliance_summary_items.compliance_item.first[:severity], 'CRITICAL')
+  end
+
+  def test_ssm_compliance_item_id
+    assert_equal(@ssm_compliance_summary_items.compliance_item.first[:id], 'version_2.0')
+  end
+end


### PR DESCRIPTION
### Description

This PR is to address getting the status of an EC2 instance, the new resource_compliance_summary combines some aws ssm api calls into 1 and returns info for a resource id such as status etc. I made status and compliance type optional params, eg. you can return a compliance summary for a resource id that has a status of 'compliant' and or compliance type of 'patch' .

In prior discussions we thought it was best to strip out IAM Role creation from the aws tf so this has really limited the integration testing as everything seems to draw from that. I will add more functional tests to the private ssm repo.

### Issues Resolved

You can now get the status of an ec2 instance through resource_compliance_summary

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
