### PR TITLE
bugfix for aws_iam_users resource

### DIFF
--- a/libraries/aws_iam_users.rb
+++ b/libraries/aws_iam_users.rb
@@ -44,12 +44,8 @@ class AwsIamUsers < AwsCollectionResourceBase
   def fetch_data
     catch_aws_errors do
       @aws.iam_client.list_users.flat_map do |response|
-        response.users.each_with_object({}) do |user, hash|
-          hash[:username] = user.arn.split('/').last
-          hash[:user_arn] = user.arn
-          hash[:user_id] = user.user_id
-          hash[:password_ever_used?] = user.password_last_used.present?
-          hash[:password_last_used_days_ago] = user.password_last_used.present? ? ((Time.current - user.password_last_used) / (24*60*60)).to_i : 0
+        response.users.each_with_object({}) do |user, array|
+          array << { username: user.arn.split('/').last, user_arn: user.arn, user_id: user.user_id, password_ever_used?: user.password_last_used.present?, password_last_used_days_ago: user.password_last_used.present? ? ((Time.current - user.password_last_used) / (24*60*60)).to_i : 0 }
         end
       end
     end


### PR DESCRIPTION
Signed-off-by: Rohit Joshi <rohit.prasad.joshi@sap.com>

### Description

The bug was initially the hash for one record was getting overwritten with the second one and so on. So the count of iam users was always returned one (which is the last one). Adding a fix for that issue where each result is getting appended to an array.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ x] All Integration Tests pass
- [x ] All Unit Tests pass
- [x ] `rake lint` passes
- [x ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
