### PR TITLE
RESOURCE-472 Removing the lint errors in the rubocop v-1.31

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'bundle'
 # Use Latest Inspec
 gem 'inspec-bin'
 
-gem 'rubocop', '~> 1.3'
+gem 'rubocop', '~> 1.31', require: false
 
 group :test do
   gem "simplecov", "~> 0.21"

--- a/libraries/aws_cloudformation_template.rb
+++ b/libraries/aws_cloudformation_template.rb
@@ -79,7 +79,7 @@ class AWSCloudFormationTemplate < AwsResourceBase
   end
 
   def parameter_constraints_allowed_values
-    (parameters.map(&:parameter_constraints)).map(&:allowed_values)
+    parameters.map(&:parameter_constraints).map(&:allowed_values)
   end
 
   def resource_types

--- a/libraries/aws_cloudfront_realtime_log_config.rb
+++ b/libraries/aws_cloudfront_realtime_log_config.rb
@@ -40,11 +40,11 @@ class AwsCloudFrontRealtimeLogConfig < AwsResourceBase
   end
 
   def end_points_kinesis_stream_config_role_arns
-    (end_points.map(&:kinesis_stream_config)).map(&:role_arn)
+    end_points.map(&:kinesis_stream_config).map(&:role_arn)
   end
 
   def end_points_kinesis_stream_config_stream_arns
-    (end_points.map(&:kinesis_stream_config)).map(&:stream_arn)
+    end_points.map(&:kinesis_stream_config).map(&:stream_arn)
   end
 
   # Here we have used the arn as it is more unique than the name.

--- a/libraries/aws_cloudfront_streaming_distribution.rb
+++ b/libraries/aws_cloudfront_streaming_distribution.rb
@@ -40,15 +40,15 @@ class AWSCloudFrontStreamingDistribution < AwsResourceBase
   end
 
   def active_aws_account_numbers
-    (active_trusted_signers.map(&:items)).map(&:aws_account_number)
+    active_trusted_signers.map(&:items).map(&:aws_account_number)
   end
 
   def active_key_pair_id_quantities
-    ((active_trusted_signers.map(&:items)).map(&:key_pair_ids)).map(&:quantity)
+    active_trusted_signers.map(&:items).map(&:key_pair_ids).map(&:quantity)
   end
 
   def active_key_pair_id_items
-    ((active_trusted_signers.map(&:items)).map(&:key_pair_ids)).map(&:items)
+    active_trusted_signers.map(&:items).map(&:key_pair_ids).map(&:items)
   end
 
   def to_s

--- a/libraries/aws_cloudwatch_anomaly_detector.rb
+++ b/libraries/aws_cloudwatch_anomaly_detector.rb
@@ -51,10 +51,10 @@ class AwsCloudwatchAnomalyDetector < AwsResourceBase
   end
 
   def configuration_start_time
-    (configuration.map(&:excluded_time_ranges)).map(&:start_time)
+    configuration.map(&:excluded_time_ranges).map(&:start_time)
   end
 
   def configuration_end_time
-    (configuration.map(&:excluded_time_ranges)).map(&:end_time)
+    configuration.map(&:excluded_time_ranges).map(&:end_time)
   end
 end

--- a/libraries/aws_ecs_task_definition.rb
+++ b/libraries/aws_ecs_task_definition.rb
@@ -47,7 +47,7 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_repository_credentials_credentials_parameters
-    (container_definitions.map(&:repository_credentials)).map(&:credentials_parameter)
+    container_definitions.map(&:repository_credentials).map(&:credentials_parameter)
   end
 
   def container_definitions_cpus
@@ -71,15 +71,15 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_port_mappings_container_ports
-    (container_definitions.map(&:port_mappings)).map(&:container_port)
+    container_definitions.map(&:port_mappings).map(&:container_port)
   end
 
   def container_definitions_port_mappings_host_ports
-    (container_definitions.map(&:port_mappings)).map(&:host_port)
+    container_definitions.map(&:port_mappings).map(&:host_port)
   end
 
   def container_definitions_port_mappings_protocols
-    (container_definitions.map(&:port_mappings)).map(&:protocol)
+    container_definitions.map(&:port_mappings).map(&:protocol)
   end
 
   def container_definitions_essentials
@@ -99,11 +99,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_environments_names
-    (container_definitions.map(&:environment)).map(&:name)
+    container_definitions.map(&:environment).map(&:name)
   end
 
   def container_definitions_environments_values
-    (container_definitions.map(&:environment)).map(&:value)
+    container_definitions.map(&:environment).map(&:value)
   end
 
   def container_definitions_environment_files
@@ -111,11 +111,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_environment_files_values
-    (container_definitions.map(&:environment_files)).map(&:value)
+    container_definitions.map(&:environment_files).map(&:value)
   end
 
   def container_definitions_environment_files_types
-    (container_definitions.map(&:environment_files)).map(&:type)
+    container_definitions.map(&:environment_files).map(&:type)
   end
 
   def container_definitions_mount_points
@@ -123,15 +123,15 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_mount_points_source_volumes
-    (container_definitions.map(&:mount_points)).map(&:source_volume)
+    container_definitions.map(&:mount_points).map(&:source_volume)
   end
 
   def container_definitions_mount_points_container_paths
-    (container_definitions.map(&:mount_points)).map(&:container_path)
+    container_definitions.map(&:mount_points).map(&:container_path)
   end
 
   def container_definitions_mount_points_read_only
-    (container_definitions.map(&:mount_points)).map(&:read_only)
+    container_definitions.map(&:mount_points).map(&:read_only)
   end
 
   def container_definitions_volumes_froms
@@ -139,11 +139,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_volumes_froms_source_containers
-    (container_definitions.map(&:volumes_from)).map(&:source_container)
+    container_definitions.map(&:volumes_from).map(&:source_container)
   end
 
   def container_definitions_volumes_froms_read_only
-    (container_definitions.map(&:volumes_from)).map(&:read_only)
+    container_definitions.map(&:volumes_from).map(&:read_only)
   end
 
   def container_definitions_linux_parameters
@@ -151,59 +151,59 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_linux_parameters_capabilities_adds
-    (container_definitions.map(&:linux_parameters)).map(&:add)
+    container_definitions.map(&:linux_parameters).map(&:add)
   end
 
   def container_definitions_linux_parameters_capabilities_drops
-    (container_definitions.map(&:linux_parameters)).map(&:drop)
+    container_definitions.map(&:linux_parameters).map(&:drop)
   end
 
   def container_definitions_linux_parameters_capabilities_devices
-    (container_definitions.map(&:linux_parameters)).map(&:devices)
+    container_definitions.map(&:linux_parameters).map(&:devices)
   end
 
   def container_definitions_linux_parameters_capabilities_devices_host_paths
-    ((container_definitions.map(&:linux_parameters)).map(&:devices)).map(&:host_path)
+    container_definitions.map(&:linux_parameters).map(&:devices).map(&:host_path)
   end
 
   def container_definitions_linux_parameters_capabilities_devices_container_paths
-    ((container_definitions.map(&:linux_parameters)).map(&:devices)).map(&:container_path)
+    container_definitions.map(&:linux_parameters).map(&:devices).map(&:container_path)
   end
 
   def container_definitions_linux_parameters_capabilities_devices_permissions
-    ((container_definitions.map(&:linux_parameters)).map(&:devices)).map(&:permissions)
+    container_definitions.map(&:linux_parameters).map(&:devices).map(&:permissions)
   end
 
   def container_definitions_linux_parameters_init_process_enabled
-    (container_definitions.map(&:linux_parameters)).map(&:init_process_enabled)
+    container_definitions.map(&:linux_parameters).map(&:init_process_enabled)
   end
 
   def container_definitions_linux_parameters_shared_memory_sizes
-    (container_definitions.map(&:linux_parameters)).map(&:shared_memory_size)
+    container_definitions.map(&:linux_parameters).map(&:shared_memory_size)
   end
 
   def container_definitions_linux_parameters_tmpfs
-    (container_definitions.map(&:linux_parameters)).map(&:tmpfs)
+    container_definitions.map(&:linux_parameters).map(&:tmpfs)
   end
 
   def container_definitions_linux_parameters_tmpfs_container_paths
-    ((container_definitions.map(&:linux_parameters)).map(&:tmpfs)).map(&:container_path)
+    container_definitions.map(&:linux_parameters).map(&:tmpfs).map(&:container_path)
   end
 
   def container_definitions_linux_parameters_tmpfs_sizes
-    ((container_definitions.map(&:linux_parameters)).map(&:tmpfs)).map(&:size)
+    container_definitions.map(&:linux_parameters).map(&:tmpfs).map(&:size)
   end
 
   def container_definitions_linux_parameters_tmpfs_mount_options
-    ((container_definitions.map(&:linux_parameters)).map(&:tmpfs)).map(&:mount_options)
+    container_definitions.map(&:linux_parameters).map(&:tmpfs).map(&:mount_options)
   end
 
   def container_definitions_linux_parameters_max_swaps
-    (container_definitions.map(&:linux_parameters)).map(&:max_swap)
+    container_definitions.map(&:linux_parameters).map(&:max_swap)
   end
 
   def container_definitions_linux_parameters_swappiness
-    (container_definitions.map(&:linux_parameters)).map(&:swappiness)
+    container_definitions.map(&:linux_parameters).map(&:swappiness)
   end
 
   def container_definitions_secrets
@@ -211,11 +211,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_secrets_names
-    (container_definitions.map(&:secrets)).map(&:name)
+    container_definitions.map(&:secrets).map(&:name)
   end
 
   def container_definitions_secrets_value_froms
-    (container_definitions.map(&:secrets)).map(&:value_from)
+    container_definitions.map(&:secrets).map(&:value_from)
   end
 
   def container_definitions_depends_on
@@ -223,11 +223,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_depends_on_container_names
-    (container_definitions.map(&:depends_on)).map(&:container_name)
+    container_definitions.map(&:depends_on).map(&:container_name)
   end
 
   def container_definitions_depends_on_conditions
-    (container_definitions.map(&:depends_on)).map(&:condition)
+    container_definitions.map(&:depends_on).map(&:condition)
   end
 
   def container_definitions_start_timeouts
@@ -275,11 +275,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_extra_hosts_hostnames
-    (container_definitions.map(&:extra_hosts)).map(&:hostname)
+    container_definitions.map(&:extra_hosts).map(&:hostname)
   end
 
   def container_definitions_extra_hosts_ip_addresses
-    (container_definitions.map(&:extra_hosts)).map(&:ip_address)
+    container_definitions.map(&:extra_hosts).map(&:ip_address)
   end
 
   def container_definitions_docker_security_options
@@ -303,15 +303,15 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_ulimits_names
-    (container_definitions.map(&:ulimits)).map(&:name)
+    container_definitions.map(&:ulimits).map(&:name)
   end
 
   def container_definitions_ulimits_soft_limits
-    (container_definitions.map(&:ulimits)).map(&:soft_limit)
+    container_definitions.map(&:ulimits).map(&:soft_limit)
   end
 
   def container_definitions_ulimits_hard_limits
-    (container_definitions.map(&:ulimits)).map(&:hard_limit)
+    container_definitions.map(&:ulimits).map(&:hard_limit)
   end
 
   def container_definitions_log_configurations
@@ -319,23 +319,23 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_log_configurations_log_drivers
-    (container_definitions.map(&:log_configuration)).map(&:log_driver)
+    container_definitions.map(&:log_configuration).map(&:log_driver)
   end
 
   def container_definitions_log_configurations_options
-    (container_definitions.map(&:log_configuration)).map(&:options)
+    container_definitions.map(&:log_configuration).map(&:options)
   end
 
   def container_definitions_log_configurations_secret_options
-    (container_definitions.map(&:log_configuration)).map(&:secret_options)
+    container_definitions.map(&:log_configuration).map(&:secret_options)
   end
 
   def container_definitions_log_configurations_secret_options_names
-    ((container_definitions.map(&:log_configuration)).map(&:secret_options)).map(&:name)
+    container_definitions.map(&:log_configuration).map(&:secret_options).map(&:name)
   end
 
   def container_definitions_log_configurations_secret_value_froms
-    ((container_definitions.map(&:log_configuration)).map(&:secret_options)).map(&:value_from)
+    container_definitions.map(&:log_configuration).map(&:secret_options).map(&:value_from)
   end
 
   def container_definitions_health_checks
@@ -343,23 +343,23 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_health_checks_commands
-    (container_definitions.map(&:health_check)).map(&:command)
+    container_definitions.map(&:health_check).map(&:command)
   end
 
   def container_definitions_health_checks_intervals
-    (container_definitions.map(&:health_check)).map(&:interval)
+    container_definitions.map(&:health_check).map(&:interval)
   end
 
   def container_definitions_health_checks_timeouts
-    (container_definitions.map(&:health_check)).map(&:timeout)
+    container_definitions.map(&:health_check).map(&:timeout)
   end
 
   def container_definitions_health_checks_retries
-    (container_definitions.map(&:health_check)).map(&:retries)
+    container_definitions.map(&:health_check).map(&:retries)
   end
 
   def container_definitions_health_checks_start_periods
-    (container_definitions.map(&:health_check)).map(&:start_period)
+    container_definitions.map(&:health_check).map(&:start_period)
   end
 
   def container_definitions_system_controls
@@ -367,11 +367,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_system_controls_namespaces
-    (container_definitions.map(&:system_controls)).map(&:namespace)
+    container_definitions.map(&:system_controls).map(&:namespace)
   end
 
   def container_definitions_system_controls_values
-    (container_definitions.map(&:system_controls)).map(&:value)
+    container_definitions.map(&:system_controls).map(&:value)
   end
 
   def container_definitions_resource_requirements
@@ -379,11 +379,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_resource_requirements_values
-    (container_definitions.map(&:resource_requirements)).map(&:value)
+    container_definitions.map(&:resource_requirements).map(&:value)
   end
 
   def container_definitions_resource_requirements_types
-    (container_definitions.map(&:resource_requirements)).map(&:type)
+    container_definitions.map(&:resource_requirements).map(&:type)
   end
 
   def container_definitions_firelens_configurations
@@ -391,11 +391,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def container_definitions_firelens_configurations_types
-    (container_definitions.map(&:firelens_configuration)).map(&:type)
+    container_definitions.map(&:firelens_configuration).map(&:type)
   end
 
   def container_definitions_firelens_configurations_options
-    (container_definitions.map(&:firelens_configuration)).map(&:options)
+    container_definitions.map(&:firelens_configuration).map(&:options)
   end
 
   def volumes_names
@@ -415,23 +415,23 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def volumes_docker_volume_configuration_scopes
-    (volumes.map(&:docker_volume_configuration)).map(&:scope)
+    volumes.map(&:docker_volume_configuration).map(&:scope)
   end
 
   def volumes_docker_volume_configuration_autoprovisions
-    (volumes.map(&:docker_volume_configuration)).map(&:autoprovision)
+    volumes.map(&:docker_volume_configuration).map(&:autoprovision)
   end
 
   def volumes_docker_volume_configuration_drivers
-    (volumes.map(&:docker_volume_configuration)).map(&:driver)
+    volumes.map(&:docker_volume_configuration).map(&:driver)
   end
 
   def volumes_docker_volume_configuration_driver_opts
-    (volumes.map(&:docker_volume_configuration)).map(&:driver_opts)
+    volumes.map(&:docker_volume_configuration).map(&:driver_opts)
   end
 
   def volumes_docker_volume_configuration_labels
-    (volumes.map(&:docker_volume_configuration)).map(&:labels)
+    volumes.map(&:docker_volume_configuration).map(&:labels)
   end
 
   def volumes_efs_volume_configurations
@@ -439,31 +439,31 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def volumes_efs_volume_configuration_file_system_ids
-    (volumes.map(&:efs_volume_configurations)).map(&:file_system_id)
+    volumes.map(&:efs_volume_configurations).map(&:file_system_id)
   end
 
   def volumes_efs_volume_configuration_root_directories
-    (volumes.map(&:efs_volume_configurations)).map(&:root_directory)
+    volumes.map(&:efs_volume_configurations).map(&:root_directory)
   end
 
   def volumes_efs_volume_configuration_transit_encryptions
-    (volumes.map(&:efs_volume_configurations)).map(&:transit_encryption)
+    volumes.map(&:efs_volume_configurations).map(&:transit_encryption)
   end
 
   def volumes_efs_volume_configuration_transit_encryption_ports
-    (volumes.map(&:efs_volume_configurations)).map(&:transit_encryption_port)
+    volumes.map(&:efs_volume_configurations).map(&:transit_encryption_port)
   end
 
   def volumes_efs_volume_configuration_authorization_configs
-    (volumes.map(&:efs_volume_configurations)).map(&:authorization_config)
+    volumes.map(&:efs_volume_configurations).map(&:authorization_config)
   end
 
   def volumes_efs_volume_configuration_authorization_config_access_point_ids
-    ((volumes.map(&:efs_volume_configurations)).map(&:authorization_config)).map(&:access_point_id)
+    volumes.map(&:efs_volume_configurations).map(&:authorization_config).map(&:access_point_id)
   end
 
   def volumes_efs_volume_configuration_authorization_config_iams
-    ((volumes.map(&:efs_volume_configurations)).map(&:authorization_config)).map(&:iam)
+    volumes.map(&:efs_volume_configurations).map(&:authorization_config).map(&:iam)
   end
 
   def volumes_fsx_windows_file_server_volume_configurations
@@ -471,23 +471,23 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def volumes_fsx_windows_file_server_volume_configurations_file_system_ids
-    (volumes.map(&:fsx_windows_file_server_volume_configuration)).map(&:file_system_id)
+    volumes.map(&:fsx_windows_file_server_volume_configuration).map(&:file_system_id)
   end
 
   def volumes_fsx_windows_file_server_volume_configurations_root_directories
-    (volumes.map(&:fsx_windows_file_server_volume_configuration)).map(&:root_directory)
+    volumes.map(&:fsx_windows_file_server_volume_configuration).map(&:root_directory)
   end
 
   def volumes_fsx_windows_file_server_volume_configurations_authorization_configs
-    (volumes.map(&:fsx_windows_file_server_volume_configuration)).map(&:authorization_config)
+    volumes.map(&:fsx_windows_file_server_volume_configuration).map(&:authorization_config)
   end
 
   def volumes_fsx_windows_file_server_volume_configurations_authorization_configs_credentials_parameters
-    ((volumes.map(&:fsx_windows_file_server_volume_configuration)).map(&:authorization_config)).map(&:credentials_parameter)
+    volumes.map(&:fsx_windows_file_server_volume_configuration).map(&:authorization_config).map(&:credentials_parameter)
   end
 
   def volumes_fsx_windows_file_server_volume_configurations_authorization_configs_domains
-    ((volumes.map(&:fsx_windows_file_server_volume_configuration)).map(&:authorization_config)).map(&:domain)
+    volumes.map(&:fsx_windows_file_server_volume_configuration).map(&:authorization_config).map(&:domain)
   end
 
   def requires_attributes_names
@@ -535,11 +535,11 @@ class AWSECSTaskDefinition < AwsResourceBase
   end
 
   def proxy_configuration_properties_names
-    (proxy_configuration.map(&:properties)).map(&:name)
+    proxy_configuration.map(&:properties).map(&:name)
   end
 
   def proxy_configuration_properties_values
-    (proxy_configuration.map(&:properties)).map(&:value)
+    proxy_configuration.map(&:properties).map(&:value)
   end
 
   def resource_id

--- a/libraries/aws_network_firewall_logging_configuration.rb
+++ b/libraries/aws_network_firewall_logging_configuration.rb
@@ -43,14 +43,14 @@ class AWSNetworkFirewallLoggingConfiguration < AwsResourceBase
   end
 
   def logging_configuration_log_destination_configs_log_type
-    (logging_configuration.map(&:log_destination_configs)).map(&:log_type)
+    logging_configuration.map(&:log_destination_configs).map(&:log_type)
   end
 
   def logging_configuration_log_destination_configs_log_destination_type
-    (logging_configuration.map(&:log_destination_configs)).map(&:log_destination_type)
+    logging_configuration.map(&:log_destination_configs).map(&:log_destination_type)
   end
 
   def logging_configuration_log_destination_configs_log_destination
-    (logging_configuration.map(&:log_destination_configs)).map(&:log_destination)
+    logging_configuration.map(&:log_destination_configs).map(&:log_destination)
   end
 end

--- a/libraries/aws_ses_receipt_rule.rb
+++ b/libraries/aws_ses_receipt_rule.rb
@@ -35,83 +35,83 @@ class AWSSESReceiptRule < AwsResourceBase
   end
 
   def s3_action_topic_arns
-    (actions.map(&:s3_action)).map(&:topic_arn)
+    actions.map(&:s3_action).map(&:topic_arn)
   end
 
   def s3_action_bucket_names
-    (actions.map(&:s3_action)).map(&:bucket_name)
+    actions.map(&:s3_action).map(&:bucket_name)
   end
 
   def s3_action_object_key_prefixes
-    (actions.map(&:s3_action)).map(&:object_key_prefix)
+    actions.map(&:s3_action).map(&:object_key_prefix)
   end
 
   def s3_action_kms_key_arns
-    (actions.map(&:s3_action)).map(&:kms_key_arn)
+    actions.map(&:s3_action).map(&:kms_key_arn)
   end
 
   def bounce_action_topic_arns
-    (actions.map(&:bounce_action)).map(&:topic_arn)
+    actions.map(&:bounce_action).map(&:topic_arn)
   end
 
   def bounce_action_smtp_reply_codes
-    (actions.map(&:bounce_action)).map(&:smtp_reply_code)
+    actions.map(&:bounce_action).map(&:smtp_reply_code)
   end
 
   def bounce_action_status_codes
-    (actions.map(&:bounce_action)).map(&:status_code)
+    actions.map(&:bounce_action).map(&:status_code)
   end
 
   def bounce_action_messages
-    (actions.map(&:bounce_action)).map(&:message)
+    actions.map(&:bounce_action).map(&:message)
   end
 
   def bounce_action_senders
-    (actions.map(&:bounce_action)).map(&:sender)
+    actions.map(&:bounce_action).map(&:sender)
   end
 
   def workmail_action_topic_arns
-    (actions.map(&:workmail_action)).map(&:topic_arn)
+    actions.map(&:workmail_action).map(&:topic_arn)
   end
 
   def workmail_action_organization_arns
-    (actions.map(&:workmail_action)).map(&:organization_arn)
+    actions.map(&:workmail_action).map(&:organization_arn)
   end
 
   def lambda_action_topic_arns
-    (actions.map(&:lambda_action)).map(&:topic_arn)
+    actions.map(&:lambda_action).map(&:topic_arn)
   end
 
   def lambda_action_function_arns
-    (actions.map(&:lambda_action)).map(&:function_arn)
+    actions.map(&:lambda_action).map(&:function_arn)
   end
 
   def lambda_action_invocation_types
-    (actions.map(&:lambda_action)).map(&:invocation_type)
+    actions.map(&:lambda_action).map(&:invocation_type)
   end
 
   def stop_action_scopes
-    (actions.map(&:stop_action)).map(&:scope)
+    actions.map(&:stop_action).map(&:scope)
   end
 
   def stop_action_topic_arns
-    (actions.map(&:stop_action)).map(&:topic_arn)
+    actions.map(&:stop_action).map(&:topic_arn)
   end
 
   def add_header_action_header_names
-    (actions.map(&:add_header_action)).map(&:header_name)
+    actions.map(&:add_header_action).map(&:header_name)
   end
 
   def add_header_action_header_values
-    (actions.map(&:add_header_action)).map(&:header_value)
+    actions.map(&:add_header_action).map(&:header_value)
   end
 
   def sns_action_topic_arns
-    (actions.map(&:sns_action)).map(&:topic_arn)
+    actions.map(&:sns_action).map(&:topic_arn)
   end
 
   def sns_action_encodings
-    (actions.map(&:sns_action)).map(&:encoding)
+    actions.map(&:sns_action).map(&:encoding)
   end
 
   def resource_id

--- a/libraries/aws_ses_receipt_rule_set.rb
+++ b/libraries/aws_ses_receipt_rule_set.rb
@@ -34,83 +34,83 @@ class AWSSESReceiptRuleSet < AwsResourceBase
   end
 
   def s3_action_topic_arns
-    (actions.map(&:s3_action)).map(&:topic_arn)
+    actions.map(&:s3_action).map(&:topic_arn)
   end
 
   def s3_action_bucket_names
-    (actions.map(&:s3_action)).map(&:bucket_name)
+    actions.map(&:s3_action).map(&:bucket_name)
   end
 
   def s3_action_object_key_prefixes
-    (actions.map(&:s3_action)).map(&:object_key_prefix)
+    actions.map(&:s3_action).map(&:object_key_prefix)
   end
 
   def s3_action_kms_key_arns
-    (actions.map(&:s3_action)).map(&:kms_key_arn)
+    actions.map(&:s3_action).map(&:kms_key_arn)
   end
 
   def bounce_action_topic_arns
-    (actions.map(&:bounce_action)).map(&:topic_arn)
+    actions.map(&:bounce_action).map(&:topic_arn)
   end
 
   def bounce_action_smtp_reply_codes
-    (actions.map(&:bounce_action)).map(&:smtp_reply_code)
+    actions.map(&:bounce_action).map(&:smtp_reply_code)
   end
 
   def bounce_action_status_codes
-    (actions.map(&:bounce_action)).map(&:status_code)
+    actions.map(&:bounce_action).map(&:status_code)
   end
 
   def bounce_action_messages
-    (actions.map(&:bounce_action)).map(&:message)
+    actions.map(&:bounce_action).map(&:message)
   end
 
   def bounce_action_senders
-    (actions.map(&:bounce_action)).map(&:sender)
+    actions.map(&:bounce_action).map(&:sender)
   end
 
   def workmail_action_topic_arns
-    (actions.map(&:workmail_action)).map(&:topic_arn)
+    actions.map(&:workmail_action).map(&:topic_arn)
   end
 
   def workmail_action_organization_arns
-    (actions.map(&:workmail_action)).map(&:organization_arn)
+    actions.map(&:workmail_action).map(&:organization_arn)
   end
 
   def lambda_action_topic_arns
-    (actions.map(&:lambda_action)).map(&:topic_arn)
+    actions.map(&:lambda_action).map(&:topic_arn)
   end
 
   def lambda_action_function_arns
-    (actions.map(&:lambda_action)).map(&:function_arn)
+    actions.map(&:lambda_action).map(&:function_arn)
   end
 
   def lambda_action_invocation_types
-    (actions.map(&:lambda_action)).map(&:invocation_type)
+    actions.map(&:lambda_action).map(&:invocation_type)
   end
 
   def stop_action_scopes
-    (actions.map(&:stop_action)).map(&:scope)
+    actions.map(&:stop_action).map(&:scope)
   end
 
   def stop_action_topic_arns
-    (actions.map(&:stop_action)).map(&:topic_arn)
+    actions.map(&:stop_action).map(&:topic_arn)
   end
 
   def add_header_action_header_names
-    (actions.map(&:add_header_action)).map(&:header_name)
+    actions.map(&:add_header_action).map(&:header_name)
   end
 
   def add_header_action_header_values
-    (actions.map(&:add_header_action)).map(&:header_value)
+    actions.map(&:add_header_action).map(&:header_value)
   end
 
   def sns_action_topic_arns
-    (actions.map(&:sns_action)).map(&:topic_arn)
+    actions.map(&:sns_action).map(&:topic_arn)
   end
 
   def sns_action_encodings
-    (actions.map(&:sns_action)).map(&:encoding)
+    actions.map(&:sns_action).map(&:encoding)
   end
 
   def resource_id

--- a/libraries/aws_ssm_patch_baseline.rb
+++ b/libraries/aws_ssm_patch_baseline.rb
@@ -48,39 +48,39 @@ class AWSSESPatchBaseline < AwsResourceBase
   end
 
   def patch_filter_keys
-    (global_filters.map(&:patch_filters)).map(&:key)
+    global_filters.map(&:patch_filters).map(&:key)
   end
 
   def patch_filter_values
-    (global_filters.map(&:patch_filters)).map(&:values)
+    global_filters.map(&:patch_filters).map(&:values)
   end
 
   def patch_filter_groups
-    ((approval_rules.map(&:patch_rules)).map(&:patch_filter_group)).map(&:patch_filters)
+    approval_rules.map(&:patch_rules).map(&:patch_filter_group).map(&:patch_filters)
   end
 
   def patch_filter_group_keys
-    (((approval_rules.map(&:patch_rules)).map(&:patch_filter_group)).map(&:patch_filters)).map(&:key)
+    approval_rules.map(&:patch_rules).map(&:patch_filter_group).map(&:patch_filters).map(&:key)
   end
 
   def patch_filter_group_values
-    (((approval_rules.map(&:patch_rules)).map(&:patch_filter_group)).map(&:patch_filters)).map(&:values)
+    approval_rules.map(&:patch_rules).map(&:patch_filter_group).map(&:patch_filters).map(&:values)
   end
 
   def compliance_levels
-    (approval_rules.map(&:patch_rules)).map(&:compliance_level)
+    approval_rules.map(&:patch_rules).map(&:compliance_level)
   end
 
   def approve_after_days
-    (approval_rules.map(&:patch_rules)).map(&:approve_after_days)
+    approval_rules.map(&:patch_rules).map(&:approve_after_days)
   end
 
   def approve_until_dates
-    (approval_rules.map(&:patch_rules)).map(&:approve_until_date)
+    approval_rules.map(&:patch_rules).map(&:approve_until_date)
   end
 
   def enable_non_securities
-    (approval_rules.map(&:patch_rules)).map(&:enable_non_security)
+    approval_rules.map(&:patch_rules).map(&:enable_non_security)
   end
 
   def source_names

--- a/libraries/aws_waf_byte_match_set.rb
+++ b/libraries/aws_waf_byte_match_set.rb
@@ -43,11 +43,11 @@ class AWSWAFByteMatchSet < AwsResourceBase
   end
 
   def byte_match_tuples_field_to_match_types
-    (byte_match_tuples.map(&:field_to_match)).map(&:type)
+    byte_match_tuples.map(&:field_to_match).map(&:type)
   end
 
   def byte_match_tuples_field_to_match_data
-    (byte_match_tuples.map(&:field_to_match)).map(&:data)
+    byte_match_tuples.map(&:field_to_match).map(&:data)
   end
 
   def byte_match_tuples_target_strings

--- a/libraries/aws_waf_size_constraint_set.rb
+++ b/libraries/aws_waf_size_constraint_set.rb
@@ -39,11 +39,11 @@ class AWSWAFSizeConstraintSet < AwsResourceBase
   end
 
   def size_constraints_field_to_match_types
-    (size_constraints.map(&:field_to_match)).map(&:type)
+    size_constraints.map(&:field_to_match).map(&:type)
   end
 
   def size_constraints_field_to_match_data
-    (size_constraints.map(&:field_to_match)).map(&:data)
+    size_constraints.map(&:field_to_match).map(&:data)
   end
 
   def size_constraints_text_transformations

--- a/libraries/aws_waf_sql_injection_match_set.rb
+++ b/libraries/aws_waf_sql_injection_match_set.rb
@@ -39,11 +39,11 @@ class AWSWAFSQLInjectionMatchSet < AwsResourceBase
   end
 
   def sql_injection_match_tuples_field_to_match_types
-    (sql_injection_match_tuples.map(&:field_to_match)).map(&:type)
+    sql_injection_match_tuples.map(&:field_to_match).map(&:type)
   end
 
   def sql_injection_match_tuples_field_to_match_data
-    (sql_injection_match_tuples.map(&:field_to_match)).map(&:data)
+    sql_injection_match_tuples.map(&:field_to_match).map(&:data)
   end
 
   def sql_injection_match_tuples_text_transformations

--- a/libraries/aws_waf_web_acl.rb
+++ b/libraries/aws_waf_web_acl.rb
@@ -51,7 +51,7 @@ class AWSWAFWebACL < AwsResourceBase
   end
 
   def rules_action_types
-    (rules.map(&:action)).map(&:type)
+    rules.map(&:action).map(&:type)
   end
 
   def rules_override_actions
@@ -59,7 +59,7 @@ class AWSWAFWebACL < AwsResourceBase
   end
 
   def rules_override_action_types
-    (rules.map(&:override_action)).map(&:type)
+    rules.map(&:override_action).map(&:type)
   end
 
   def rules_types
@@ -71,7 +71,7 @@ class AWSWAFWebACL < AwsResourceBase
   end
 
   def rules_excluded_rules_rule_ids
-    (rules.map(&:excluded_rules)).map(&:rule_id)
+    rules.map(&:excluded_rules).map(&:rule_id)
   end
 
   def resource_id

--- a/libraries/aws_waf_xss_match_set.rb
+++ b/libraries/aws_waf_xss_match_set.rb
@@ -39,11 +39,11 @@ class AWSWAFXSSMatchSet < AwsResourceBase
   end
 
   def xss_match_tuples_field_to_match_types
-    (xss_match_tuples.map(&:field_to_match)).map(&:type)
+    xss_match_tuples.map(&:field_to_match).map(&:type)
   end
 
   def xss_match_tuples_field_to_match_data
-    (xss_match_tuples.map(&:field_to_match)).map(&:data)
+    xss_match_tuples.map(&:field_to_match).map(&:data)
   end
 
   def xss_match_tuples_text_transformations


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

Previously the rubocop version was 1.25. Now in the buildkite, the rubocop version changed to 1.31. The problem was that some of the library files were failing in the newer version of the rubocop. 

So we have updated the rubocop version in the local and then checked. Also, we have modified the changes in the libraries directory. 

Now the lint error is fixed with the newer version of the rubocop.

### Issues Resolved

List any existing issues this PR resolves or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill a box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
