### PR TITLE
fixing 'secure transport' function definition

### DIFF
--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -86,7 +86,7 @@ class AwsS3Bucket < AwsResourceBase
   end
 
   def has_secure_transport_enabled?
-    bucket_policy.any? { |s| s.effect == 'Deny' && s.condition == { 'Bool' => { 'aws:SecureTransport'=>'false' } } }
+    bucket_policy.any? { |s| s.effect == 'Deny' && s.condition['Bool']['aws:SecureTransport'] == 'false' }
   end
 
   # below is to preserve the original 'unsupported' function but isn't used in the above

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -86,7 +86,7 @@ class AwsS3Bucket < AwsResourceBase
   end
 
   def has_secure_transport_enabled?
-    bucket_policy.any? { |s| s.effect == 'Deny' && s.condition['Bool']['aws:SecureTransport'] == 'false' }
+    bucket_policy.any? { |s| s.effect == 'Deny' && s.condition && s.condition['Bool'] && s.condition['Bool']['aws:SecureTransport'] && s.condition['Bool']['aws:SecureTransport'] == 'false' }
   end
 
   # below is to preserve the original 'unsupported' function but isn't used in the above


### PR DESCRIPTION
Signed-off-by: Rohit Joshi <rohit.prasad.joshi@sap.com>

### Description

This function defined: 'has_secure_transport_enabled?' checks that effect == 'Deny' and condition block is ''Bool' => { 'aws:SecureTransport'=>'false' }'. However, if there are multiple parameters defined in condition block this function returns false even if 'Bool' => { 'aws:SecureTransport'=>'false' } parameter is present which ideally it should return true. This happens because the current function definition enforces the condition block to only include 'Bool' => { 'aws:SecureTransport'=>'false' }' and does not take into consideration the test case where multiple parameters are defined inside condition block. Hence, the current bugfix just checks for that particular parameter defined in the condition block irrespective of multiple parameters present.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
