### PR TITLE
Fix: Resource aws_rds_clusters Raises NULLException

### DIFF
--- a/docs/resources/aws_rds_clusters.md
+++ b/docs/resources/aws_rds_clusters.md
@@ -43,7 +43,7 @@ See also the [AWS documentation on RDS](https://docs.aws.amazon.com/rds/?id=docs
 ### Ensure a specific cluster exists
 
     describe aws_rds_clusters do
-      its('db_cluster_identifier') { should include 'cluster-12345678' }
+      its('db_cluster_identifier') { should include ['cluster-12345678', 'cluster-456786786'] }
     end
 
 ### Request the IDs of all RDS clusters, then test in-depth using `aws_rds_cluster` to ensure all clusters are encrypted and have a sensible size.

--- a/libraries/aws_rds_clusters.rb
+++ b/libraries/aws_rds_clusters.rb
@@ -42,7 +42,7 @@ class AwsRdsClusters < AwsResourceBase
       response.db_clusters.each do |rds_cluster|
         cluster_rows += [{ cluster_identifier:               rds_cluster.db_cluster_identifier,
                            database_name:                    rds_cluster.database_name,
-                           cluster_members:                  rds_cluster.db_cluster_members[0].db_instance_identifier,
+                           cluster_members:                  rds_cluster.db_cluster_members.map(&:db_instance_identifier),
                            engine:                           rds_cluster.engine,
                            engine_version:                   rds_cluster.engine_version,
                            status:                           rds_cluster.status,


### PR DESCRIPTION
Signed-off-by: nirbhay1997 <nkumar@progress.com>

### Description

Resource aws_rds_clusters Raises NULL Exception Fix



List any existing issues this PR resolves or any Discourse or StackOverflow discussion that's relevant
[](url)

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
