### PR TITLE
Adding bucket ownership attribute in s3 bucket resource

### DIFF
--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -47,6 +47,13 @@ class AwsS3Bucket < AwsResourceBase
     end
   end
 
+  def bucket_ownership_controls
+    return [] unless exists? # exists? would throw the same NoSuchBucket error if the bucket name was not valid
+    catch_aws_errors do
+      @bucket_ownership_controls ||= @aws.storage_client.get_bucket_ownership_controls(bucket: @bucket_name).ownership_controls.rules[0].object_ownership
+    end
+  end
+
   def public?
     return false unless exists?
     catch_aws_errors do


### PR DESCRIPTION
### Description

Adding 'bucket ownership controls' attribute in s3 bucket resource

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x ] All Unit Tests pass
- [x ] `rake lint` passes
- [x ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
