### PR TITLE
Fix title in resource doc

### DIFF
--- a/docs/resources/aws_waf_size_constraint_sets.md
+++ b/docs/resources/aws_waf_size_constraint_sets.md
@@ -1,5 +1,5 @@
 ---
-title: About the aws_waf_size_constraint_set resource
+title: About the aws_waf_size_constraint_sets resource
 platform: aws
 ---
 


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

Fix Markdown title of aws_waf_size_constraint_sets resource

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
