### PR TITLE
Adding aws cloudformation stack policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gem 'bundle'
 # Note that 'aws-sdk' pulls in a large number of libraries, choose explicitly those to include instead
-# gem 'aws-sdk', '~> 3'
+gem 'aws-sdk', '~> 3'
 #
 # See service list here: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/index.html
 #

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gem 'bundle'
 # Note that 'aws-sdk' pulls in a large number of libraries, choose explicitly those to include instead
-gem 'aws-sdk', '~> 3'
+# gem 'aws-sdk', '~> 3'
 #
 # See service list here: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/index.html
 #

--- a/libraries/aws_cloudformation_stack_policy.rb
+++ b/libraries/aws_cloudformation_stack_policy.rb
@@ -18,7 +18,7 @@ class AwsCloudformationStackPolicy < AwsResourceBase
     opts = { stack_name: opts } if opts.is_a?(String)
     super(opts)
     validate_parameters(required: [:stack_name])
-
+    
     catch_aws_errors do
       name = { stack_name: opts[:stack_name] }
       @resp = @aws.cloudformation_client.get_stack_policy(name)

--- a/libraries/aws_cloudformation_stack_policy.rb
+++ b/libraries/aws_cloudformation_stack_policy.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AwsCloudformationStack < AwsResourceBase
+  name 'aws_cloudformation_stack_policy'
+  desc 'Verifies policy settings for an aws CloudFormation Stack'
+
+  example "
+    describe aws_cloudformation_stack_policy('stack_name') do
+      it { should exist }
+    end
+  "
+
+  attr_reader :stack_name, :stack_policy_body
+
+  def initialize(opts = {})
+    opts = { stack_name: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: [:stack_name])
+    catch_aws_errors do
+      @resp = @aws.cloudformation_client.get_stack_policy(stack_name)
+      @stack_policy_body = @resp
+    end
+  end
+
+  def exists?
+    !@stack_policy_body.nil?
+  end
+
+  def has_statement?(criteria = {})
+    return false unless @stack_policy_body
+    document = JSON.parse(URI.decode_www_form_component(@stack_policy_body.stack_policy_body), { symbolize_names: true })
+    statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document{:Statement}
+    statement_match = []
+
+    criteria = criteria.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    criteria[:Resource] = criteria[:Resource].is_a?(Array) ? criteria[:Resource].sort : criteria[:Resource]
+    statements.each do |s|
+      actions    = s[:Action] || []
+      notactions = s[:NotAction] || []
+      effect     = s[:Effect]
+      resource   = s[:Resource].is_a?(Array) ? s[:Resource].sort : s[:Resource]
+
+      action_match = criteria[:Action].nil? ? true : actions.include?(criteria[:Action])
+
+      no_action_match = criteria[:NotAction].nil? ? true : notactions.include?(criteria[:NotAction])
+
+      effect_match = criteria[:Effect].nil? ? true : effect.eql?(criteria[:Effect])
+
+      resource_match = criteria[:Resource].nil? ? true : resource.eql?(criteria[:Resource])
+
+      statement_match.push(action_match && no_action_match && effect_match && resource_match)
+    end
+    statement_match.include?(true)
+  end
+
+  def statement_count
+    return false unless @stack_policy_body
+    document = JSON.parse(URI.decode_www_form_component(@stack_policy_body.stack_policy_body), { symbolize_names: true })
+    statements = document[:Statement].is_a?(Hash) ? [document[:Statement]] : document[:Statement]
+    statements.length
+  end
+    end
+
+
+  def to_s
+    "AWS CloudFormation Stack Policy  for #{@stack_name}"
+  end
+end

--- a/test/unit/resources/aws_cloudformation_stack_policy_test.rb
+++ b/test/unit/resources/aws_cloudformation_stack_policy_test.rb
@@ -27,13 +27,13 @@ class AwsCloudformationStackPolicyTest < Minitest::Test
     @mock_stack = @mock.stack
 
     # When
-    @stack= AwsCloudformationStackPolicy.new(stack_name:  @mock_stack[:stack_name],
-                           client_args: { stub_responses: true },
-                           stub_data: @mock.stub_data)
+    @stack = AwsCloudformationStackPolicy.new(stack_name:  @mock_stack[:stack_name],
+                                         client_args: { stub_responses: true },
+                                         stub_data: @mock.stub_data)
   end
 
   def test_stack_name
-    assert_equal(@stack.stack_name, @mock_policy[:stack_name])
+    assert_equal(@stack.stack_name, @mock_stack[:stack_name])
   end
 
   def test_statement_count

--- a/test/unit/resources/aws_cloudformation_stack_policy_test.rb
+++ b/test/unit/resources/aws_cloudformation_stack_policy_test.rb
@@ -1,0 +1,62 @@
+require 'aws-sdk-core'
+require 'aws_cloudformation_stack_policy'
+require 'helper'
+require_relative 'mock/aws_cloudformation_stack_policy_mock'
+
+
+class AwsCloudformationStackPolicyConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AwsCloudformationStackPolicy.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_required_any_params_not_ok
+    assert_raises(ArgumentError) { AwsCloudformationStackPolicy.new(stack_name: 'stack-name', client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_unrecognized_params
+    assert_raises(ArgumentError) { AwsCloudformationStackPolicy.new(rubbish: 9) }
+  end
+end
+
+class AwsCloudformationStackPolicyTest < Minitest::Test
+
+  def setup
+    # Given
+    @mock = AwsCloudformationStackPolicyMock.new
+    @mock_stack = @mock.stack
+
+    # When
+    @stack= AwsCloudformationStackPolicy.new(stack_name:  @mock_stack[:stack_name],
+                           client_args: { stub_responses: true },
+                           stub_data: @mock.stub_data)
+  end
+
+  def test_stack_name
+    assert_equal(@stack.stack_name, @mock_policy[:stack_name])
+  end
+
+  def test_statement_count
+    assert_equal(@stack.statement_count, 2)
+  end
+
+  def test_exists
+    assert @stack.exists?
+  end
+
+  def test_statement_contains_action
+    assert @stack.has_statement?(Action: "Update:*")
+  end
+
+  def test_statment_contains_action_existing_with_effect
+    assert @stack.has_statement?(Action: "Update:*", Effect: "Allow")
+  end
+
+  def test_statment_contains_action_existing_with_effect_and_resource
+    assert @stack.has_statement?(Action: "Update:*", Effect: "Allow", Resource: "*")
+  end
+
+  def test_statement_wrong_action
+    refute @stack.has_statement?(NotAction: "Update:*", Effect: "Allow", Resource: "*")
+  end
+end

--- a/test/unit/resources/mock/aws_cloudformation_stack_policy_mock.rb
+++ b/test/unit/resources/mock/aws_cloudformation_stack_policy_mock.rb
@@ -1,0 +1,37 @@
+require_relative 'aws_base_resource_mock'
+
+class AwsCloudformationStackPolicyMock < AwsBaseResourceMock
+  def initialize
+    super
+    @stack_required = {}
+    @stack_required[:stack_name] = @aws.any_string
+
+    @stack = Hash[@stack_required]
+    @stack[:stack_name] = 'test-stack'
+    @stack[:stack_policy_body] = "%7B%0A%20%20%20%20%20%22Statement%22%20%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22Effect%22%20%3A%20%22Deny%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Action%22%20%3A%20%22Update%3A*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Principal%22%20%3A%20%22*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Resource%22%20%3A%20%22LogicalResourceId%2FProductionDatabase%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22Effect%22%20%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Action%22%20%3A%20%22Update%3A*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Principal%22%20%3A%20%22*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Resource%22%20%3A%20%22*%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A"
+  end
+
+  def stub_data
+    stub_data = []
+
+    stack = { :client => Aws::CloudFormation::Client,
+               :method => :get_stack_policy,
+               :data => { :stack_policy_body => @stack[:stack_policy_body],
+                          :stack_name => @stack[:stack_name]
+                        }}
+
+    statements = { :client => Aws::CloudFormation::Client,
+                   :method => :get_stack_policy,
+                   :data => { :stack_policy_body => @stack[:stack_policy_body],
+                        :stack_name => @stack[:stack_name]
+                      }}
+
+    # stub_data += [stack]
+    stub_data += [statements]
+
+  end
+
+  def stack
+    @stack
+  end
+end

--- a/test/unit/resources/mock/aws_cloudformation_stack_policy_mock.rb
+++ b/test/unit/resources/mock/aws_cloudformation_stack_policy_mock.rb
@@ -3,30 +3,37 @@ require_relative 'aws_base_resource_mock'
 class AwsCloudformationStackPolicyMock < AwsBaseResourceMock
   def initialize
     super
-    @stack_required = {}
-    @stack_required[:stack_name] = @aws.any_string
+    @param_required = {}
+    @param_required[:stack_name] = @aws.any_string
 
-    @stack = Hash[@stack_required]
-    @stack[:stack_name] = 'test-stack'
-    @stack[:stack_policy_body] = "%7B%0A%20%20%20%20%20%22Statement%22%20%3A%20%5B%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22Effect%22%20%3A%20%22Deny%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Action%22%20%3A%20%22Update%3A*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Principal%22%20%3A%20%22*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Resource%22%20%3A%20%22LogicalResourceId%2FProductionDatabase%22%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%22Effect%22%20%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Action%22%20%3A%20%22Update%3A*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Principal%22%20%3A%20%22*%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22Resource%22%20%3A%20%22*%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%5D%0A%20%20%20%20%7D%0A"
+    @stack = Hash[@param_required]
+    @stack[:stack_name] = "testStack"
+    @stack[:stack_policy_body] =  '{Statement: [
+                                    {
+                                      Effect: "Deny",
+                                      Action: "Update:*",
+                                      Principal: "*",
+                                      Resource: "LogicalResourceId/ProductionDatabase"
+                                    },
+                                    {
+                                      Effect: "Allow",
+                                      Action: "Update:*",
+                                      Principal: "*",
+                                      Resource: "*"
+                                    }
+                                  ]
+                                }'
   end
 
   def stub_data
     stub_data = []
 
-    stack = { :client => Aws::CloudFormation::Client,
-               :method => :get_stack_policy,
-               :data => { :stack_policy_body => @stack[:stack_policy_body],
-                          :stack_name => @stack[:stack_name]
-                        }}
-
     statements = { :client => Aws::CloudFormation::Client,
                    :method => :get_stack_policy,
                    :data => { :stack_policy_body => @stack[:stack_policy_body],
-                        :stack_name => @stack[:stack_name]
-                      }}
+                   :stack_name => @stack[:stack_name]
+                  }}
 
-    # stub_data += [stack]
     stub_data += [statements]
 
   end


### PR DESCRIPTION
### Description

Support needed for error encountered during unit test. 
Even though the stack_name in test case is string, an error "ArgumentError: unexpected value at params[:stack_name]" persists. Support on why this occurs and how to resolve this is needed.



### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
