### PR TITLE
Fix issues failing integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ local
 inspec-aws.tfvars.*
 vendor
 .bundle
+.rakeTasks

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -144,6 +144,7 @@ variable "aws_vpc_cidr_block" {}
 variable "aws_vpc_instance_tenancy" {}
 variable "aws_vpc_name" {}
 variable "aws_vpc_dhcp_options_name" {}
+variable "aws_vpc_endpoint_name" {}
 variable "aws_route_53_zone" {}
 
 provider "aws" {
@@ -201,8 +202,8 @@ resource "aws_subnet" "inspec_subnet" {
 
 
 resource "aws_iam_role" "for_ec2" {
-  count         = var.aws_enable_creation
-  name          = var.aws_iam_role_name_for_ec2
+  count = var.aws_enable_creation
+  name  = var.aws_iam_role_name_for_ec2
 
   assume_role_policy = <<EOF
 {
@@ -222,9 +223,9 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "for_ec2" {
-  count         = var.aws_enable_creation
-  name          = var.aws_iam_profile_name_for_ec2
-  role = aws_iam_role.for_ec2[0].name
+  count = var.aws_enable_creation
+  name  = var.aws_iam_profile_name_for_ec2
+  role  = aws_iam_role.for_ec2[0].name
 }
 
 data "aws_ami" "linux_ubuntu" {
@@ -253,9 +254,9 @@ data "aws_ami" "linux_ubuntu" {
 }
 
 resource "aws_instance" "linux_ubuntu_vm" {
-  count         = var.aws_enable_creation
-  ami           = data.aws_ami.linux_ubuntu.id
-  instance_type = var.aws_vm_size
+  count                = var.aws_enable_creation
+  ami                  = data.aws_ami.linux_ubuntu.id
+  instance_type        = var.aws_vm_size
   iam_instance_profile = aws_iam_instance_profile.for_ec2[0].name
 
   tags = {
@@ -995,7 +996,7 @@ resource "aws_cloudtrail" "trail_1" {
   is_multi_region_trail         = true
   enable_log_file_validation    = true
 
-  cloud_watch_logs_group_arn = aws_cloudwatch_log_group.trail_1_log_group[0].arn
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.trail_1_log_group[0].arn}:*" # CloudTrail requires the Log Stream wildcard
   cloud_watch_logs_role_arn  = aws_iam_role.cloud_watch_logs_role[0].arn
   kms_key_id                 = aws_kms_key.trail_1_key[0].arn
 }
@@ -1446,7 +1447,7 @@ resource "aws_subnet" "rds_subnet_1" {
   count             = var.aws_enable_creation
   vpc_id            = aws_vpc.eks_vpc[0].id
   availability_zone = "${var.aws_region}b"
-  cidr_block        = "10.0.50.0/20"
+  cidr_block        = "10.0.48.0/20"
 
   depends_on = [aws_internet_gateway.igw]
 
@@ -1618,31 +1619,24 @@ resource "aws_lb" "aws-alb" {
   }
 }
 
-resource "aws_cloudformation_stack" "network" {
+resource "aws_cloudformation_stack" "ecr" {
   count = var.aws_enable_creation
   name  = var.aws_cloudformation_stack_name
-
-  parameters = {
-    VPCCidr = "10.0.0.0/16"
-  }
 
   template_body = <<STACK
 {
   "Parameters" : {
-    "VPCCidr" : {
+    "ECRrepo" : {
       "Type" : "String",
-      "Default" : "10.0.0.0/16",
-      "Description" : "CIDR block for the VPC"
+      "Default" : "aws-inspec-cloudformation_stack_ecr_name_fuevqbvfns",
+      "Description" : "ECR repo created by cloud formation."
     }
   },
   "Resources" : {
-    "myVpc": {
-      "Type" : "AWS::EC2::VPC",
+    "myEcrRepo": {
+      "Type" : "AWS::ECR::Repository",
       "Properties" : {
-        "CidrBlock" : { "Ref" : "VPCCidr" },
-        "Tags" : [
-          {"Key": "Name", "Value": "Primary_CF_VPC"}
-        ]
+        "RepositoryName" : { "Ref" : "ECRrepo" }
       }
     }
   }
@@ -1703,7 +1697,7 @@ resource "aws_rds_cluster_instance" "instance2" {
 }
 
 resource "aws_ec2_transit_gateway" "gateway" {
-  count               = var.aws_enable_creation
+  count       = var.aws_enable_creation
   description = "transitgateway1"
 }
 
@@ -1773,7 +1767,7 @@ locals {
   test_lambda_zip_file_name = "${path.module}/files/lambda.zip"
 }
 resource "aws_lambda_function" "lambda_test" {
-  count             = var.aws_enable_creation
+  count            = var.aws_enable_creation
   filename         = local.test_lambda_zip_file_name
   description      = "Test Lambda"
   function_name    = "test_Lambda"
@@ -1810,7 +1804,7 @@ resource "aws_ecr_repository" "inspec_test_ecr_repository" {
 }
 
 resource "aws_vpc" "for_igw" {
-  count = var.aws_enable_creation
+  count      = var.aws_enable_creation
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -1819,7 +1813,7 @@ resource "aws_vpc" "for_igw" {
 }
 
 resource "aws_internet_gateway" "inspec_test" {
-  count = var.aws_enable_creation
+  count  = var.aws_enable_creation
   vpc_id = aws_vpc.for_igw[0].id
 
   tags = {
@@ -1828,8 +1822,8 @@ resource "aws_internet_gateway" "inspec_test" {
 }
 
 resource "aws_subnet" "for_nat_gateway" {
-  count = var.aws_enable_creation
-  vpc_id = aws_vpc.for_igw[0].id
+  count      = var.aws_enable_creation
+  vpc_id     = aws_vpc.for_igw[0].id
   cidr_block = "10.0.1.0/24"
 
   tags = {
@@ -1838,8 +1832,8 @@ resource "aws_subnet" "for_nat_gateway" {
 }
 
 resource "aws_eip" "for_nat_gateway" {
-  count = var.aws_enable_creation
-  vpc = true
+  count            = var.aws_enable_creation
+  vpc              = true
   public_ipv4_pool = "amazon"
 
   tags = {
@@ -1848,10 +1842,10 @@ resource "aws_eip" "for_nat_gateway" {
 }
 
 resource "aws_nat_gateway" "inspec_test" {
-  count = var.aws_enable_creation
+  count         = var.aws_enable_creation
   allocation_id = aws_eip.for_nat_gateway[0].id
-  subnet_id = aws_subnet.for_nat_gateway[0].id
-  depends_on = ["aws_internet_gateway.inspec_test[0]"]
+  subnet_id     = aws_subnet.for_nat_gateway[0].id
+  depends_on    = ["aws_internet_gateway.inspec_test[0]"]
 
   tags = {
     Name = var.aws_nat_gateway_name
@@ -1894,4 +1888,14 @@ resource "aws_ssm_document" "ssm_document_1" {
     }
   }
 DOC
+}
+
+resource "aws_vpc_endpoint" "vpc_endpoint_1" {
+  count           = var.aws_enable_creation
+  vpc_id          = aws_vpc.inspec_vpc[0].id
+  service_name    = "com.amazonaws.${var.aws_region}.s3"
+  route_table_ids = [aws_route_table.route_table_first[0].id]
+  tags = {
+    Name = var.aws_vpc_endpoint_name
+  }
 }

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -261,4 +261,3 @@ output "aws_ssm_document_name" {
 output "aws_ssm_document_document_type" {
   value = aws_ssm_document.ssm_document_1.0.document_type
 }
-


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description
1) Fixes #253 

2) `Error: Error creating CloudTrail: InvalidCloudWatchLogsLogGroupArnException: Check the log group ARN: CloudTrail can't validate it.`
The issue was related to a major version update of terraform. See [here](https://www.gitmemory.com/issue/terraform-providers/terraform-provider-aws/14557/671975672).

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
