### PR TITLE
region="eu-west-1" if LocationConstraint set ="EU"

### DIFF
--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -25,7 +25,7 @@ class AwsS3Bucket < AwsResourceBase
         @region = @aws.storage_client.get_bucket_location(bucket: @bucket_name).location_constraint
         # LocationConstraint "EU" correlates to the region "eu-west-1", but region "EU" does not exist as a "region", only a LocationConstraint
         # this currently is the only Location constraint that can have either of 2 values "EU" or "eu-west-1".  But only "eu-west-1" is a region
-        @region = "eu-west-1" if @region == "EU"
+        @region = 'eu-west-1' if @region == 'EU'
         # Forcing bucket region for future bucket calls to avoid warnings about multiple unnecessary
         # redirects and signing attempts.
         opts[:aws_region] = @region.empty? ? 'us-east-1' : @region

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -23,6 +23,9 @@ class AwsS3Bucket < AwsResourceBase
     catch_aws_errors do
       begin
         @region = @aws.storage_client.get_bucket_location(bucket: @bucket_name).location_constraint
+        # LocationConstraint "EU" correlates to the region "eu-west-1", but region "EU" does not exist as a "region", only a LocationConstraint
+        # this currently is the only Location constraint that can have either of 2 values "EU" or "eu-west-1".  But only "eu-west-1" is a region
+        @region = "eu-west-1" if @region == "EU"
         # Forcing bucket region for future bucket calls to avoid warnings about multiple unnecessary
         # redirects and signing attempts.
         opts[:aws_region] = @region.empty? ? 'us-east-1' : @region


### PR DESCRIPTION
### Description

Currently there is an edge case from AWS documentation(https://docs.aws.amazon.com/general/latest/gr/s3.html - search for "EU "(with a space) in the table), where the Location Constraint value, for the Ireland region, can be set to either of 2 values.  "EU" or "eu-west-1".  Unfortunately, if the Location Constraint is set to "EU", no region exists called "EU".  However, since "EU" Location Constraint only exists for region "eu-west-1" it is possible to set the value of region to "eu-west-1" when encountering Location Constraint "EU". 


### Issues Resolved

When the Location Constraint is set to "EU", the inspec-aws code currently sets the region to the Location Constraint(eg "EU").  However, no region called "EU" exists, which results in name resolution errors( ping s3.eu.amazonaws.com
ping: cannot resolve s3.eu.amazonaws.com: Unknown host).   The issue, is that whilst Location Constraint can have "EU" as a valid entry, no region in AWS exists for "EU".  However, the EU Location Constraint does map to eu-west-1 region, according to AWS documentation, see above description for details

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [N/A] New functionality includes integration tests/controls
- [N/A ] New Terraform resources
- [N/A] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [x ] `rake lint` passes
- [x ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

