### PR TITLE
RESOURCE-32 Extend buildkite timeout

### DIFF
--- a/.expeditor/coverage.pipeline.yml
+++ b/.expeditor/coverage.pipeline.yml
@@ -1,4 +1,9 @@
 ---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 20
+
 steps:
 
 - label: coverage-ruby-2.7


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AWS](https://github.com/inspec/inspec-aws/CONTRIBUTING.md) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
