### PR TITLE
changes done to remove the rake warning

### DIFF
--- a/libraries/aws_ec2_transit_gateway_attachments.rb
+++ b/libraries/aws_ec2_transit_gateway_attachments.rb
@@ -5,11 +5,11 @@ require 'aws_backend'
 class AwsEc2TransitGatewayAttachments < AwsResourceBase
   name 'aws_ec2_transit_gateway_attachments'
   desc 'Describes one or more attachments between resources and transit gateways. By default, all attachments are described. Alternatively, you can filter the results by attachment ID, attachment state, resource ID, or resource owner.'
-  example `
+  example "
     describe aws_ec2_transit_gateway_attachements do
       it { should exist }
     end
-  `
+  "
 
   attr_reader :table
 

--- a/libraries/aws_ec2_transit_gateway_route_table_association.rb
+++ b/libraries/aws_ec2_transit_gateway_route_table_association.rb
@@ -6,11 +6,11 @@ class AwsEc2TransitGatewayRouteTableAssociation < AwsResourceBase
   name 'aws_ec2_transit_gateway_route_table_association'
   desc 'Gets information about the associations for the specified transit gateway route table.'
 
-  example `
+  example "
     describe aws_ec2_transit_gateway_route_table_association(transit_gateway_route_table_id: 'tgw-attach-0123456789') do
       it { should exist }
     end
-  `
+  "
 
   attr_reader :table
 

--- a/libraries/aws_ec2_transit_gateway_route_table_associations.rb
+++ b/libraries/aws_ec2_transit_gateway_route_table_associations.rb
@@ -5,11 +5,11 @@ require 'aws_backend'
 class AwsEc2TransitGatewayRouteTableAssociations < AwsResourceBase
   name 'aws_ec2_transit_gateway_route_table_associations'
   desc 'Gets information about the associations for the specified transit gateway route table.'
-  example `
+  example "
     describe aws_ec2_transit_gateway_route_table_associations(transit_gateway_route_table_id: 'tgw-attach-0123456789') do
       it { should exist }
     end
-  `
+  "
 
   attr_reader :table
 

--- a/libraries/aws_ec2_transit_gateway_route_tables.rb
+++ b/libraries/aws_ec2_transit_gateway_route_tables.rb
@@ -6,11 +6,11 @@ class AwsEc2TransitGatewayRouteTables < AwsResourceBase
   name 'aws_ec2_transit_gateway_route_tables'
   desc 'Describes one or more transit gateway route tables. By default, all transit gateway route tables are described. Alternatively, you can filter the results.'
 
-  example `
+  example "
     describe aws_ec2_transit_gateway_route_tables do
       it { should exist }
     end
-  `
+  "
 
   attr_reader :table
 

--- a/libraries/aws_launch_configurations.rb
+++ b/libraries/aws_launch_configurations.rb
@@ -4,12 +4,12 @@ require 'aws_backend'
 
 class AwsLaunchConfigurations < AwsResourceBase
   name 'aws_launch_configurations'
-  desc 'Verifies settings for a collection AWS Launch Configurations'
-  example '
+  desc 'Verifies settings for a collection AWS Launch Configurations.'
+  example "
     describe aws_launch_configurations do
       it { should exist }
     end
-  '
+  "
 
   attr_reader :table
 

--- a/libraries/aws_rds_option_group.rb
+++ b/libraries/aws_rds_option_group.rb
@@ -4,7 +4,7 @@ require 'aws_backend'
 
 class AwsRdsOptionGroup < AwsResourceBase
   name 'aws_rds_option_group'
-  desc 'Verifies settings for an RDS Option Group'
+  desc 'Verifies settings for an RDS Option Group.'
 
   example "
     describe aws_rds_option_group(option_group_name: 'test-option_group_name') do
@@ -15,6 +15,7 @@ class AwsRdsOptionGroup < AwsResourceBase
       it { should exist }
     end
   "
+
   def initialize(opts = {})
     opts = { option_group_name: opts } if opts.is_a?(String)
     super(opts)

--- a/libraries/aws_rds_option_groups.rb
+++ b/libraries/aws_rds_option_groups.rb
@@ -5,11 +5,11 @@ require 'aws_backend'
 class AwsRdsOptionGroups < AwsResourceBase
   name 'aws_rds_option_groups'
   desc 'Verifies settings for a collection AWS RDS Clusters'
-  example '
+  example "
     describe aws_rds_group_options do
       it { should exist }
     end
-  '
+  "
 
   attr_reader :table
 

--- a/libraries/aws_redshift_cluster_parameter_group.rb
+++ b/libraries/aws_redshift_cluster_parameter_group.rb
@@ -5,11 +5,11 @@ require 'aws_backend'
 class AwsRedshiftClusterParameterGroup < AwsResourceBase
   name 'aws_redshift_cluster_parameter_group'
   desc 'Describes a parameter group.'
-  example '
+  example "
     describe aws_redshift_cluster_parameter_group(parameter_group_name: aws_parameter_group_name) do
       it { should exist }
     end
-  '
+  "
 
   def initialize(opts = {})
     opts = { public_ip: opts } if opts.is_a?(String)

--- a/libraries/aws_redshift_cluster_parameter_groups.rb
+++ b/libraries/aws_redshift_cluster_parameter_groups.rb
@@ -5,11 +5,11 @@ require 'aws_backend'
 class AwsRedshiftClusterParameterGroups < AwsResourceBase
   name 'aws_redshift_cluster_parameter_groups'
   desc 'Describes a parameter group.'
-  example `
-    describe aws_redshift_cluster_parameter_group(parameter_group_name: aws_parameter_group_name) do
+  example "
+    describe aws_redshift_cluster_parameter_groups do
       it { should exist }
     end
-  `
+  "
   attr_reader :table
 
   FilterTable.create


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

We were getting some syntax errors while running the command "bundle exec rake" - In this or those are fixed.

### Issues Resolved

We were getting some syntax errors while running the command "bundle exec rake" - In this or those are fixed.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
