### PR TITLE
Add attributes to ebs volumes resource

### DIFF
--- a/docs/resources/aws_ebs_volume.md
+++ b/docs/resources/aws_ebs_volume.md
@@ -5,34 +5,33 @@ platform: aws
 
 # aws\_ebs\_volume
 
-Use the `aws_ebs_volume` InSpec audit resource to test properties of a single AWS EBS volume.
+Use the `aws_ebs_volume` InSpec audit resource to test the properties of a single AWS EBS volume.
 
 ## Syntax
 
 Ensure an EBS exists
 
-    describe aws_ebs_volume('vol-01a2349e94458a507') do
+    describe aws_ebs_volume('VOLUME-01a2349e94458a507') do
       it { should exist }
     end
-You may also use hash syntax to pass the EBS volume name
 
-    describe aws_ebs_volume(name: 'data-vol') do
+You may also use hash syntax to pass the EBS volume name.
+
+    describe aws_ebs_volume(name: 'DATA-VOLUME') do
       it { should exist }
     end
-    
-#### Parameters
-This resource accepts a single parameter, either the EBS Volume name or id. At least one must be provided.
 
-##### volume\_id _(required if `name` not provided)_
+## Parameters
 
-The EBS Volume ID which uniquely identifies the volume.
-This can be passed as either a string or an `volume_id: 'value'` key-value entry in a hash.
+This resource accepts a single parameter, either the EBS volume name or ID. _mandatory_
 
-##### name _(required if `volume_id` not provided)_
+### volume\_id _(required if `name` not provided)_
 
-The EBS Volume Name which uniquely identifies the volume.
-This must be passed as a `name: 'value'` key-value entry in a hash.
+The EBS volume ID which uniquely identifies the volume. This can be passed as either a string or an `volume_id: 'value'` key-value entry in a hash.
 
+### name _(required if `volume_id` not provided)_
+
+The EBS volume name which uniquely identifies the volume. This must be passed as a `name: 'value'` key-value entry in a hash.
 
 See also the [AWS documentation on EBS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AmazonEBS.html).
 
@@ -40,30 +39,32 @@ See also the [AWS documentation on EBS](https://docs.aws.amazon.com/AWSEC2/lates
 
 |Property            | Description|
 | ---                | --- |
-|availability\_zone  | The Availability Zone for the volume. |
-|encrypted           | Indicates whether the volume will be encrypted. |
+|availability\_zone  | The availability zone for the volume. |
+|encrypted           | Indicates whether the volume is encrypted. |
 |iops                | The number of I/O operations per second (IOPS) that the volume supports. |
-|kms\_key\_id        | The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to protect the volume encryption key for the volume.  |
-|size                | The size of the volume, in GiBs. |
-|snapshot\_id        | The snapshot from which the volume was created, if applicable. |
+|kms\_key\_id        | The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) is used to protect the encryption key for the volume.  |
+|size                | The size of the volume in GiBs. |
+|snapshot\_id        | The snapshot from which the volume is created, if applicable. |
 |status              | The volume state. |
 |volume\_type        | The volume type. |
 
 ## Examples
 
+### Test that an EBS Volume does not exist
 
-##### Test that an EBS Volume does not exist
-    describe aws_ebs_volume(name: 'data_vol') do
+    describe aws_ebs_volume(name: 'DATA-VOLUME') do
       it { should_not exist }
     end
 
-##### Test that an EBS Volume is encrypted
-    describe aws_ebs_volume(name: 'secure_data_vol') do
+### Test that an EBS Volume is encrypted
+
+    describe aws_ebs_volume(name: 'SECURE_DATA-VOLUME') do
       it { should be_encrypted }
     end
 
-##### Test that an EBS Volume the correct size
-    describe aws_ebs_volume(name: 'data_vol') do
+### Test that an EBS Volume has the correct size
+
+    describe aws_ebs_volume(name: 'DATA-VOLUME') do
       its('size') { should cmp 32 }
     end
 
@@ -77,22 +78,22 @@ The control will pass if the describe returns at least one result.
 
 Use `should_not` to test the entity should not exist.
 
-    describe aws_ebs_volume(name: 'data_vol') do
+    describe aws_ebs_volume(name: 'DATA-VOLUME') do
       it { should exist }
     end
 
-    describe aws_ebs_volume(name: 'data_vol') do
+    describe aws_ebs_volume(name: 'DATA-VOLUME') do
       it { should_not exist }
     end
 
 #### be\_encrypted
 
-The `be_encrypted` matcher tests if the described EBS Volume is encrypted.
+The `be_encrypted` matcher tests if the described EBS volume is encrypted.
 
     it { should be_encrypted }
 
 ## AWS Permissions
 
-Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `EC2:Client:DescribeVolumesResult` actions set to allow.
+Your [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html#intro-structure-principal) will need the `EC2:Client:DescribeVolumesResult` actions set to `allow`.
 
 You can find detailed documentation at [Actions, Resources, and Condition Keys for Amazon EC2](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonec2.html), and [Actions, Resources, and Condition Keys for Identity And Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_identityandaccessmanagement.html).

--- a/docs/resources/aws_ebs_volumes.md
+++ b/docs/resources/aws_ebs_volumes.md
@@ -27,7 +27,21 @@ See also the [AWS documentation on EBS](https://docs.aws.amazon.com/AWSEC2/lates
 
 |Property                    | Description|
 | ---                        | --- |
-|volume_ids                 | The unique IDs of the EBS Volumes returned. |
+| attachments | The EBS Volume attachments returned. |
+| availability_zones | The list of availability zones in use by the EBS Volumes. |
+| create_times | The creation times of the EBS Volumes. |
+| encrypted | The list of true/false values indicating whether the EBS Volumes are encrypted. |
+| fast_restored | The list of true/false values indicating whether the EBS Volume was created with a snapshot enabled for fast snapshot restore. |
+| iops | The list of I/O per second for each EBS Volume. |
+| kms_key_ids | The list of ARNs for EBS Volume KMS Keys. |
+| multi_attach_enabled | The list of boolean values indicating whether the EBS Volume is Multi-Attach enabled. |
+| outpost_arns | The list of ARNs of Outposts. |
+| sizes | The list of EBS Volume sizes. |
+| snapshot_ids | The list of snapshots from which EBS Volumes were created. |
+| states | The list of volume states returned. |
+| tags | The list of volume tags returned. |
+| volume_ids | The unique IDs of the EBS Volumes returned. |
+| volume_types | The list of volume types returned |
 |entries                     | Provides access to the raw results of the query, which can be treated as an array of hashes. |
 
 ## Examples

--- a/docs/resources/aws_ebs_volumes.md
+++ b/docs/resources/aws_ebs_volumes.md
@@ -5,16 +5,16 @@ platform: aws
 
 # aws_ebs_volumes
 
-Use the `aws_ebs_volumes` InSpec audit resource to test properties of a collection of AWS EBS volumes.
+Use the `aws_ebs_volumes` InSpec audit resource to test the properties of a collection of AWS EBS volumes.
 
-EBS volumes are persistent block storage volumes for use with Amazon EC2 instances in the AWS Cloud.
+EBS volumes are persistent block storage volumes for Amazon EC2 instances in the AWS Cloud.
 
 ## Syntax
 
- Ensure you have exactly 3 volumes
+ Ensure you have exactly three volumes.
 
     describe aws_ebs_volumes do
-      its('volume_ids.count') { should cmp 3 }
+      its('VOLUME_ID_COUNT') { should cmp 3 }
     end
 
 ## Parameters
@@ -25,34 +25,36 @@ See also the [AWS documentation on EBS](https://docs.aws.amazon.com/AWSEC2/lates
 
 ## Properties
 
-|Property                    | Description|
+| Property                   | Description |
 | ---                        | --- |
-| attachments | The EBS Volume attachments returned. |
-| availability_zones | The list of availability zones in use by the EBS Volumes. |
-| create_times | The creation times of the EBS Volumes. |
-| encrypted | The list of true/false values indicating whether the EBS Volumes are encrypted. |
-| fast_restored | The list of true/false values indicating whether the EBS Volume was created with a snapshot enabled for fast snapshot restore. |
-| iops | The list of I/O per second for each EBS Volume. |
-| kms_key_ids | The list of ARNs for EBS Volume KMS Keys. |
-| multi_attach_enabled | The list of boolean values indicating whether the EBS Volume is Multi-Attach enabled. |
-| outpost_arns | The list of ARNs of Outposts. |
-| sizes | The list of EBS Volume sizes. |
-| snapshot_ids | The list of snapshots from which EBS Volumes were created. |
-| states | The list of volume states returned. |
-| tags | The list of volume tags returned. |
-| volume_ids | The unique IDs of the EBS Volumes returned. |
-| volume_types | The list of volume types returned |
-|entries                     | Provides access to the raw results of the query, which can be treated as an array of hashes. |
+| attachments                | The EBS volume attachments returned. |
+| availability_zones         | The list of availability zones in use by the EBS volumes. |
+| create_times               | The creation times of the EBS volumes. |
+| encrypted                  | The list of true/false values indicating whether the EBS volumes are encrypted. |
+| fast_restored              | The list of true/false values indicating whether the EBS volume is created with a snapshot enabled for fast snapshot restore. |
+| iops                       | The list of I/O per second for each EBS volume. |
+| kms_key_ids                | The list of ARNs for EBS volume KMS keys. |
+| multi_attach_enabled       | The list of boolean values indicating whether the EBS volume is multi-attach enabled. |
+| outpost_arns               | The list of ARNs of outposts. |
+| sizes                      | The list of EBS volume sizes. |
+| snapshot_ids               | The list of snapshots from which EBS volumes are created. |
+| states                     | The list of volume states returned. |
+| tags                       | The list of volume tags returned. |
+| volume_ids                 | The unique IDs of the EBS volumes returned. |
+| volume_types               | The list of volume types returned. |
+| entries                    | Provides access to the raw results of the query, which can be treated as an array of hashes. |
 
 ## Examples
 
 ### Ensure a specific volume exists
 
     describe aws_ebs_volumes do
-      its('volume_ids') { should include 'vol-12345678' }
+      its('VOLUME_IDs') { should include 'VOLUME-12345678' }
     end
 
-### Use the InSpec resource to request the IDs of all EBS volumes, then test in-depth using `aws_ebs_volume` to ensure all volumes are encrypted and have a sensible size.
+### Request the EBS volumes IDs
+
+Test in-depth using `aws_ebs_volume` to ensure all volumes are encrypted and have a sensible size.
 
     aws_ebs_volumes.volume_ids.each do |volume_id|
       describe aws_ebs_volume(volume_id) do
@@ -61,7 +63,6 @@ See also the [AWS documentation on EBS](https://docs.aws.amazon.com/AWSEC2/lates
         its('iops') { should cmp 100 }
       end
     end
-
 
 ## Matchers
 

--- a/libraries/aws_ebs_volumes.rb
+++ b/libraries/aws_ebs_volumes.rb
@@ -14,7 +14,21 @@ class AwsEbsVolumes < AwsResourceBase
   attr_reader :table
 
   FilterTable.create
+             .register_column(:attachments, field: :attachments)
+             .register_column(:availability_zones, field: :availability_zone)
+             .register_column(:create_times, field: :create_time)
+             .register_column(:encrypted, field: :encrypted)
+             .register_column(:kms_key_ids, field: :kms_key_id)
+             .register_column(:outpost_arns, field: :outpost_arn)
+             .register_column(:sizes, field: :size)
+             .register_column(:snapshot_ids, field: :snapshot_id)
+             .register_column(:states, field: :state)
              .register_column(:volume_ids, field: :volume_id)
+             .register_column(:iops, field: :iops)
+             .register_column(:tags, field: :tags)
+             .register_column(:volume_types, field: :volume_type)
+             .register_column(:fast_restored, field: :fast_restored)
+             .register_column(:multi_attach_enabled, field: :multi_attach_enabled)
              .install_filter_methods_on_resource(self, :table)
 
   def initialize(opts = {})
@@ -30,10 +44,26 @@ class AwsEbsVolumes < AwsResourceBase
       catch_aws_errors do
         @api_response = @aws.compute_client.describe_volumes(pagination_options)
       end
-      return [] if !@api_response || @api_response.empty?
+      return volume_rows if !@api_response || @api_response.empty?
 
       @api_response.volumes.map do |volume|
-        volume_rows += [{ volume_id: volume.volume_id }]
+        volume_rows += [{
+          attachments: volume.attachments,
+                        availability_zone: volume.availability_zone,
+                        create_time: volume.create_time,
+                        encrypted: volume.encrypted,
+                        kms_key_id: volume.kms_key_id,
+                        outpost_arn: volume.outpost_arn,
+                        size: volume.size,
+                        snapshot_id: volume.snapshot_id,
+                        state: volume.state,
+                        volume_id: volume.volume_id,
+                        iops: volume.iops,
+                        tags: volume.tags,
+                        volume_type: volume.volume_type,
+                        fast_restored: volume.fast_restored,
+                        multi_attach_enabled: volume.multi_attach_enabled,
+        }]
       end
       break unless @api_response.next_token
       pagination_options = { next_token: @api_response.next_token }

--- a/test/integration/build/outputs.tf
+++ b/test/integration/build/outputs.tf
@@ -38,6 +38,23 @@ output "aws_ebs_volume_id" {
   value = aws_ebs_volume.inspec_ebs_volume.0.id
 }
 
+output "aws_ebs_volume_encrypted" {
+  value = aws_ebs_volume.inspec_encrypted_ebs_volume.0.encrypted
+}
+
+output "aws_ebs_volume_iops" {
+  value = aws_ebs_volume.inspec_encrypted_ebs_volume.0.iops
+}
+
+output "aws_ebs_volume_size" {
+  value = aws_ebs_volume.inspec_encrypted_ebs_volume.0.size
+}
+
+output "aws_ebs_volume_type" {
+  value = aws_ebs_volume.inspec_encrypted_ebs_volume.0.type
+}
+
+
 output "aws_ebs_snapshot_id" {
   value = aws_ebs_snapshot.inspec_ebs_snapshot.0.id
 }

--- a/test/integration/verify/controls/aws_ebs_volumes.rb
+++ b/test/integration/verify/controls/aws_ebs_volumes.rb
@@ -1,4 +1,8 @@
 aws_ebs_volume_id = attribute(:aws_ebs_volume_id, value: '', description: 'The AWS EBS Volume ID.')
+aws_ebs_volume_encrypted = attribute(:aws_ebs_volume_encrypted, value: '', description: 'Whether the AWS EBS Volume is encrypted.')
+aws_ebs_volume_iops = attribute(:aws_ebs_volume_iops, value: '', description: 'The iops settings of the volumes')
+aws_ebs_volume_size = attribute(:aws_ebs_volume_size, value: '', description: 'The size of the ebs volume.')
+aws_ebs_volume_type = attribute(:aws_ebs_volume_type, value: '', description: 'The type of ebs volume.')
 
 title 'Test AWS EBS Volumes in bulk'
 
@@ -10,5 +14,9 @@ control 'aws-ebs-volumes-1.0' do
   describe aws_ebs_volumes do
     it { should exist }
     its ('volume_ids') { should include aws_ebs_volume_id }
+    its ('encrypted') { should include aws_ebs_volume_encrypted }
+    its ('iops') { should include aws_ebs_volume_iops } 
+    its ('sizes') { should include aws_ebs_volume_size }
+    its ('volume_types') { should include aws_ebs_volume_type }
   end
 end

--- a/test/unit/resources/aws_ebs_volumes_test.rb
+++ b/test/unit/resources/aws_ebs_volumes_test.rb
@@ -20,11 +20,33 @@ end
 class AwsEbsVolumesHappyPathTest < Minitest::Test
 
   def setup
+    attachment_state = %w(attaching attached detaching)
+    encrypted = [true, false]
+    volume_id = "ebs-12345"
+    delete_on_termination = [true, false]
+    state = %w(creating available in-use deleting deleted error)
+    volume_type = %w(standard io1 io2 gp2 sc1 st1)
+    fast_restore = [true, false]
+    multi_attach = [true, false]
     data = {}
     data[:method] = :describe_volumes
-    mock_volume = {}
-    mock_volume[:volume_id] = 'vol-012b75749d0b5ceb5'
-    data[:data] = { :volumes => [mock_volume] }
+    @mock_volume = {}
+    @mock_volume[:volume_id] = 'vol-012b75749d0b5ceb5'
+    @mock_volume[:availability_zone] = 'us-east1a'
+    @mock_volume[:create_time] = Time.now.round(0)
+    @mock_volume[:encrypted] = encrypted.sample
+    @mock_volume[:kms_key_id] = 'keyid'
+    @mock_volume[:outpost_arn] = 'arn'
+    @mock_volume[:size] = 10
+    @mock_volume[:snapshot_id] = "snap-123456"
+    @mock_volume[:state] = state.sample
+    @mock_volume[:iops] = 100
+    @mock_volume[:tags] = [{ :key => 'keykey', :value => 'valuevalue' }]
+    @mock_volume[:volume_type] = volume_type.sample
+    @mock_volume[:fast_restored] = fast_restore.sample
+    @mock_volume[:multi_attach_enabled] = multi_attach.sample
+    @mock_volume[:attachments] = [{ :attach_time => Time.now, :device => 'devicename', :instance_id => 'instanceid', :state => attachment_state.sample, :volume_id => volume_id, :delete_on_termination => delete_on_termination.sample }]
+    data[:data] = { :volumes => [@mock_volume] }
     data[:client] = Aws::EC2::Client
     @volumes = AwsEbsVolumes.new(client_args: { stub_responses: true }, stub_data: [data])
   end
@@ -34,7 +56,64 @@ class AwsEbsVolumesHappyPathTest < Minitest::Test
   end
 
   def test_volumes_ids
-    assert_equal(@volumes.volume_ids, ['vol-012b75749d0b5ceb5'])
+    assert_equal(@volumes.volume_ids, [@mock_volume[:volume_id]])
+  end
+
+  def test_attachments
+    assert_equal(@volumes.attachments[0][0].state, @mock_volume[:attachments][0][:state])
+  end
+
+  def test_availability_zones
+    assert_equal(@volumes.availability_zones, [@mock_volume[:availability_zone]])
+  end
+
+  def test_create_time
+    assert_equal(@volumes.create_times, [@mock_volume[:create_time]])
+  end
+
+  def test_encrypted
+    assert_equal(@volumes.encrypted, [@mock_volume[:encrypted]])
+  end
+
+  def test_kms_key_id
+    assert_equal(@volumes.kms_key_ids, [@mock_volume[:kms_key_id]])
+  end
+
+  def test_outpost_arn
+    assert_equal(@volumes.outpost_arns, [@mock_volume[:outpost_arn]])
+  end
+
+  def test_size
+    assert_equal(@volumes.sizes, [@mock_volume[:size]])
+  end
+
+  def test_multi_attach_enabled
+    assert_equal(@volumes.multi_attach_enabled, [@mock_volume[:multi_attach_enabled]])
+  end
+
+  def test_fast_restored
+    assert_equal(@volumes.fast_restored, [@mock_volume[:fast_restored]])
+  end
+
+  def test_fast_restored
+    assert_equal(@volumes.volume_types, [@mock_volume[:volume_type]])
+  end
+
+  def test_tags
+    assert_equal(@volumes.tags[0][0].key, @mock_volume[:tags][0][:key])
+    assert_equal(@volumes.tags[0][0].value, @mock_volume[:tags][0][:value])
+  end
+
+  def test_iops
+    assert_equal(@volumes.iops, [@mock_volume[:iops]])
+  end
+
+  def test_state
+    assert_equal(@volumes.states, [@mock_volume[:state]])
+  end
+
+  def test_snapshot_id
+    assert_equal(@volumes.snapshot_ids, [@mock_volume[:snapshot_id]])
   end
 
   def test_volumes_filtering_not_there


### PR DESCRIPTION
Signed-off-by: Justin Nikles <justin.nikles@sap.com>

### Description

Added attributes to the ebs volumes resource so that additional attributes other than the volume_id can be accessed



### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [x] Documentation provided or updated for resources
- [x] All Integration Tests pass 
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
