### PR TITLE
RESOURCE-376 resource_ids - Storage

### DIFF
--- a/libraries/aws_cloudfront_cache_policy.rb
+++ b/libraries/aws_cloudfront_cache_policy.rb
@@ -34,6 +34,10 @@ class AWSCloudFrontCachePolicy < AwsResourceBase
     !@res.nil? && !@res.empty?
   end
 
+  def resource_id
+    @display_name
+  end
+
   def to_s
     "ID: #{@display_name}"
   end

--- a/libraries/aws_cloudfront_distribution.rb
+++ b/libraries/aws_cloudfront_distribution.rb
@@ -114,6 +114,10 @@ class AwsCloudFrontDistribution < AwsResourceBase
     disallowed?(@custom_origin_ssl_protocols)
   end
 
+  def resource_id
+    @distribution_id
+  end
+
   def to_s
     "AWS CloudFront Distribution #{@distribution_id}"
   end

--- a/libraries/aws_cloudfront_key_group.rb
+++ b/libraries/aws_cloudfront_key_group.rb
@@ -34,6 +34,10 @@ class AwsCloudFrontKeyGroup < AwsResourceBase
     !@resp.nil? && !@resp.empty?
   end
 
+  def resource_id
+    @display_name
+  end
+
   def to_s
     "Key Group ID: #{@display_name}"
   end

--- a/libraries/aws_cloudfront_origin_access_identity.rb
+++ b/libraries/aws_cloudfront_origin_access_identity.rb
@@ -34,6 +34,10 @@ class AWSCloudFrontOriginAccessIdentity < AwsResourceBase
     !@res.nil? && !@res.empty?
   end
 
+  def resource_id
+    @display_name
+  end
+
   def to_s
     "ID: #{@display_name}"
   end

--- a/libraries/aws_cloudfront_origin_request_policy.rb
+++ b/libraries/aws_cloudfront_origin_request_policy.rb
@@ -32,6 +32,10 @@ class AWSCloudFrontOriginRequestPolicy < AwsResourceBase
     !@origin_request_policy.nil? && !@origin_request_policy.empty?
   end
 
+  def resource_id
+    @display_name
+  end
+
   def to_s
     "Origin Request Policy ID: #{@display_name}"
   end

--- a/libraries/aws_cloudfront_public_key.rb
+++ b/libraries/aws_cloudfront_public_key.rb
@@ -34,6 +34,10 @@ class AWSCloudFrontPublicKey < AwsResourceBase
     !@res.nil? && !@res.empty?
   end
 
+  def resource_id
+    @display_name
+  end
+
   def to_s
     "ID: #{@display_name}"
   end

--- a/libraries/aws_cloudfront_realtime_log_config.rb
+++ b/libraries/aws_cloudfront_realtime_log_config.rb
@@ -34,10 +34,6 @@ class AwsCloudFrontRealtimeLogConfig < AwsResourceBase
     !@res.nil? && !@res.empty?
   end
 
-  def to_s
-    "Config Name: #{@display_name}"
-  end
-
   def end_points_stream_types
     end_points.map(&:stream_type)
   end
@@ -48,5 +44,14 @@ class AwsCloudFrontRealtimeLogConfig < AwsResourceBase
 
   def end_points_kinesis_stream_config_stream_arns
     (end_points.map(&:kinesis_stream_config)).map(&:stream_arn)
+  end
+
+  # Here we have used the arn as it is more unique than the name.
+  def resource_id
+    @res[:arn]
+  end
+
+  def to_s
+    "Config Name: #{@display_name}"
   end
 end

--- a/libraries/aws_cloudfront_streaming_distribution.rb
+++ b/libraries/aws_cloudfront_streaming_distribution.rb
@@ -34,10 +34,6 @@ class AWSCloudFrontStreamingDistribution < AwsResourceBase
     !@res.nil? && !@res.empty?
   end
 
-  def to_s
-    "ID: #{@display_name}"
-  end
-
   def active_aws_account_numbers
     (active_trusted_signers.map(&:items)).map(&:aws_account_number)
   end
@@ -48,5 +44,13 @@ class AWSCloudFrontStreamingDistribution < AwsResourceBase
 
   def active_key_pair_id_items
     ((active_trusted_signers.map(&:items)).map(&:key_pair_ids)).map(&:items)
+  end
+
+  def resource_id
+    @display_name
+  end
+
+  def to_s
+    "ID: #{@display_name}"
   end
 end

--- a/libraries/aws_efs_file_system.rb
+++ b/libraries/aws_efs_file_system.rb
@@ -74,6 +74,10 @@ class AwsEfsFileSystem < AwsResourceBase
     @file_system[:encrypted]
   end
 
+  def resource_id
+    @file_system[:file_system_id]
+  end
+
   def to_s
     "EFS File System #{@display_name}"
   end

--- a/libraries/aws_efs_mount_target.rb
+++ b/libraries/aws_efs_mount_target.rb
@@ -5,7 +5,6 @@ require 'aws_backend'
 class AWSEFSMountTarget < AwsResourceBase
   name 'aws_efs_mount_target'
   desc 'Returns the descriptions of all the current mount targets, or a specific mount target, for a file system. When requesting all of the current mount targets, the order of mount targets returned in the response is unspecified.'
-
   example "
     describe aws_efs_mount_target(mount_target_id: 'test') do
       it { should exist }
@@ -16,7 +15,6 @@ class AWSEFSMountTarget < AwsResourceBase
     opts = { mount_target_id: opts } if opts.is_a?(String)
     super(opts)
     validate_parameters(required: [:mount_target_id])
-
     raise ArgumentError, "#{@__resource_name__}: mount_target_id must be provided" unless opts[:mount_target_id] && !opts[:mount_target_id].empty?
     @display_name = opts[:mount_target_id]
     catch_aws_errors do
@@ -33,6 +31,10 @@ class AWSEFSMountTarget < AwsResourceBase
 
   def exists?
     !@mount_targets.nil? && !@mount_targets.empty?
+  end
+
+  def resource_id
+    @display_name
   end
 
   def to_s

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -152,6 +152,10 @@ class AwsS3Bucket < AwsResourceBase
     map_tags(tag_list)
   end
 
+  def resource_id
+    @bucket_name
+  end
+
   def to_s
     "S3 Bucket #{@bucket_name}"
   end

--- a/libraries/aws_s3_bucket_object.rb
+++ b/libraries/aws_s3_bucket_object.rb
@@ -51,7 +51,7 @@ class AwsS3BucketObject < AwsResourceBase
   end
 
   def resource_id
-    @key
+    "#{@bucket_name}_#{@key}"
   end
 
   def to_s

--- a/libraries/aws_s3_bucket_object.rb
+++ b/libraries/aws_s3_bucket_object.rb
@@ -50,6 +50,10 @@ class AwsS3BucketObject < AwsResourceBase
     !@bucket_object.nil?
   end
 
+  def resource_id
+    @key
+  end
+
   def to_s
     "s3://#{@bucket_name}/#{@key}"
   end

--- a/libraries/aws_s3_bucket_policy.rb
+++ b/libraries/aws_s3_bucket_policy.rb
@@ -28,6 +28,10 @@ class AWSS3BucketPolicy < AwsResourceBase
     !@parsed_json.nil? && !@parsed_json.empty?
   end
 
+  def resource_id
+    @display_name
+  end
+
   def to_s
     "S3 Bucket Name: #{@display_name}"
   end

--- a/test/unit/resources/aws_cloudfront_cache_policy_test.rb
+++ b/test/unit/resources/aws_cloudfront_cache_policy_test.rb
@@ -103,4 +103,9 @@ class AWSCloudFrontCachePolicySuccessPathTest < Minitest::Test
   def test_query_string_behavior
     assert_equal(@resp.cache_policy_config.parameters_in_cache_key_and_forwarded_to_origin.query_strings_config.query_string_behavior, 'test1')
   end
+
+  def test_resource_id
+    assert !@resp.resource_id.nil?
+    assert_equal(@resp.resource_id, @resp.id)
+  end
 end

--- a/test/unit/resources/aws_cloudfront_distribution_test.rb
+++ b/test/unit/resources/aws_cloudfront_distribution_test.rb
@@ -97,6 +97,11 @@ class AwsCloudFrontDistributionS3OriginDefaultCertificateTest < Minitest::Test
     refute @cloudfront_distribution.send(:disallowed?, %w{TLSv1.2_2021})
     refute @cloudfront_distribution.send(:disallowed?, %w{TLSV1.2_2018 TLSv1.1 TLSv1.2_2021})
   end
+
+  def test_resource_id
+    assert !@cloudfront_distribution.resource_id.nil?
+    assert_equal(@cloudfront_distribution.resource_id, @cloudfront_distribution.distribution_id)
+  end
 end
 
 class AwsCloudFrontDistributionCustomTest < Minitest::Test
@@ -162,5 +167,10 @@ class AwsCloudFrontDistributionCustomTest < Minitest::Test
     refute @cloudfront_distribution.send(:disallowed?, %w{TLSv1.2_2019})
     refute @cloudfront_distribution.send(:disallowed?, %w{TLSv1.2_2021})
     refute @cloudfront_distribution.send(:disallowed?, %w{TLSv1.2_2021 TLSv1.2_2019 TLSv1.2_2018 TLSv1.2})
+  end
+
+  def test_resource_id
+    assert !@cloudfront_distribution.resource_id.nil?
+    assert_equal(@cloudfront_distribution.resource_id, @cloudfront_distribution.distribution_id)
   end
 end

--- a/test/unit/resources/aws_cloudfront_key_group_test.rb
+++ b/test/unit/resources/aws_cloudfront_key_group_test.rb
@@ -58,4 +58,9 @@ class AwsCloudFrontKeyGroupSuccessPathTest < Minitest::Test
   def test_comment
     assert_equal(@resp.key_group_config.comment, 'test1')
   end
+
+  def test_resource_id
+    assert !@resp.resource_id.nil?
+    assert_equal(@resp.resource_id, @resp.id)
+  end
 end

--- a/test/unit/resources/aws_cloudfront_origin_access_identity_test.rb
+++ b/test/unit/resources/aws_cloudfront_origin_access_identity_test.rb
@@ -55,4 +55,9 @@ class AWSCloudFrontOriginAccessIdentitySuccessPathTest < Minitest::Test
   def test_comment
     assert_equal(@resp.cloud_front_origin_access_identity_config.comment, 'test1')
   end
+
+  def test_resource_id
+    assert !@resp.resource_id.nil?
+    assert_equal(@resp.resource_id, @resp.id)
+  end
 end

--- a/test/unit/resources/aws_cloudfront_origin_request_policy_test.rb
+++ b/test/unit/resources/aws_cloudfront_origin_request_policy_test.rb
@@ -79,4 +79,9 @@ class AWSCloudFrontOriginRequestPolicyHappyPathTest < Minitest::Test
   def test_origin_request_policy_config_query_strings_config_query_string_behavior
     assert_equal(@resp.origin_request_policy_config.query_strings_config.query_string_behavior , 'test1')
   end
+
+  def test_resource_id
+    assert !@resp.resource_id.nil?
+    assert_equal(@resp.resource_id, @resp.id)
+  end
 end

--- a/test/unit/resources/aws_cloudfront_public_key_test.rb
+++ b/test/unit/resources/aws_cloudfront_public_key_test.rb
@@ -63,4 +63,9 @@ class AWSCloudFrontPublicKeyHappyPathTest < Minitest::Test
   def test_comment
     assert_equal(@resp.public_key_config.comment, 'test1')
   end
+
+  def test_resource_id
+    assert !@resp.resource_id.nil?
+    assert_equal(@resp.resource_id, @resp.id)
+  end
 end

--- a/test/unit/resources/aws_cloudfront_realtime_log_config_test.rb
+++ b/test/unit/resources/aws_cloudfront_realtime_log_config_test.rb
@@ -56,4 +56,9 @@ class AwsCloudFrontRealtimeLogConfigSuccessPathTest < Minitest::Test
   def test_fields
     assert_equal(@resp.fields, [])
   end
+
+  def test_resource_id
+    assert !@resp.resource_id.nil?
+    assert_equal(@resp.resource_id, @resp.arn)
+  end
 end

--- a/test/unit/resources/aws_cloudfront_streaming_distribution_test.rb
+++ b/test/unit/resources/aws_cloudfront_streaming_distribution_test.rb
@@ -149,4 +149,9 @@ class AWSCloudFrontStreamingDistributionSuccessPathTest < Minitest::Test
   def test_streaming_distribution_config_enabled
     assert_equal(@resp.streaming_distribution_config.enabled, true)
   end
+
+  def test_resource_id
+    assert !@resp.resource_id.nil?
+    assert_equal(@resp.resource_id, @resp.id)
+  end
 end

--- a/test/unit/resources/aws_efs_file_system_test.rb
+++ b/test/unit/resources/aws_efs_file_system_test.rb
@@ -109,4 +109,9 @@ class AwsEfsFileSystemTest < Minitest::Test
   def test_encrypted
     assert_equal(@file_system.encrypted, @m_f_s[:encrypted])
   end
+
+  def test_resource_id
+    assert !@file_system.resource_id.nil?
+    assert_equal(@file_system.resource_id, @file_system.file_system_id)
+  end
 end

--- a/test/unit/resources/aws_efs_mount_target_test.rb
+++ b/test/unit/resources/aws_efs_mount_target_test.rb
@@ -56,4 +56,9 @@ class AWSEFSMountTargetSuccessPathTest < Minitest::Test
   def test_life_cycle_state
     assert_equal(@mount_targets.life_cycle_state, 'test1')
   end
+
+  def test_resource_id
+    assert !@mount_targets.resource_id.nil?
+    assert_equal(@mount_targets.resource_id, @mount_targets.file_system_id)
+  end
 end

--- a/test/unit/resources/aws_s3_bucket_object_test.rb
+++ b/test/unit/resources/aws_s3_bucket_object_test.rb
@@ -101,7 +101,7 @@ class AwsS3BucketObjecPublicTest < Minitest::Test
   end
 
   def test_resource_id
-    assert_equal(@bucket_object.resource_id, 'public.file')
+    assert_equal(@bucket_object.resource_id, 'public_bucket_public.file')
   end
 
   def test_resource_id_not_nil_check
@@ -154,7 +154,7 @@ class AwsS3BucketObjecPrivateTest < Minitest::Test
   end
 
   def test_resource_id
-    assert_equal(@bucket_object.resource_id, 'private.file')
+    assert_equal(@bucket_object.resource_id, 'private_bucket_private.file')
   end
 
   def test_resource_id_not_nil_check

--- a/test/unit/resources/aws_s3_bucket_object_test.rb
+++ b/test/unit/resources/aws_s3_bucket_object_test.rb
@@ -109,7 +109,7 @@ class AwsS3BucketObjecPublicTest < Minitest::Test
   end
 end
 
-class AwsS3BucketObjecPrivateTest < Minitest::Test
+class AwsS3BucketObjectPrivateTest < Minitest::Test
 
   def setup
     # an empty response from get_object is sufficient in this case for the resource to exist

--- a/test/unit/resources/aws_s3_bucket_object_test.rb
+++ b/test/unit/resources/aws_s3_bucket_object_test.rb
@@ -99,6 +99,14 @@ class AwsS3BucketObjecPublicTest < Minitest::Test
     end
     refute_empty(public_grants)
   end
+
+  def test_resource_id
+    assert_equal(@bucket_object.resource_id, 'public.file')
+  end
+
+  def test_resource_id_not_nil_check
+    assert !@bucket_object.resource_id.nil?
+  end
 end
 
 class AwsS3BucketObjecPrivateTest < Minitest::Test
@@ -143,5 +151,13 @@ class AwsS3BucketObjecPrivateTest < Minitest::Test
       g.grantee.type == 'Group' && g.grantee.uri =~ /AuthenticatedUsers/
     end
     assert_empty(auth_users_grants)
+  end
+
+  def test_resource_id
+    assert_equal(@bucket_object.resource_id, 'private.file')
+  end
+
+  def test_resource_id_not_nil_check
+    assert !@bucket_object.resource_id.nil?
   end
 end

--- a/test/unit/resources/aws_s3_bucket_policy_test.rb
+++ b/test/unit/resources/aws_s3_bucket_policy_test.rb
@@ -32,5 +32,13 @@ class AWSS3BucketPolicySuccessPathTest < Minitest::Test
   def test_s3_policy_exist
     assert @resp.exists?
   end
+
+  def test_resource_id
+    assert_equal(@resp.resource_id, 'test1')
+  end
+
+  def test_resource_id_not_nil_check
+    assert !@resp.resource_id.nil?
+  end
 end
 

--- a/test/unit/resources/aws_s3_bucket_test.rb
+++ b/test/unit/resources/aws_s3_bucket_test.rb
@@ -159,6 +159,14 @@ EOP
   def test_bucket_lifecycle_rules
     assert_equal([], @bucket.bucket_lifecycle_rules)
   end
+
+  def test_resource_id
+    assert_equal(@bucket.resource_id, 'bucket-12345')
+  end
+
+  def test_resource_id_not_nil_check
+    assert !@bucket.resource_id.nil?
+  end
 end
 
 class AwsS3BucketPrivateTest < Minitest::Test
@@ -288,6 +296,14 @@ EOP
   def test_bucket_lifecycle_rules
     assert_equal(365, @bucket.bucket_lifecycle_rules.first.expiration.days)
   end
+
+  def test_resource_id
+    assert_equal(@bucket.resource_id, 'private')
+  end
+
+  def test_resource_id_not_nil_check
+    assert !@bucket.resource_id.nil?
+  end
 end
 
 class AwsS3BucketAuthUsersTest < Minitest::Test
@@ -341,5 +357,4 @@ class AwsS3BucketAuthUsersTest < Minitest::Test
   def test_property_bucket_policy_auth
     assert_empty(@bucket.bucket_policy)
   end
-
 end


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

The following resources are added with the resource_id.

        Amazon S3:
            aws_s3_bucket
            aws_s3_bucket_object
            aws_s3_bucket_policy
        
        CloudFront:
            aws_cloudfront_cache_policy
            aws_cloudfront_distribution
            aws_cloudfront_key_group
            aws_cloudfront_origin_access_identity
            aws_cloudfront_origin_request_policy
            aws_cloudfront_public_key
            aws_cloudfront_realtime_log_config
            aws_cloudfront_streaming_distribution
        
        EFS:
            aws_efs_file_system
            aws_efs_mount_target

### Issues Resolved

NA

### Check List
Please fill the box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
