### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -8,7 +8,8 @@ ruby -v
 bundle --version
 
 echo "--- bundle install"
-bundle install --jobs=7 --retry=3 --without tools maintenance deploy
+bundle config set --local without tools maintenance deploy
+bundle install --jobs=7 --retry=3
 
 echo "+++ bundle exec rake lint"
 bundle exec rake lint


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AWS](https://github.com/inspec/inspec-aws/CONTRIBUTING.md) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
