### PR TITLE
Adding KMS key attribute to SNS topic resource

### DIFF
--- a/docs/resources/aws_sns_topic.md
+++ b/docs/resources/aws_sns_topic.md
@@ -30,6 +30,7 @@ See also the [AWS documentation on SNS](https://docs.aws.amazon.com/sns/latest/d
 
 |Property                       | Description|
 | ---                           | --- |
+|kms\_master\_key\_id           | Provides the ID of an AWS-managed customer master key (CMK) for Amazon SNS topic or a custom CMK. |
 |confirmed\_subscription\_count | An integer indicating the number of currently active subscriptions. |
 
 ## Examples

--- a/libraries/aws_sns_topic.rb
+++ b/libraries/aws_sns_topic.rb
@@ -11,7 +11,7 @@ class AwsSnsTopic < AwsResourceBase
       its('confirmed_subscription_count') { should_not be_zero }
     end
   "
-  attr_reader :arn, :confirmed_subscription_count
+  attr_reader :arn, :kms_master_key_id, :confirmed_subscription_count
 
   def initialize(opts = {})
     opts = { arn: opts } if opts.is_a?(String)
@@ -25,6 +25,7 @@ class AwsSnsTopic < AwsResourceBase
       begin
         resp = @aws.sns_client.get_topic_attributes(topic_arn: @arn).attributes.to_h
         @confirmed_subscription_count = resp['SubscriptionsConfirmed'].to_i
+        @kms_master_key_id = resp['KmsMasterKeyId']
         create_resource_methods(resp)
       rescue Aws::SNS::Errors::NotFound
         return

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -134,6 +134,7 @@ variable "aws_ssm_parameter_name" {}
 variable "aws_ssm_document_name" {}
 variable "aws_sqs_queue_name" {}
 variable "aws_subnet_ip_address_count" {}
+variable "aws_sns_topic_with_encryption" {}
 variable "aws_sns_topic_no_subscription" {}
 variable "aws_sns_topic_subscription_sqs" {}
 variable "aws_sns_topic_with_subscription" {}
@@ -582,6 +583,12 @@ resource "aws_sns_topic_subscription" "sqs_test_queue_subscription" {
 resource "aws_sns_topic" "sns_topic_no_subscription" {
   count = var.aws_enable_creation
   name  = var.aws_sns_topic_no_subscription
+}
+
+resource "aws_sns_topic" "sns_topic_encryption" {
+  count             = var.aws_enable_creation
+  name              = var.aws_sns_topic_with_encryption
+  kms_master_key_id = "alias/aws/sns"
 }
 
 # Security Groups and Rules

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -86,6 +86,14 @@ output "aws_sns_topic_no_subscription_arn" {
   value = aws_sns_topic.sns_topic_no_subscription.0.arn
 }
 
+output "aws_sns_topic_with_encryption_arn" {
+  value = aws_sns_topic.sns_topic_encryption.0.arn
+}
+
+output "aws_sns_topic_kms_master_key_id" {
+  value = aws_sns_topic.sns_topic_encryption.0.kms_master_key_id
+}
+
 output "sns_sqs_queue_arn" {
   value = aws_sqs_queue.sns_sqs_queue.0.arn
 }

--- a/test/integration/configuration/aws_inspec_config.rb
+++ b/test/integration/configuration/aws_inspec_config.rb
@@ -177,6 +177,7 @@ module AWSInspecConfig
       aws_ssm_parameter_name: "parameter-name-#{add_random_string}",
       aws_ssm_document_name: "aws_ssm_document_name_#{add_random_string}",
       aws_sqs_queue_name: "aws-sqs-queue-#{add_random_string}",
+      aws_sns_topic_with_encryption: "aws-sns-topic-encryption-#{add_random_string}",
       aws_sns_topic_no_subscription: "aws-sns-topic-no-subscription-#{add_random_string}",
       aws_sns_topic_subscription_sqs: "aws-sns-topic-subscription-sqs-#{add_random_string}",
       aws_sns_topic_with_subscription: "aws-sns-topic-subscription-#{add_random_string}",

--- a/test/integration/verify/controls/aws_sns_topic.rb
+++ b/test/integration/verify/controls/aws_sns_topic.rb
@@ -4,6 +4,8 @@ aws_region = attribute(:aws_region, default: '', description: 'The AWS region id
 aws_account_id = attribute(:aws_account_id, default: '', description: 'The AWS account identifier.')
 aws_sns_topic_with_subscription_arn = attribute(:aws_sns_topic_with_subscription_arn, default: '', description: 'The AWS SNS topic ARN.')
 aws_sns_topic_no_subscription_arn = attribute(:aws_sns_topic_no_subscription_arn, default: '', description: 'The SNS topic ARN.')
+aws_sns_topic_with_encryption_arn = attribute(:aws_sns_topic_with_encryption_arn, default: '', description: 'The AWS SNS topic with encryption ARN.')
+kms_master_key_id = attribute(:aws_sns_topic_kms_master_key_id, default: '', description: 'The AWS SNS topic kms master key id.')
 
 control 'aws-sns-topic-1.0' do
 
@@ -18,6 +20,10 @@ control 'aws-sns-topic-1.0' do
   describe aws_sns_topic(arn: aws_sns_topic_no_subscription_arn) do
     it { should exist }
     its('confirmed_subscription_count') { should be_zero }
+  end
+
+  describe aws_sns_topic(arn: aws_sns_topic_with_encryption_arn) do
+    its('kms_master_key_id') { should eq kms_master_key_id }
   end
 
   describe aws_sns_topic(arn: "arn:aws:sns:#{aws_region}:#{aws_account_id}:not-existing-arn-dxeeggchuqdbphgmmqebzzedu") do

--- a/test/integration/verify/controls/aws_sns_topics.rb
+++ b/test/integration/verify/controls/aws_sns_topics.rb
@@ -17,4 +17,20 @@ control 'aws-sns-topics-1.0' do
     its('topic_arns') { should include aws_sns_topic_no_subscription_arn }
     its('topic_arns') { should_not include "arn:aws:sns:#{aws_region}:#{aws_account_id}:not-existing-arn-dxeeggchuqdbphgmmqebzzedu" }
   end
+
+  aws_regions.region_names.each do |region|
+    aws_sns_topics(aws_region: region).topic_arns.each do |topic_arn|
+      describe.one do
+        describe aws_sns_topic(aws_region: region, arn: topic_arn) do
+          it { should exist }
+          its('kms_master_key_id') { should_not be_nil }
+        end
+
+        describe aws_sns_topic(aws_region: region, arn: topic_arn) do
+          it { should exist }
+          its('kms_master_key_id') { should be_nil }
+        end
+      end
+    end
+  end
 end

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -1,6 +1,7 @@
 require 'helper'
 require 'aws_sns_topic'
 require 'aws-sdk-core'
+require_relative 'mock/iam/aws_sns_topic_mock'
 
 class AwsSnsTopicConstructorTest < Minitest::Test
 
@@ -77,5 +78,27 @@ class AwsSnsTopicTopicNoSubscriptionTest < Minitest::Test
 
   def test_sns_topic_confirmed_subscription_count
     assert_equal(0, @sns_topic.confirmed_subscription_count)
+  end
+end
+
+class AwsSnsTopicTest < Minitest::Test
+
+  def setup
+    # Given
+    @mock = AwsSnsTopicMock.new
+    @mock_topic = @mock.topic
+
+    # When
+    @topic = AwsSnsTopic.new(arn: 'arn:aws:sns:us-west-2:012345678901:aws-sns-topic-auzoitotenajpdiftuiorkmrf',
+                            client_args: { stub_responses: true },
+                            stub_data: @mock.stub_data)
+  end
+
+  def test_exists
+    assert @topic.exists?
+  end
+
+  def test_sns_topic_kms_id
+    assert_equal(@topic.kms_master_key_id, @mock_topic[:attributes]['KmsMasterKeyId'])
   end
 end

--- a/test/unit/resources/mock/iam/aws_sns_topic_mock.rb
+++ b/test/unit/resources/mock/iam/aws_sns_topic_mock.rb
@@ -11,13 +11,14 @@ class AwsSnsTopicMock < AwsBaseResourceMock
   end
 
   def stub_data
-    stub_data = []
 
-    topic = {:client => Aws::SNS::Client,
-             :method => :get_topic_attributes,
-             :data => @topic}
+    topic = {
+      client: Aws::SNS::Client,
+      method: :get_topic_attributes,
+      data: @topic
+    }
 
-    stub_data += [topic]
+    [topic]
   end
 
   def topic

--- a/test/unit/resources/mock/iam/aws_sns_topic_mock.rb
+++ b/test/unit/resources/mock/iam/aws_sns_topic_mock.rb
@@ -1,0 +1,26 @@
+require_relative '../aws_base_resource_mock'
+
+class AwsSnsTopicMock < AwsBaseResourceMock
+
+  def initialize
+    super
+    @topic = {}
+    @attributes = {"TopicArn"=> @aws.any_arn,
+                   "KmsMasterKeyId"=> "alias/aws/sns"}
+    @topic[:attributes] = @attributes
+  end
+
+  def stub_data
+    stub_data = []
+
+    topic = {:client => Aws::SNS::Client,
+             :method => :get_topic_attributes,
+             :data => @topic}
+
+    stub_data += [topic]
+  end
+
+  def topic
+    @topic
+  end
+end


### PR DESCRIPTION
### Description

Adding KMS key attribute to SNS topic resource

### Issues Resolved

Adding new attribute so no issues resolved

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [x] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
