### PR TITLE
Remove duplicate terraform plan creation at setup_integration_tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,9 +46,9 @@ namespace :test do
     sh("bundle exec inspec check #{CONTROLS_DIR}")
   end
 
-  task :setup_integration_tests => ['tf:tf_dir', 'tf:plan_integration_tests', 'tf:setup_integration_tests']
+  task :setup_integration_tests => ['tf:setup_integration_tests']
 
-  task :plan_integration_tests => ['tf:tf_dir', 'tf:init_workspace', 'tf:plan_integration_tests']
+  task :plan_integration_tests => ['tf:plan_integration_tests']
 
   task :run_integration_tests do
     puts '----> Running InSpec tests'
@@ -61,7 +61,7 @@ namespace :test do
     sh(cmd)
   end
 
-  task :cleanup_integration_tests => ['tf:tf_dir', 'tf:cleanup_integration_tests']
+  task :cleanup_integration_tests => ['tf:cleanup_integration_tests']
 
   desc 'Perform Integration Tests'
   task integration: ['tf:setup_integration_tests'] do
@@ -97,7 +97,10 @@ namespace :tf do
     sh(cmd)
   end
 
-  task setup_integration_tests: [:tf_dir, :plan_integration_tests] do
+  task setup_integration_tests: [:tf_dir] do
+    unless File.exist?(TF_PLAN_FILE)
+      Rake::Task['test:plan_integration_tests'].execute
+    end
     puts '----> Applying the plan'
     # Apply the plan on AWS
     cmd = format('terraform apply %s', TF_PLAN_FILE)


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

`test:setup_integration_plan` is creating a new plan regardless of the one created with `test:plan_integration_plan`.

### Issues Resolved

N/A

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
