### PR TITLE
Setup sonarscanner

### DIFF
--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -16,3 +16,33 @@ bundle exec rake lint
 
 echo "+++ bundle exec rake test"
 bundle exec rake test
+RAKE_EXIT=$?
+
+# If coverage is enabled, then we need to pick up the coverage/coverage.json file
+if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
+  echo "--- installing sonarscanner"
+  export SONAR_SCANNER_VERSION=4.6.2.2472
+  export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux
+  curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
+  unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
+  export PATH=$SONAR_SCANNER_HOME/bin:$PATH
+  export SONAR_SCANNER_OPTS="-server"
+
+  echo "--- installing vault"
+  export VAULT_VERSION=1.9.3
+  export VAULT_HOME=$HOME/vault
+  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
+  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
+
+  echo "--- fetching Sonar token from vault"
+  export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secret/inspec/sonar)
+
+  echo "--- running sonarscanner"
+  sonar-scanner \
+  -Dsonar.organization=inspec \
+  -Dsonar.projectKey=inspec_inspec-aws \
+  -Dsonar.sources=. \
+  -Dsonar.host.url=https://sonarcloud.io
+fi
+
+exit $RAKE_EXIT

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,7 +9,6 @@ slack:
 pipelines:
  - verify:
     description: Pull Request validation tests
-    public: true
 
 github:
  delete_branch_on_merge: true

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -13,6 +13,7 @@ steps:
   command:
     - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
   expeditor:
+    secrets: true
     executor:
       docker:
         image: ruby:2.7-buster


### PR DESCRIPTION
### Description

Sets up sonarscanner for our CI system, allowing us to collect unit test coverage statistics. 

Before merging this, the verify BK pipeline needs to be deleted (this PR will recreate it as a private pipeline) so that it can access the Chef secrets store.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
