### PR TITLE
RESOURCE-446 Add APIGatewayV2 sdk in the library

### DIFF
--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -62,6 +62,7 @@ require 'aws-sdk-securityhub'
 require 'aws-sdk-ses'
 require 'aws-sdk-waf'
 require 'aws-sdk-synthetics'
+require 'aws-sdk-apigatewayv2'
 
 # AWS Inspec Backend Classes
 #
@@ -333,6 +334,10 @@ class AwsConnection
 
   def synthetics_client
     aws_client(Aws::Synthetics::Client)
+  end
+
+  def apigatewayv2_client
+    aws_client(Aws::ApiGatewayV2::Client)
   end
 end
 


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

We have added the apigatewayv2 sdk in the lib. As it was not there earlier. It would be difficult to work on the apigatewayv2 resources. Everytime we have to create it and then there will be merge conflicts. So avoid this, we are creating this PR.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
