### PR TITLE
aws_auto_scaling_groups lint error fix

### DIFF
--- a/libraries/aws_auto_scaling_group.rb
+++ b/libraries/aws_auto_scaling_group.rb
@@ -34,11 +34,15 @@ class AwsAutoScalingGroup < AwsResourceBase
       @tags = []
 
       auto_scaling_group[:tags].map { |tag|
-        @tags.push({ 'resource_id':         tag.resource_id,
-                         'resource_type':       tag.resource_type,
-                         'key':                 tag.key,
-                         'value':               tag.value,
-                         'propagate_at_launch': tag.propagate_at_launch })
+        @tags.push(
+          {
+            'resource_id':              tag.resource_id,
+            'resource_type':            tag.resource_type,
+            'key':                      tag.key,
+            'value':                    tag.value,
+            'propagate_at_launch':      tag.propagate_at_launch,
+          },
+        )
       }
     end
   end

--- a/libraries/aws_auto_scaling_groups.rb
+++ b/libraries/aws_auto_scaling_groups.rb
@@ -45,11 +45,15 @@ class AwsAutoScalingGroups < AwsResourceBase
                          health_check_type:         group[:health_check_type] }]
 
         group[:tags].map { |tag|
-          config_rows.push({ 'resource_id':          tag.resource_id,
-                                  'resource_type':       tag.resource_type,
-                                  'key':                 tag.key,
-                                  'value':               tag.value,
-                                  'propagate_at_launch': tag.propagate_at_launch })
+          config_rows.push(
+            {
+              'resource_id':          tag.resource_id,
+              'resource_type':        tag.resource_type,
+              'key':                  tag.key,
+              'value':                tag.value,
+              'propagate_at_launch':  tag.propagate_at_launch,
+            },
+          )
         }
       end
     end


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description
This is the fix of the lint error that occurred due to the update in the bundle version.

### Issues Resolved
While checking the lint errors, the /aws_auto_scaling_group.rb and soumyo/aws_auto_scaling_groups.rb files in the libraries folder were throwing lint errors, those are fixed in this branch. This branch is taken from the master branch as in the master branch only we are getting the errors.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
