### PR TITLE
Updating IAM Role Documentation

### DIFF
--- a/docs/resources/aws_iam_role.md
+++ b/docs/resources/aws_iam_role.md
@@ -39,8 +39,8 @@ See also the [AWS documentation on IAM Roles](https://docs.aws.amazon.com/IAM/la
 |permissions\_boundary\_type    | The permissions boundary usage type that indicates what type of IAM resource is used as the permissions boundary for an entity. This data type can only have a value of Policy . |
 |permissions\_boundary\_arn     | The ARN of the policy used to set the permissions boundary for the user or role. |
 |inline\_policies               | A list of inline policy names associated with the described role. |
-|attached\_policies\_name       | A list of attached policy names associated with the described role. |
-|attached\_policies\_arn        | A list of attached policy ARNs associated with the described role. |
+|attached\_policies\_names      | A list of attached policy names associated with the described role. |
+|attached\_policies\_arns       | A list of attached policy ARNs associated with the described role. |
 
 
 ## Examples
@@ -49,6 +49,11 @@ See also the [AWS documentation on IAM Roles](https://docs.aws.amazon.com/IAM/la
     describe aws_iam_role(role_name: aws_iam_role_name) do
         it               { should exist }
         its('role_name') { should eq aws_iam_role_name }
+    end
+
+##### Test that an IAM Role has an attached policy ARN
+    describe aws_iam_role(role_name: aws_iam_role_name) do
+        its('attahed_policies_arns') { should include 'arn:aws:iam::aws:policy/IAMReadOnlyAccess'}
     end
 
 ## Matchers


### PR DESCRIPTION
docs(aws_iam_role.md): updated docs to reflect plural naming of attached_policies_names and attached_policies_arns

As given by lines 68 & 69 of aws_iam_role.rb the exposed lists are pluralized to attached_policies_arns instead of attached_policies_arn, likewise for attached_policies_names.

### Description

This change updates the IAM Role documentation to accurately reflect the correct Property names for the aws_iam_role resource. Existing documentation references the `attached_policies_arn` and `attached_policies_name` which as give by lines 68 & 69 of `aws_iam_role.rb` are pluralized. 

An additional example was added to the documentation to show end users how to adequately validate if a particular ARN is provided in the exposed list property.

### Issues Resolved

This does not resolve any existing issues (to my knowledge).

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ N/A ] New functionality includes integration tests/controls
- [ N/A ] New Terraform resources
- [ X ] Documentation provided or updated for resources 
- [ X ] All Integration Tests pass
- [ X ] All Unit Tests pass
- [ X ] `rake lint` passes
- [ X ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
