### PR TITLE
Fix/ECR infinite loop when 1000+ container registries in account

### DIFF
--- a/libraries/aws_ecr_repositories.rb
+++ b/libraries/aws_ecr_repositories.rb
@@ -59,7 +59,7 @@ class AwsEcrRepositories < AwsResourceBase
         }]
       end
       break unless @api_response.next_token
-      query_params[:next_token] = @api_response.next_token
+      @query_params[:next_token] = @api_response.next_token
     end
     ecr_repositories_rows
   end


### PR DESCRIPTION
### Description

- Found a bug which occurred when an account had more than 1000 ECR repositories, it would get caught in an infinite loop as it did not iterate during pagination correctly. This has now been fixed in this PR.

### Issues Resolved

- See above

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [N/A] New functionality includes integration tests/controls
- [N/A] New Terraform resources
- [N/A] Documentation provided or updated for resources 
- [X] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
