### PR TITLE
Improve `include?` method in AwsResourceProbe to enable key:pair lookups

### DIFF
--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -456,12 +456,20 @@ class AwsResourceProbe
     @count = item.length if item.respond_to? :length
   end
 
-  # Allows resources to respond to the include test
-  # This means that things like tags can be checked for and then their value tested
+  # Allows resources to respond to the `include` test
   #
-  # @param [String] key Name of the item to look for in the @item property
-  def include?(key)
-    @item.key?(key)
+  # @param [String, Hash, Symbol] opt => the item to look for in the @item property
+  #   String, Symbol: Key name
+  #   Hash: Key=>Value pair to look for in the @item property
+  def include?(opt)
+    unless opt.is_a?(Symbol) || opt.is_a?(Hash) || opt.is_a?(String)
+      raise ArgumentError, 'Key or Key:Value pair should be provided.'
+    end
+    if opt.is_a?(Hash)
+      raise ArgumentError, 'Only one item can be provided' if opt.keys.size > 1
+      return @item[opt.keys.first] == opt.values.first
+    end
+    @item.key?(opt.to_sym)
   end
 
   # Prevent undefined method error by returning nil.

--- a/test/integration/verify/controls/aws_lambdas.rb
+++ b/test/integration/verify/controls/aws_lambdas.rb
@@ -7,6 +7,6 @@ control "Check that any lambdas are correctly configured" do
   desc    "Ensure that our lambdas are correctly deployed"
 
   describe aws_lambdas() do
-    its ('count') { should eq 1}    
+    its ('count') { should > 1}
   end
 end

--- a/test/integration/verify/controls/aws_vpcs.rb
+++ b/test/integration/verify/controls/aws_vpcs.rb
@@ -1,9 +1,10 @@
 title 'Test AWS VPCs in bulk'
 
-aws_vpc_id = attribute(:aws_vpc_id, default: '', description: 'The AWS VPC ID.')
-aws_vpc_cidr_block = attribute(:aws_vpc_cidr_block, default: '', description: 'The AWS VPC CIDR block.')
-aws_vpc_instance_tenancy = attribute(:aws_vpc_instance_tenancy, default: '', description: 'The AWS VPC instance tenancy option.')
-aws_vpc_dhcp_options_id = attribute(:aws_vpc_dhcp_options_id, default: '', description: 'The AWS VPC DHCP options ID.')
+aws_vpc_id = attribute(:aws_vpc_id, value: '', description: 'The AWS VPC ID.')
+aws_vpc_cidr_block = attribute(:aws_vpc_cidr_block, value: '', description: 'The AWS VPC CIDR block.')
+aws_vpc_instance_tenancy = attribute(:aws_vpc_instance_tenancy, value: '', description: 'The AWS VPC instance tenancy option.')
+aws_vpc_dhcp_options_id = attribute(:aws_vpc_dhcp_options_id, value: '', description: 'The AWS VPC DHCP options ID.')
+aws_vpc_name = attribute(:aws_vpc_name, value: '', description: 'The AWS VPC name.')
 
 control 'aws-vpcs-1.0' do
 
@@ -19,7 +20,7 @@ control 'aws-vpcs-1.0' do
     its('dhcp_options_ids')  { should include aws_vpc_dhcp_options_id }
     its('instance_tenancys') { should include aws_vpc_instance_tenancy }
     its('is_defaults')       { should be_in [true, false] }
-    its('tags')              { should include('Name' => 'inspec-aws-vpc') }
+    its('tags')              { should include('Name' => aws_vpc_name) }
   end
 
 end


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

This will enable `key:value` lookups.
```
inspec> aws_ec2_instance('instance_id').network_interfaces
=> [#<#<Class:0x00007f9d584b18e0>::AwsResourceProbe:0x00007f9d59c05b90
  @count=15,
  @item=
   {...
    :owner_id=>"510367013823",
...
    :source_dest_check=>true,
    :status=>"in-use",
...
    :interface_type=>"interface"}>]

```

```
describe aws_ec2_instance('instance_id') do
  its('network_interfaces.first') { should include(:owner_id) }      # existing feature
  its('network_interfaces.first') { should include(owner_id: '510367013823') }     # new feature    
end
```

### Issues Resolved

Update some integration tests failing integration tests.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
