### PR TITLE
RESOURCE-385 Increase the Timeout Limit of build

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,4 +1,9 @@
 ---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 20
+
 steps:
 
 - label: lint-ruby-3.0


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

We have increased the timeout limit to 20 mins. 

### Issues Resolved

As previously there is no timeout limit, the build was getting failed. And we are getting the error below:

```
# Received cancellation signal, interrupting
--
  | .........🚨 Error: The command exited with status -1
```

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
