### PR TITLE
Change date format in publish-release-notes script

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 PRODUCT=inspec-aws
-CURRENTDATE=$(date +"%m-%d-%Y")
+CURRENTDATE=$(date +"%Y-%m-%d")
 DOCS_DIR="docs-chef-io/static/release-notes/inspec-aws"
 BRANCH="expeditor/update_release_notes_${CURRENTDATE}"
 


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>

### Description

Change date format from MM-DD-YYYY to YYYY-MM-DD in publish-release-notes.sh

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AWS](https://github.com/inspec/inspec-aws/CONTRIBUTING.md) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
