### PR TITLE
Return child property names when they are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .envrc
 .ruby-version
+.ruby-gemset
 .direnv
 Gemfile.lock
 inspec.lock

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -482,7 +482,7 @@ class AwsResourceProbe
   end
 
   def to_s
-    "Missing property extension. Followings can be tested via dot notation: #{item.keys.map(&:to_s)}"
+    "Property is missing! The following are available: #{item.keys.map(&:to_s)}"
   end
 end
 

--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -480,6 +480,10 @@ class AwsResourceProbe
   def respond_to_missing?(*several_variants)
     super
   end
+
+  def to_s
+    "Missing property extension. Followings can be tested via dot notation: #{item.keys.map(&:to_s)}"
+  end
 end
 
 # Ensure to return nil recursively.


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

Testing a legitimate property without its extension (child property) was returning the result of the default `to_s` method of Ruby, which seems like an error.

```ruby
×  EC2 Instance i-0d57a350bec111fc0 monitoring is expected to cmp == "disabled"
     expected: disabled
          got: #<#<Class:0x00007fb9321b30a8>::AwsResourceProbe:0x00007fb9368aa510>
     (compared using `cmp` matcher)
```

Now, the `to_s` method returns the available child property names that can be tested via dot notation.
```ruby
×  EC2 Instance i-0d57a350bec111fc0 monitoring is expected to cmp == "disabled"
    expected: disabled
          got: Missing property extension. Followings are available: [:state]
     (compared using `cmp` matcher)
```

### Issues Resolved

https://chefio.slack.com/archives/C0DP7SAGY/p1597259531102800?thread_ts=1597254958.098600&cid=C0DP7SAGY

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
