### PR TITLE
Added support for Cloud front origin request policy

### DIFF
--- a/docs/resources/aws_cloud_front_origin_request_policy.md
+++ b/docs/resources/aws_cloud_front_origin_request_policy.md
@@ -1,0 +1,78 @@
+---
+title: About the aws_cloud_front_origin_request_policy Resource
+platform: aws
+---
+
+# aws_cloud_front_origin_request_policy
+
+Use the `aws_cloud_front_origin_request_policy` InSpec audit resource to test properties of a single specific AWS CloudFront Origin Request Policy.
+
+## Syntax
+
+Ensure that the custom resource exists.
+
+    describe aws_cloud_front_origin_request_policy(id: 'ID') do
+      it { should exist }
+    end
+
+## Parameters
+
+`id` _(required)_
+
+| Property | Description |
+| --- | --- |
+| id | The unique identifier for the origin request policy. |
+
+For additional information, see the [AWS documentation on AWS CloudFormation CachePolicy.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-cachepolicy.html).
+
+## Properties
+
+| Property | Description | Field | 
+| --- | --- | --- |
+| origin_request_policy.id| The unique identifier for the origin request policy.  | origin_request_policy.id |
+| origin_request_policy.last_modified_time | The date and time when the origin request policy was last modified. | last_modified_time |
+| etag | The current version of the origin request policy. | etag |
+
+## Examples
+
+### Ensure a id is available.
+    describe aws_cloud_front_origin_request_policy(id: 'ID') do
+      its('id') { should eq 'ID' }
+    end
+
+### Verify the max ttl of the policy.
+    describe aws_cloud_front_origin_request_policy(id: 'ID') do
+        its('etag') { should eq 'ETAG' }
+    end
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+The controls will pass if the `get` method returns at least one result.
+
+### exist
+
+Use `should` to test that the entity exists.
+
+    describe aws_cloud_front_origin_request_policy(id: 'ID') do
+      it { should exist }
+    end
+
+Use `should_not` to test the entity does not exist.
+
+    describe aws_cloud_front_origin_request_policy(id: 'dummy') do
+      it { should_not exist }
+    end
+
+### be_available
+
+Use `should` to check if the entity is available.
+
+    describe aws_cloud_front_origin_request_policy(id: 'ID') do
+      it { should be_available }
+    end
+
+## AWS Permissions
+
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `CloudFront:Client:GetOriginRequestPolicyResult` action with `Effect` set to `Allow`.

--- a/libraries/aws_cloud_front_origin_request_policy.rb
+++ b/libraries/aws_cloud_front_origin_request_policy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'aws_backend'
+
+class AWSCloudFrontOriginRequestPolicy < AwsResourceBase
+  name 'aws_cloud_front_origin_request_policy'
+  desc 'Describes an origin request policy .'
+
+  example "
+    describe aws_cloud_front_origin_request_policy(id: 'test1') do
+      it { should exist }
+    end
+  "
+
+  def initialize(opts = {})
+    opts = { id: opts } if opts.is_a?(String)
+    super(opts)
+    validate_parameters(required: [:id])
+
+    raise ArgumentError, "#{@__resource_name__}: id must be provided" unless opts[:id] && !opts[:id].empty?
+    @display_name = opts[:id]
+    resp = @aws.cloudfront_client.get_origin_request_policy({ id: opts[:id] })
+    @origin_request_policy= resp.origin_request_policy.to_h
+    create_resource_methods(@origin_request_policy)
+  end
+
+  def id
+    return nil unless exists?
+    @origin_request_policy[:id]
+  end
+
+  def exists?
+    !@origin_request_policy.nil? && !@origin_request_policy.empty?
+  end
+
+  def to_s
+    "Origin request policy ID: #{@display_name}"
+  end
+end

--- a/test/unit/resources/aws_cloud_front_origin_request_policy_test.rb
+++ b/test/unit/resources/aws_cloud_front_origin_request_policy_test.rb
@@ -1,0 +1,41 @@
+require 'helper'
+require 'aws_cloud_front_origin_request_policy'
+require 'aws-sdk-core'
+
+class AWSCloudFrontOriginRequestPolicyConstructorTest < Minitest::Test
+
+  def test_empty_params_not_ok
+    assert_raises(ArgumentError) { AWSCloudFrontOriginRequestPolicy.new(client_args: { stub_responses: true }) }
+  end
+
+  def test_rejects_other_args
+    assert_raises(ArgumentError) { AWSCloudFrontOriginRequestPolicy.new(ids: 'rubbish') }
+  end
+end
+
+class AWSCloudFrontOriginRequestPolicyHappyPathTest < Minitest::Test
+
+  def setup
+    data = {}
+    data[:method] = :get_origin_request_policy
+    mock_parameter = {}
+    mock_parameter[:id] = "test1"
+    mock_parameter[:last_modified_time] = Time.now
+    mock_parameter[:origin_request_policy_config] = {comment: 'test1' , name: 'test1' , headers_config: {header_behavior: 'test1'}, cookies_config: {cookie_behavior: 'test1'}, query_strings_config: { query_string_behavior: 'test1'} }
+    data[:data] = { origin_request_policy: mock_parameter }
+    data[:client] = Aws::CloudFront::Client
+    @origin_request_policy = AWSCloudFrontOriginRequestPolicy.new(id: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+  end
+
+  def origin_request_policy_exists
+    assert @origin_request_policy.exists?
+  end
+
+  def test_origin_request_policy_id
+    assert_equal(@origin_request_policy.id, 'test1')
+  end
+
+  def test_origin_request_policy_etag
+    assert_equal(@origin_request_policy.origin_request_policy_config.name , 'test1')
+  end
+end


### PR DESCRIPTION
Signed-off-by: Nirbhay Kumar <nkumar@progress.com>

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AWS](https://github.com/inspec/inspec-aws/CONTRIBUTING.md) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
