### PR TITLE
Fix resource name in docs

### DIFF
--- a/docs/resources/aws_ec2_vpn_gateway_route_propagations.md
+++ b/docs/resources/aws_ec2_vpn_gateway_route_propagations.md
@@ -1,13 +1,13 @@
 ---
-title: About the aws_ec2_transit_gateway_route_table_propagations Resource
+title: About the aws_ec2_vpn_gateway_route_propagations Resource
 platform: aws
 ---
 
-# aws\_ec2\_transit_gateway_route\_table\_propagations
+# aws_ec2_vpn_gateway_route_propagations
 
-Use the `aws_ec2_transit_gateway_route_table_propagations` InSpec audit resource to test if virtual private gateways can propagate routes to multiple AWS EC2 route tables.
+Use the `aws_ec2_vpn_gateway_route_propagations` InSpec audit resource to test if virtual private gateways can propagate routes to multiple AWS EC2 route tables.
 
-The `AWS::EC2::TransitGatewayRouteTablePropagation` resource enables a virtual private gateway (VGW) to propagate routes to the specified route table of a VPC.
+The `AWS::EC2::VPNGatewayRoutePropagation` resource enables a virtual private gateway (VGW) to propagate routes to the specified route table of a VPC.
 
 ## Syntax
 


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

Fix resource name in aws_ec2_vpn_gateway_route_propagations.md page

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
