### PR TITLE
RESOURCE-558 Remove the impact from the controls in inspec-aws

### DIFF
--- a/test/integration/verify/controls/aws_alb.rb
+++ b/test/integration/verify/controls/aws_alb.rb
@@ -4,7 +4,6 @@ aws_alb_arn = input(:aws_alb_arn, value: '', description: 'The AWS ALB arn.')
 region = input(:aws_region, value: '', description: 'The AWS region.')
 
 control 'aws-alb-1.0' do
-  impact 1.0
   title 'Ensure AWS ALB has the correct properties.'
 
   describe aws_alb(load_balancer_arn: aws_alb_arn) do

--- a/test/integration/verify/controls/aws_albs.rb
+++ b/test/integration/verify/controls/aws_albs.rb
@@ -3,7 +3,6 @@ title 'Test AWS ALBs'
 aws_alb_arn = input(:aws_alb_arn, value: '', description: 'The AWS ALB arn.')
 
 control 'aws-albs-1.0' do
-  impact 1.0
   title 'Ensure AWS ALBs have the correct properties.'
 
   describe aws_albs do

--- a/test/integration/verify/controls/aws_ami.rb
+++ b/test/integration/verify/controls/aws_ami.rb
@@ -1,7 +1,6 @@
 title 'Test a single AWS AMI'
 
 control 'aws-ami-1.0' do
-  impact 1.0
   title 'Ensure AWS AMI has current properties'
 
   describe aws_ami(image_id: '000000') do

--- a/test/integration/verify/controls/aws_amis.rb
+++ b/test/integration/verify/controls/aws_amis.rb
@@ -1,7 +1,6 @@
 title 'Test AWS AMIs in bulk'
 
 control 'aws-amis-1.0' do
-  impact 1.0
   title 'Ensure AWS AMI has current properties'
 
   aws_amis(architecture: 'i386', platform_details: 'Linux/UNIX', is_public: true, hypervisor: 'ovm').where { state == 'available' }.image_ids.each do |image|

--- a/test/integration/verify/controls/aws_amplify_app.rb
+++ b/test/integration/verify/controls/aws_amplify_app.rb
@@ -3,7 +3,6 @@ app_id = input(:app_id, value: "", description: "")
 title 'Audits Amplify App.'
 
 control 'aws_amplify_app-1.0' do
-  impact 1.0
   title 'Ensure Amplify App have the correct properties.'
   
   describe aws_amplify_app(app_id: app_id) do

--- a/test/integration/verify/controls/aws_amplify_apps.rb
+++ b/test/integration/verify/controls/aws_amplify_apps.rb
@@ -3,7 +3,6 @@ app_id = input(:app_id, value: '', description: '')
 title 'Audits Amplify Apps.'
 
 control 'aws_amplify_apps-1.0' do
-  impact 1.0
   title 'Ensure all Amplify App have the correct properties.'
   
   describe aws_amplify_apps do

--- a/test/integration/verify/controls/aws_amplify_branch.rb
+++ b/test/integration/verify/controls/aws_amplify_branch.rb
@@ -4,7 +4,6 @@ branch_name = input(:branch_name, value: '', description: '')
 title 'Ensure Amplify App have the correct properties.'
 
 control 'aws_amplify_branch-1.0' do
-  impact 1.0
   title 'Ensure Amplify App have the correct properties.'
 
   describe aws_amplify_branch(app_id: app_id, branch_name: branch_name) do

--- a/test/integration/verify/controls/aws_amplify_branches.rb
+++ b/test/integration/verify/controls/aws_amplify_branches.rb
@@ -4,7 +4,6 @@ branch_name = input(:branch_name, value: '', description: '')
 title 'Ensure all Amplify App have the correct properties.'
 
 control 'aws_amplify_branches-1.0' do
-  impact 1.0
   title 'Ensure all Amplify App have the correct properties.'
 
   describe aws_amplify_branches(app_id: app_id) do

--- a/test/integration/verify/controls/aws_api_gateway_deployment.rb
+++ b/test/integration/verify/controls/aws_api_gateway_deployment.rb
@@ -2,7 +2,6 @@ aws_api_gateway_deployement_id = input(:aws_api_gateway_deployement_id, value: '
 aws_api_gateway_rest_api_id_test = input(:aws_api_gateway_rest_api_id_test, value: '', description: '')
 
 control 'aws-api-gateway-deployment-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway deployment.'
 
   describe aws_api_gateway_deployment(rest_api_id: aws_api_gateway_rest_api_id_test, deployment_id: aws_api_gateway_deployement_id) do

--- a/test/integration/verify/controls/aws_api_gateway_deployments.rb
+++ b/test/integration/verify/controls/aws_api_gateway_deployments.rb
@@ -2,7 +2,6 @@ aws_api_gateway_deployement_id = input(:aws_api_gateway_deployement_id, value: '
 aws_api_gateway_rest_api_id_test = input(:aws_api_gateway_rest_api_id_test, value: '', description: '')
 
 control 'aws-api-gateway-deployments-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway deployments.'
 
   describe aws_api_gateway_deployments(rest_api_id: aws_api_gateway_rest_api_id_test) do

--- a/test/integration/verify/controls/aws_api_gateway_documentation_part.rb
+++ b/test/integration/verify/controls/aws_api_gateway_documentation_part.rb
@@ -5,7 +5,6 @@ start_index = documentation_part_id.index("/")
 aws_api_gateway_documentation_part_id = documentation_part_id[start_index..]
 
 control 'aws-api-gateway-documentation-part-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway documentation part.'
 
   describe aws_api_gateway_documentation_part(rest_api_id: aws_api_gateway_rest_api_id, documentation_part_id: aws_api_gateway_documentation_part_id) do

--- a/test/integration/verify/controls/aws_api_gateway_documentation_parts.rb
+++ b/test/integration/verify/controls/aws_api_gateway_documentation_parts.rb
@@ -5,7 +5,6 @@ start_index = documentation_part_id.index("/")
 aws_api_gateway_documentation_part_id = documentation_part_id[start_index..]
 
 control 'aws-api-gateway-documentation-parts-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway documentation parts.'
 
   describe aws_api_gateway_documentation_parts(rest_api_id: aws_api_gateway_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_documentation_version.rb
+++ b/test/integration/verify/controls/aws_api_gateway_documentation_version.rb
@@ -5,7 +5,6 @@ start_index = documentation_version_id.index("/")
 aws_api_gateway_documentation_version_id = documentation_version_id[start_index..]
 
 control 'aws-api-gateway-documentation-version-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway documentation version.'
 
   describe aws_api_gateway_documentation_version(rest_api_id: aws_api_gateway_rest_api_id, documentation_version: aws_api_gateway_documentation_version_id) do

--- a/test/integration/verify/controls/aws_api_gateway_documentation_versions.rb
+++ b/test/integration/verify/controls/aws_api_gateway_documentation_versions.rb
@@ -5,7 +5,6 @@ start_index = documentation_version_id.index("/")
 aws_api_gateway_documentation_version_id = documentation_version_id[start_index..]
 
 control 'aws-api-gateway-documentation-versions-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway documentation versions.'
 
   describe aws_api_gateway_documentation_versions(rest_api_id: aws_api_gateway_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_domain_name.rb
+++ b/test/integration/verify/controls/aws_api_gateway_domain_name.rb
@@ -13,7 +13,6 @@ aws_api_gateway_domain_name_status_message = input(:aws_api_gateway_domain_name_
 aws_api_gateway_security_policy = input(:aws_api_gateway_security_policy, value: 'TLS_1_2', description: '')
 
 control 'aws-api-gateway-domain-name-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway domain name.'
   
   describe aws_api_gateway_domain_name(domain_name: aws_api_gateway_domain_name) do

--- a/test/integration/verify/controls/aws_api_gateway_domain_names.rb
+++ b/test/integration/verify/controls/aws_api_gateway_domain_names.rb
@@ -13,7 +13,6 @@ aws_api_gateway_domain_name_status_message = input(:aws_api_gateway_domain_name_
 aws_api_gateway_security_policy = input(:aws_api_gateway_security_policy, value: 'TLS_1_2', description: '')
 
 control 'aws-api-gateway-domain-names-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway domain names.'
   
   describe aws_api_gateway_domain_names do

--- a/test/integration/verify/controls/aws_api_gateway_method.rb
+++ b/test/integration/verify/controls/aws_api_gateway_method.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-api-gateway-method-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway method.'
   
   describe aws_api_gateway_method(rest_api_id: '', resource_id: '', http_method: 'GET') do

--- a/test/integration/verify/controls/aws_api_gateway_methods.rb
+++ b/test/integration/verify/controls/aws_api_gateway_methods.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-api-gateway-method-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway method.'
   
   describe aws_api_gateway_methods(rest_api_id: '', resource_id: '', http_method: 'GET') do

--- a/test/integration/verify/controls/aws_api_gateway_model.rb
+++ b/test/integration/verify/controls/aws_api_gateway_model.rb
@@ -5,7 +5,6 @@ aws_api_gateway_model_description = input(:aws_api_gateway_model_description, va
 aws_api_gateway_model_rest_api_id = input(:aws_api_gateway_model_rest_api_id, value: '', description: '')
 
 control 'aws-api-gateway-model-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway model.'
 
   describe aws_api_gateway_model(rest_api_id: aws_api_gateway_model_rest_api_id, model_name: aws_api_gateway_model_name) do

--- a/test/integration/verify/controls/aws_api_gateway_models.rb
+++ b/test/integration/verify/controls/aws_api_gateway_models.rb
@@ -5,7 +5,6 @@ aws_api_gateway_model_description = input(:aws_api_gateway_model_description, va
 aws_api_gateway_model_rest_api_id = input(:aws_api_gateway_model_rest_api_id, value: '', description: '')
 
 control 'aws-api-gateway-models-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway models.'
 
   describe aws_api_gateway_models(rest_api_id: aws_api_gateway_model_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_request_validator.rb
+++ b/test/integration/verify/controls/aws_api_gateway_request_validator.rb
@@ -5,7 +5,6 @@ aws_api_gateway_request_validator_validate_request_body = input(:aws_api_gateway
 aws_api_gateway_request_validator_validate_request_parameters = input(:aws_api_gateway_request_validator_validate_request_body, value: false, description: '')
 
 control 'aws-api-gateway-request-validator-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway request validator.'
 
   describe aws_api_gateway_request_validator(rest_api_id: aws_api_gateway_request_validator_rest_api_id, request_validator_id: aws_api_gateway_request_validator_id) do

--- a/test/integration/verify/controls/aws_api_gateway_request_validators.rb
+++ b/test/integration/verify/controls/aws_api_gateway_request_validators.rb
@@ -5,7 +5,6 @@ aws_api_gateway_request_validator_validate_request_body = input(:aws_api_gateway
 aws_api_gateway_request_validator_validate_request_parameters = input(:aws_api_gateway_request_validator_validate_request_body, value: false, description: '')
 
 control 'aws-api-gateway-request-validators-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway request validators.'
 
   describe aws_api_gateway_request_validators(rest_api_id: aws_api_gateway_request_validator_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_resource.rb
+++ b/test/integration/verify/controls/aws_api_gateway_resource.rb
@@ -5,7 +5,6 @@ aws_api_gateway_resource_path = input(:aws_api_gateway_resource_path, value: '',
 aws_api_gateway_resource_path_part = input(:aws_api_gateway_resource_path_part, value: '', description: 'The last path segment for this resource.')
 
 control 'aws-api-gateway-resource-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway resource.'
 
   describe aws_api_gateway_resource(rest_api_id: aws_api_gateway_rest_api_id, resource_id: aws_api_gateway_resource_id) do

--- a/test/integration/verify/controls/aws_api_gateway_resources.rb
+++ b/test/integration/verify/controls/aws_api_gateway_resources.rb
@@ -5,7 +5,6 @@ aws_api_gateway_resource_path = input(:aws_api_gateway_resource_path, value: '',
 aws_api_gateway_resource_path_part = input(:aws_api_gateway_resource_path_part, value: '', description: 'The last path segment for this resource.')
 
 control 'aws-api-gateway-resources-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway resources.'
 
   describe aws_api_gateway_resources(rest_api_id: aws_api_gateway_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_response.rb
+++ b/test/integration/verify/controls/aws_api_gateway_response.rb
@@ -2,7 +2,6 @@ aws_api_gateway_gateway_response_response_type = input(:aws_api_gateway_gateway_
 aws_api_gateway_gateway_response_rest_api_id = input(:aws_api_gateway_gateway_response_rest_api_id, value: '', description: '')
 
 control 'aws-api-gateway-response-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway response.'
 
   describe aws_api_gateway_response(rest_api_id: aws_api_gateway_gateway_response_rest_api_id, response_type: aws_api_gateway_gateway_response_response_type) do

--- a/test/integration/verify/controls/aws_api_gateway_responses.rb
+++ b/test/integration/verify/controls/aws_api_gateway_responses.rb
@@ -2,7 +2,6 @@ aws_api_gateway_gateway_response_response_type = input(:aws_api_gateway_gateway_
 aws_api_gateway_gateway_response_rest_api_id = input(:aws_api_gateway_gateway_response_rest_api_id, value: '', description: '')
 
 control 'aws-api-gateway-responses-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway responses.'
 
   describe aws_api_gateway_responses(rest_api_id: aws_api_gateway_gateway_response_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_restapi.rb
+++ b/test/integration/verify/controls/aws_api_gateway_restapi.rb
@@ -1,7 +1,6 @@
 aws_api_gateway_rest_api_id = input(:aws_api_gateway_rest_api_id, value: '', description: '')
 
 control 'aws-api-gateway-restapi-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway restapi.'
 
   describe aws_api_gateway_restapi(rest_api_id: aws_api_gateway_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_restapis.rb
+++ b/test/integration/verify/controls/aws_api_gateway_restapis.rb
@@ -1,7 +1,6 @@
 aws_api_gateway_rest_api_id = input(:aws_api_gateway_rest_api_id, value: '', description: '')
 
 control 'aws-api-gateway-restapis-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway restapis.'
 
   describe aws_api_gateway_restapis do

--- a/test/integration/verify/controls/aws_api_gateway_stage.rb
+++ b/test/integration/verify/controls/aws_api_gateway_stage.rb
@@ -4,7 +4,6 @@ aws_api_gateway_client_certificate_id = input(:aws_api_gateway_client_certificat
 aws_api_gateway_rest_api_id = input(:aws_api_gateway_rest_api_id_test, value: '', description: '')
 
 control 'aws-apigateway-stage' do
-  impact 1.0
   title 'Ensure API Gateway Stage resource has the correct properties.'
 
   describe aws_api_gateway_stage(rest_api_id: aws_api_gateway_rest_api_id, stage_name: aws_api_gateway_stage_name) do

--- a/test/integration/verify/controls/aws_api_gateway_stages.rb
+++ b/test/integration/verify/controls/aws_api_gateway_stages.rb
@@ -4,7 +4,6 @@ aws_api_gateway_client_certificate_id = input(:aws_api_gateway_client_certificat
 aws_api_gateway_rest_api_id = input(:aws_api_gateway_rest_api_id_test, value: '', description: '')
 
 control 'aws-apigateway-stages' do
-  impact 1.0
   title 'Ensure API Gateway Stages resource has the correct properties.'
 
   describe aws_api_gateway_stages(rest_api_id: aws_api_gateway_rest_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_usage_plan.rb
+++ b/test/integration/verify/controls/aws_api_gateway_usage_plan.rb
@@ -4,7 +4,6 @@ aws_api_gateway_usage_plan_description = input(:aws_api_gateway_usage_plan_descr
 aws_api_gateway_usage_plan_product_code = input(:aws_api_gateway_usage_plan_product_code, value: '', description: '')
 
 control 'aws-api-gateway-usage-plan-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway usage plan.'
 
   describe aws_api_gateway_usage_plan(usage_plan_id: aws_api_gateway_usage_plan_id) do

--- a/test/integration/verify/controls/aws_api_gateway_usage_plan_key.rb
+++ b/test/integration/verify/controls/aws_api_gateway_usage_plan_key.rb
@@ -5,7 +5,6 @@ aws_api_gateway_usage_plan_key_name = attribute(:aws_api_gateway_usage_plan_key_
 aws_api_gateway_usage_plan_key_value = attribute(:aws_api_gateway_usage_plan_key_value, value: '', description: '')
 
 control 'aws-api-gateway-usage-plan-key-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway usage plan key.'
 
   describe aws_api_gateway_usage_plan_key(usage_plan_id: aws_api_gateway_usage_plan_id, key_id: aws_api_gateway_usage_plan_key_id) do

--- a/test/integration/verify/controls/aws_api_gateway_usage_plan_keys.rb
+++ b/test/integration/verify/controls/aws_api_gateway_usage_plan_keys.rb
@@ -5,7 +5,6 @@ aws_api_gateway_usage_plan_key_name = attribute(:aws_api_gateway_usage_plan_key_
 aws_api_gateway_usage_plan_key_value = attribute(:aws_api_gateway_usage_plan_key_value, value: '', description: '')
 
 control 'aws-api-gateway-usage-plan-keys-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway usage plan keys.'
 
   describe aws_api_gateway_usage_plan_keys(usage_plan_id: aws_api_gateway_usage_plan_id) do

--- a/test/integration/verify/controls/aws_api_gateway_usage_plans.rb
+++ b/test/integration/verify/controls/aws_api_gateway_usage_plans.rb
@@ -4,7 +4,6 @@ aws_api_gateway_usage_plan_description = input(:aws_api_gateway_usage_plan_descr
 aws_api_gateway_usage_plan_product_code = input(:aws_api_gateway_usage_plan_product_code, value: '', description: '')
 
 control 'aws-api-gateway-usage-plans-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway usage plans.'
 
   describe aws_api_gateway_usage_plans do

--- a/test/integration/verify/controls/aws_api_gateway_v2_api.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_api.rb
@@ -8,7 +8,6 @@ aws_apigatewayv2_api_protocol_type = attribute(:aws_apigatewayv2_api_protocol_ty
 aws_apigatewayv2_api_route_selection_expression = attribute(:aws_apigatewayv2_api_route_selection_expression, value: '', description: '')
 
 control 'aws-api-gateway-v2-api' do
-  impact 1.0
   title 'Ensure API Gateway API resource has the correct properties.'
   
   describe aws_api_gateway_v2_api(api_id: aws_apigatewayv2_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_api_mapping.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_api_mapping.rb
@@ -5,7 +5,6 @@ aws_apigatewayv2_api_mapping_api_mapping_key = input(:aws_apigatewayv2_api_mappi
 aws_apigatewayv2_api_mapping_stage = input(:aws_apigatewayv2_api_mapping_stage, value: '', description: '')
 
 control 'aws-api-gateway-v2-api-mapping' do
-  impact 1.0
   title 'Ensure API Gateway API Mapping resource has the correct properties.'
   
   describe aws_api_gateway_v2_api_mapping(api_mapping_id: aws_apigatewayv2_api_mapping_id, domain_name: aws_apigatewayv2_api_mapping_domain_name) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_api_mappings.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_api_mappings.rb
@@ -5,7 +5,6 @@ aws_apigatewayv2_api_mapping_api_mapping_key = input(:aws_apigatewayv2_api_mappi
 aws_apigatewayv2_api_mapping_stage = input(:aws_apigatewayv2_api_mapping_stage, value: '', description: '')
 
 control 'aws-api-gateway-v2-api-mappings' do
-  impact 1.0
   title 'Ensure API Gateway API Mappings resource has the correct properties.'
   
   describe aws_api_gateway_v2_api_mappings(domain_name: aws_apigatewayv2_api_mapping_domain_name) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_apis.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_apis.rb
@@ -8,7 +8,6 @@ aws_apigatewayv2_api_protocol_type = attribute(:aws_apigatewayv2_api_protocol_ty
 aws_apigatewayv2_api_route_selection_expression = attribute(:aws_apigatewayv2_api_route_selection_expression, value: '', description: '')
 
 control 'aws-api-gateway-v2-apis' do
-  impact 1.0
   title 'Ensure API Gateway APIs resource has the correct properties.'
   
   describe aws_api_gateway_v2_apis do

--- a/test/integration/verify/controls/aws_api_gateway_v2_authorizer.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_authorizer.rb
@@ -7,7 +7,6 @@ aws_apigatewayv2_authorizer_jwt_configuration_issuer = input(:aws_apigatewayv2_a
 aws_apigatewayv2_authorizer_name = input(:aws_apigatewayv2_authorizer_name, value: '', description: 'The authorizer name.')
 
 control 'aws-api-gateway-v2-api-authorizer' do
-  impact 1.0
   title 'Ensure API Gateway API Authorizer resource has the correct properties.'
   
   describe aws_api_gateway_v2_authorizer(api_id: aws_apigatewayv2_authorizer_api_id, authorizer_id: aws_apigatewayv2_authorizer_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_authorizers.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_authorizers.rb
@@ -5,7 +5,6 @@ aws_apigatewayv2_authorizer_identity_sources = input(:aws_apigatewayv2_authorize
 aws_apigatewayv2_authorizer_name = input(:aws_apigatewayv2_authorizer_name, value: '', description: 'The authorizer name.')
 
 control 'aws-api-gateway-v2-api-authorizers' do
-  impact 1.0
   title 'Ensure API Gateway API Authorizers resource has the correct properties.'
   
   describe aws_api_gateway_v2_authorizers(api_id: aws_apigatewayv2_authorizer_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_deployment.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_deployment.rb
@@ -6,7 +6,6 @@ aws_apigatewayv2_deployment_description = input(:aws_apigatewayv2_deployment_des
 aws_apigatewayv2_deployment_id = input(:aws_apigatewayv2_deployment_id, value: '', description: '')
 
 control 'aws-api-gateway-v2-deployment-v1.0.0' do
-  impact 1.0
   title 'Ensure API Gateway API Deployment resource has the correct properties.'
   desc 'Ensure API Gateway API Deployment resource has the correct properties.'
 

--- a/test/integration/verify/controls/aws_api_gateway_v2_deployments.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_deployments.rb
@@ -6,7 +6,6 @@ aws_apigatewayv2_deployment_description = input(:aws_apigatewayv2_deployment_des
 aws_apigatewayv2_deployment_id = input(:aws_apigatewayv2_deployment_id, value: '', description: '')
 
 control 'aws-api-gateway-v2-deployments-v1.0.0' do
-  impact 1.0
   title 'Ensure API Gateway API Deployments resource has the correct properties.'
   desc 'Ensure API Gateway API Deployments resource has the correct properties.'
   

--- a/test/integration/verify/controls/aws_api_gateway_v2_domain_name.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_domain_name.rb
@@ -7,7 +7,6 @@ aws_apigatewayv2_domain_name_security_policy = input(:aws_apigatewayv2_domain_na
 aws_apigatewayv2_domain_name_target_domain_name = input(:aws_apigatewayv2_domain_name_target_domain_name, value: '', description: '')
 
 control 'aws-api-gateway-v2-domain-name' do
-  impact 1.0
   title 'Ensure API Gateway API Domain Name resource has the correct properties.'
 
   describe aws_api_gateway_v2_domain_name(domain_name: aws_apigatewayv2_domain_name_domain_name) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_domain_names.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_domain_names.rb
@@ -1,7 +1,6 @@
 aws_apigatewayv2_domain_name_domain_name = input(:aws_apigatewayv2_domain_name_domain_name, value: '', description: '')
 
 control 'aws-api-gateway-v2-domain-names' do
-  impact 1.0
   title 'Ensure API Gateway API Domain Names resource has the correct properties.'
 
   describe aws_api_gateway_v2_domain_names do

--- a/test/integration/verify/controls/aws_api_gateway_v2_integration.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_integration.rb
@@ -19,7 +19,6 @@ aws_apigatewayv2_integration_timeout_milliseconds = input(:aws_apigatewayv2_inte
 aws_apigatewayv2_integration_tls_config = input(:aws_apigatewayv2_integration_tls_config, value: '', description: '')
 
 control 'aws-api-gateway-v2-integration-v1.0.0' do
-  impact 1.0
   title 'Ensure API Gateway API Integration resource has the correct properties.'
 
   describe aws_api_gateway_v2_integration(api_id: aws_apigatewayv2_integration_api_id, integration_id: aws_apigatewayv2_integration_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_integration_response.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_integration_response.rb
@@ -4,7 +4,6 @@ aws_apigatewayv2_integration_response_integration_id = input(:aws_apigatewayv2_i
 aws_apigatewayv2_integration_response_integration_response_key = input(:aws_apigatewayv2_integration_response_integration_response_key, value: '', description: '')
 
 control 'aws-api-gateway-v2-integration-response-v-1.0.0' do
-  impact 1.0
   title 'Ensure API Gateway API Integration Response resource has the correct properties.'
   
   describe aws_api_gateway_v2_integration_response(api_id: aws_apigatewayv2_integration_response_api_id, integration_id: aws_apigatewayv2_integration_response_integration_id, integration_response_id: aws_apigatewayv2_integration_response_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_integration_responses.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_integration_responses.rb
@@ -4,7 +4,6 @@ aws_apigatewayv2_integration_response_integration_id = input(:aws_apigatewayv2_i
 aws_apigatewayv2_integration_response_integration_response_key = input(:aws_apigatewayv2_integration_response_integration_response_key, value: '', description: '')
 
 control 'aws-api-gateway-v2-integration-responses-v-1.0.0' do
-  impact 1.0
   title 'Ensure API Gateway API Integration Responses resource has the correct properties.'
 
   describe aws_api_gateway_v2_integration_responses(api_id: aws_apigatewayv2_integration_response_api_id, integration_id: aws_apigatewayv2_integration_response_integration_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_integrations.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_integrations.rb
@@ -19,7 +19,6 @@ aws_apigatewayv2_integration_timeout_milliseconds = input(:aws_apigatewayv2_inte
 aws_apigatewayv2_integration_tls_config = input(:aws_apigatewayv2_integration_tls_config, value: '', description: '')
 
 control 'aws-api-gateway-v2-integrations-v1.0.0' do
-  impact 1.0
   title 'Ensure API Gateway API Integrations resource has the correct properties.'
   
   describe aws_api_gateway_v2_integrations(api_id: aws_apigatewayv2_integration_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_model.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_model.rb
@@ -4,7 +4,6 @@ aws_apigatewayv2_model_id = input(:aws_apigatewayv2_model_id, value: '', descrip
 aws_apigatewayv2_model_name = input(:aws_apigatewayv2_model_name, value: 'example', description: '')
 
 control 'aws-api-gateway-v2-model-v-1.0.0' do
-  impact 1.0
   title 'Ensure API Gateway API Model resource has the correct properties.'
   
   describe aws_api_gateway_v2_model(api_id: aws_apigatewayv2_model_api_id, model_id: aws_apigatewayv2_model_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_models.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_models.rb
@@ -4,7 +4,6 @@ aws_apigatewayv2_model_id = input(:aws_apigatewayv2_model_id, value: '', descrip
 aws_apigatewayv2_model_name = input(:aws_apigatewayv2_model_name, value: 'example', description: '')
 
 control 'aws-api-gateway-v2-models-v-1-0-0' do
-  impact 1.0
   title 'Ensure API Gateway API Models resource has the correct properties.'
   
   describe aws_api_gateway_v2_models(api_id: aws_apigatewayv2_model_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_route.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_route.rb
@@ -12,7 +12,6 @@ aws_apigatewayv2_route_request_models = input(:aws_apigatewayv2_model_api_id, va
 aws_apigatewayv2_route_request_parameter = input(:aws_apigatewayv2_route_request_parameter, value: '', description: '')
 
 control 'aws-api-gateway-v2-route' do
-  impact 1.0
   title 'Ensure API Gateway API Route resource has the correct properties.'
   
   describe aws_api_gateway_v2_route(api_id: aws_apigatewayv2_route_api_id, route_id: aws_apigatewayv2_route_id) do

--- a/test/integration/verify/controls/aws_api_gateway_v2_routes.rb
+++ b/test/integration/verify/controls/aws_api_gateway_v2_routes.rb
@@ -12,7 +12,6 @@ aws_apigatewayv2_route_request_models = input(:aws_apigatewayv2_model_api_id, va
 aws_apigatewayv2_route_request_parameter = input(:aws_apigatewayv2_route_request_parameter, value: '', description: '')
 
 control 'aws-api-gateway-v2-routes' do
-  impact 1.0
   title 'Ensure API Gateway API Routes resource has the correct properties.'
   
   describe aws_api_gateway_v2_routes(api_id: aws_apigatewayv2_route_api_id) do

--- a/test/integration/verify/controls/aws_api_gateway_vpc_link.rb
+++ b/test/integration/verify/controls/aws_api_gateway_vpc_link.rb
@@ -6,7 +6,6 @@ aws_api_gateway_status = input(:aws_api_gateway_status, value: '', description: 
 aws_api_gateway_status_message = input(:aws_api_gateway_status_message, value: '', description: 'A description about the VPC link status.')
 
 control 'aws-api-gateway-vpc-link-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway vpc link.'
 
   describe aws_api_gateway_vpc_link(vpc_link_id: aws_api_gateway_vpc_link_id) do

--- a/test/integration/verify/controls/aws_api_gateway_vpc_links.rb
+++ b/test/integration/verify/controls/aws_api_gateway_vpc_links.rb
@@ -6,7 +6,6 @@ aws_api_gateway_status = input(:aws_api_gateway_status, value: '', description: 
 aws_api_gateway_status_message = input(:aws_api_gateway_status_message, value: '', description: 'A description about the VPC link status.')
 
 control 'aws-api-gateway-vpc-links-1.0' do
-  impact 1.0
   title 'Test the properties of the api gateway VPC links.'
 
   describe aws_api_gateway_vpc_links do

--- a/test/integration/verify/controls/aws_apigateway_account.rb
+++ b/test/integration/verify/controls/aws_apigateway_account.rb
@@ -2,7 +2,6 @@ aws_api_gateway_account_cloudwatch_role_arn = input(:aws_api_gateway_account_clo
 
 control 'aws-apigateway-account' do
 
-  impact 1.0
   title 'Ensure API Gateway Account resource has the correct properties.'
 
   describe aws_apigateway_account do

--- a/test/integration/verify/controls/aws_apigateway_api_key.rb
+++ b/test/integration/verify/controls/aws_apigateway_api_key.rb
@@ -3,7 +3,6 @@ aws_api_gateway_api_key_created_date = input(:aws_api_gateway_api_key_created_da
 aws_api_gateway_api_key_last_updated_date = input(:aws_api_gateway_api_key_last_updated_date, value: '', description: '')
 
 control 'aws-apigateway-api-key' do
-  impact 1.0
   title 'Ensure API Gateway API Key resource has the correct properties.'
 
   describe aws_apigateway_api_key(api_key: aws_api_gateway_api_key_id) do

--- a/test/integration/verify/controls/aws_apigateway_api_keys.rb
+++ b/test/integration/verify/controls/aws_apigateway_api_keys.rb
@@ -4,7 +4,6 @@ aws_api_gateway_api_key_last_updated_date = input(:aws_api_gateway_api_key_last_
 
 control 'aws-apigateway-api-keys' do
 
-  impact 1.0
   title 'Ensure API Gateway API Key resource has the correct properties.'
 
   describe aws_apigateway_api_keys do

--- a/test/integration/verify/controls/aws_apigateway_authorizer.rb
+++ b/test/integration/verify/controls/aws_apigateway_authorizer.rb
@@ -5,7 +5,6 @@ aws_api_gateway_authorizer_authorizer_result_ttl_in_seconds = input(:aws_api_gat
 aws_api_gateway_authorizer_authorizer_uri = input(:aws_api_gateway_authorizer_authorizer_uri, value: '', description: '')
 
 control 'aws-apigateway-authorizer' do
-  impact 1.0
   title 'Ensure API Gateway Authorizer resource has the correct properties.'
 
   describe aws_apigateway_authorizer(rest_api_id: aws_api_gateway_rest_api_id, authorizer_id: aws_api_gateway_authorizer_id) do

--- a/test/integration/verify/controls/aws_apigateway_authorizers.rb
+++ b/test/integration/verify/controls/aws_apigateway_authorizers.rb
@@ -5,7 +5,6 @@ aws_api_gateway_authorizer_authorizer_result_ttl_in_seconds = input(:aws_api_gat
 aws_api_gateway_authorizer_authorizer_uri = input(:aws_api_gateway_authorizer_authorizer_uri, value: '', description: '')
 
 control 'aws-apigateway-authorizers' do
-  impact 1.0
   title 'Ensure API Gateway Authorizer resource has the correct properties.'
 
   describe aws_apigateway_authorizers(rest_api_id: aws_api_gateway_rest_api_id) do

--- a/test/integration/verify/controls/aws_apigateway_base_path_mapping.rb
+++ b/test/integration/verify/controls/aws_apigateway_base_path_mapping.rb
@@ -4,7 +4,6 @@ aws_api_gateway_rest_api_id1 = input(:aws_api_gateway_rest_api_id1, value: '', d
 aws_api_gateway_stage_name = input(:aws_api_gateway_stage_name, value: '', description: '')
 
 control 'aws_apigateway_base_path_mapping-1.0' do
-  impact 1.0
   title 'Describes the base path mapping for the specified API Gateway.'
 
   describe aws_apigateway_base_path_mapping(domain_name: aws_api_gateway_base_path_mapping_domain_name, base_path: aws_apigateway_base_path_mapping_base_path) do

--- a/test/integration/verify/controls/aws_apigateway_base_path_mappings.rb
+++ b/test/integration/verify/controls/aws_apigateway_base_path_mappings.rb
@@ -4,7 +4,6 @@ aws_api_gateway_rest_api_id1 = input(:aws_api_gateway_rest_api_id1, value: '', d
 aws_api_gateway_stage_name = input(:aws_api_gateway_stage_name, value: '', description: '')
 
 control 'aws_apigateway_base_path_mappings-1.0' do
-  impact 1.0
   title 'Describes the base path mapping for the specified API Gateway.'
 
   describe aws_apigateway_base_path_mappings(domain_name: aws_api_gateway_base_path_mapping_domain_name) do

--- a/test/integration/verify/controls/aws_apigateway_client_certificate.rb
+++ b/test/integration/verify/controls/aws_apigateway_client_certificate.rb
@@ -4,7 +4,6 @@ aws_api_gateway_client_certificate_expiration_date = input(:aws_api_gateway_clie
 aws_api_gateway_client_certificate_pem_encoded_certificate = input(:aws_api_gateway_client_certificate_pem_encoded_certificate, value: '', description: '')
 
 control 'aws-apigateway-client-certificate' do
-  impact 1.0
   title 'Ensure API Gateway Client Certificate resource has the correct properties.'
 
   describe aws_apigateway_client_certificate(client_certificate_id: aws_api_gateway_client_certificate_id) do

--- a/test/integration/verify/controls/aws_apigateway_client_certificates.rb
+++ b/test/integration/verify/controls/aws_apigateway_client_certificates.rb
@@ -4,7 +4,6 @@ aws_api_gateway_client_certificate_expiration_date = input(:aws_api_gateway_clie
 aws_api_gateway_client_certificate_pem_encoded_certificate = input(:aws_api_gateway_client_certificate_pem_encoded_certificate, value: '', description: '')
 
 control 'aws-apigateway-client-certificates' do
-  impact 1.0
   title 'Ensure API Gateway Client Certificate resource has the correct properties.'
 
   describe aws_apigateway_client_certificates do

--- a/test/integration/verify/controls/aws_application_autoscaling_scalable_target.rb
+++ b/test/integration/verify/controls/aws_application_autoscaling_scalable_target.rb
@@ -1,5 +1,4 @@
 control 'aws-application-autoscaling-scalable-target' do
-  impact 1.0
   title 'Ensure Application AutoScaling Target resource has the correct properties.'
 
   describe aws_application_autoscaling_scalable_target( service_namespace: 'dynamodb' ) do

--- a/test/integration/verify/controls/aws_application_autoscaling_scalable_targets.rb
+++ b/test/integration/verify/controls/aws_application_autoscaling_scalable_targets.rb
@@ -1,5 +1,4 @@
 control 'aws-application-autoscaling-scalable-targets' do
-  impact 1.0
   title 'Ensure Application AutoScaling Targets resource has the correct properties.'
   
   describe aws_application_autoscaling_scalable_targets( service_namespace: 'dynamodb' ) do

--- a/test/integration/verify/controls/aws_application_autoscaling_scaling_policies.rb
+++ b/test/integration/verify/controls/aws_application_autoscaling_scaling_policies.rb
@@ -1,5 +1,4 @@
 control 'aws-application-autoscaling-scalable-policies' do
-  impact 1.0
   title 'Ensure Application AutoScaling Policies resource has the correct properties.'
   
   describe aws_application_autoscaling_scaling_policies(service_namespace: 'dynamodb') do

--- a/test/integration/verify/controls/aws_application_autoscaling_scaling_policy.rb
+++ b/test/integration/verify/controls/aws_application_autoscaling_scaling_policy.rb
@@ -1,5 +1,4 @@
 control 'aws-application-autoscaling-scalable-policy' do
-  impact 1.0
   title 'Ensure Application AutoScaling Policy resource has the correct properties.'
   
   describe aws_application_autoscaling_scaling_policy(service_namespace: 'dynamodb') do

--- a/test/integration/verify/controls/aws_athena_work_group.rb
+++ b/test/integration/verify/controls/aws_athena_work_group.rb
@@ -5,7 +5,6 @@ aws_configuration_enforce_work_group_configuration = input(:aws_enforce_workgrou
 aws_configuration_publish_cloud_watch_metrics_enabled = input(:aws_publish_cloudwatch_metrics_enabled, value: '', description: '')
 
 control 'aws-athena-work-group-1.0' do
-  impact 1.0
   title 'Test the properties of Athena Work Group.'
 
   describe aws_athena_work_group(work_group: aws_athena_workgroup) do

--- a/test/integration/verify/controls/aws_athena_work_groups.rb
+++ b/test/integration/verify/controls/aws_athena_work_groups.rb
@@ -3,7 +3,6 @@ aws_state = input(:aws_athena_workgroup_state, value: '', description: '')
 aws_description = input(:aws_athena_workgroup_description, value: '', description: '')
 
 control 'aws-athena-work-groups-1.0' do
-  impact 1.0
   title 'Test the properties of Athena Work Groups.'
 
   describe aws_athena_work_groups do

--- a/test/integration/verify/controls/aws_auto_scaling_group.rb
+++ b/test/integration/verify/controls/aws_auto_scaling_group.rb
@@ -3,7 +3,6 @@ title 'Test single AWS Auto Scaling Group'
 group_name = input(:aws_auto_scaling_group, value: '', description: 'The AWS Auto Scaling Group name.')
 
 control 'aws-auto-scaling-group-1.0' do
-  impact 1.0
   title 'Ensure AWS Auto Scaling Group has the correct properties.'
 
   describe aws_auto_scaling_group(auto_scaling_group_name: group_name) do

--- a/test/integration/verify/controls/aws_auto_scaling_groups.rb
+++ b/test/integration/verify/controls/aws_auto_scaling_groups.rb
@@ -3,7 +3,6 @@ title 'Test collection of AWS Auto Scaling Groups'
 group_name = input(:aws_auto_scaling_group, value: '', description: 'The AWS Auto Scaling Group name.')
 
 control 'aws-auto-scaling-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS Auto Scaling Group plural resource have the correct properties.'
 
   describe aws_auto_scaling_groups() do

--- a/test/integration/verify/controls/aws_autoscaling_scaling_policies.rb
+++ b/test/integration/verify/controls/aws_autoscaling_scaling_policies.rb
@@ -5,7 +5,6 @@ aws_auto_scaling_adjustment_type = input(:aws_auto_scaling_adjustment_type, valu
 aws_auto_scaling_cooldown = input(:aws_auto_scaling_cooldown, value: '', description: '')
 
 control 'aws-autoscaling-scalable-policies-1.0' do
-  impact 1.0
   title 'Describes the policies for the specified Auto Scaling group.'
   
   describe aws_autoscaling_scaling_policies do

--- a/test/integration/verify/controls/aws_autoscaling_scaling_policy.rb
+++ b/test/integration/verify/controls/aws_autoscaling_scaling_policy.rb
@@ -5,7 +5,6 @@ aws_auto_scaling_adjustment_type = input(:aws_auto_scaling_adjustment_type, valu
 aws_auto_scaling_cooldown = input(:aws_auto_scaling_cooldown, value: '', description: '')
 
 control 'aws-autoscaling-scalable-policy-1.0' do
-  impact 1.0
   title 'Describes the policy for the specified Auto Scaling group.'
   
   describe aws_autoscaling_scaling_policy(auto_scaling_group_name: aws_auto_scaling_group_name) do

--- a/test/integration/verify/controls/aws_batch_compute_environment.rb
+++ b/test/integration/verify/controls/aws_batch_compute_environment.rb
@@ -5,7 +5,6 @@ aws_compute_resources_minv_cpus = input(:aws_min_vcpus, value: '', description: 
 aws_compute_resources_maxv_cpus = input(:aws_max_vcpus, value: '', description: '')
 
 control 'aws-batch-compute-environment-1.0' do
-  impact 1.0
   title 'Test the properties of Batch Compute Environment.'
 
   describe aws_batch_compute_environment(compute_environment_name: aws_compute_environment_name) do

--- a/test/integration/verify/controls/aws_batch_compute_environments.rb
+++ b/test/integration/verify/controls/aws_batch_compute_environments.rb
@@ -5,7 +5,6 @@ aws_compute_resources_minv_cpus = input(:aws_min_vcpus, value: '', description: 
 aws_compute_resources_maxv_cpus = input(:aws_max_vcpus, value: '', description: '')
 
 control 'aws-batch-compute-environment-1.0' do
-  impact 1.0
   title 'Test the properties of Batch Compute Environment.'
 
   describe aws_batch_compute_environments do

--- a/test/integration/verify/controls/aws_batch_job_definition.rb
+++ b/test/integration/verify/controls/aws_batch_job_definition.rb
@@ -5,7 +5,6 @@ aws_status = input(:aws_status, value: '', description: '')
 aws_type = input(:aws_batch_job_id, value: '', description: '')
 
 control 'aws-batch-job-definition-1.0' do
-  impact 1.0
   title 'Test the properties of Batch Job Definition.'
 
   describe aws_batch_job_definition(job_definition_name: aws_job_definition_name) do

--- a/test/integration/verify/controls/aws_batch_job_definitions.rb
+++ b/test/integration/verify/controls/aws_batch_job_definitions.rb
@@ -5,7 +5,6 @@ aws_status = input(:aws_status, value: '', description: '')
 aws_type = input(:aws_batch_job_id, value: '', description: '')
 
 control 'aws-batch-job-definitions-1.0' do
-  impact 1.0
   title 'Test the properties of Batch Job Definitions.'
 
   describe aws_batch_job_definitions do

--- a/test/integration/verify/controls/aws_batch_job_queue.rb
+++ b/test/integration/verify/controls/aws_batch_job_queue.rb
@@ -5,7 +5,6 @@ aws_priority = input(:aws_batch_job_queue_priority, value: 1, description: '')
 aws_compute_environment_compute_environment = input(:batch_job_queue_compute_environments, value: '', description: '')
 
 control 'aws-batch-job-queue-1.0' do
-  impact 1.0
   title 'Ensure AWS Batch Job Queue has the correct properties.'
   
   describe aws_batch_job_queue(job_queue_name: aws_job_queue_name) do

--- a/test/integration/verify/controls/aws_batch_job_queues.rb
+++ b/test/integration/verify/controls/aws_batch_job_queues.rb
@@ -5,7 +5,6 @@ aws_priority = input(:aws_batch_job_queue_priority, value: 1, description: '')
 aws_compute_environment_compute_environment = input(:batch_job_queue_compute_environments, value: '', description: '')
 
 control 'aws-batch-job-queues-1.0' do
-  impact 1.0
   title 'Ensure AWS Batch Job Queues has the correct properties.'
   
   describe aws_batch_job_queues do

--- a/test/integration/verify/controls/aws_cloud_formation_stack_set.rb
+++ b/test/integration/verify/controls/aws_cloud_formation_stack_set.rb
@@ -3,7 +3,6 @@ title 'Test single AWS CloudFormation Stack set'
 aws_cloudformation_stack_name = input(:aws_cloudformation_stack_name, value: '', description: 'The AWS CloudFormation stack name.')
 
 control 'aws-cloudformation-stack-1.0' do
-  impact 1.0
   title 'Ensure AWS CloudFormation Stack has the correct properties.'
 
   describe aws_cloud_formation_stack_sets do

--- a/test/integration/verify/controls/aws_cloud_formation_stack_sets.rb
+++ b/test/integration/verify/controls/aws_cloud_formation_stack_sets.rb
@@ -3,7 +3,6 @@ title 'Test single AWS CloudFormation Stack set'
 aws_cloudformation_stack_name = input(:aws_cloudformation_stack_name, value: '', description: 'The AWS CloudFormation stack name.')
 
 control 'aws-cloudformation-stack-1.0' do
-  impact 1.0
   title 'Ensure AWS CloudFormation Stack has the correct properties.'
   
   describe aws_cloud_formation_stack_sets do

--- a/test/integration/verify/controls/aws_cloudformation_stack.rb
+++ b/test/integration/verify/controls/aws_cloudformation_stack.rb
@@ -3,7 +3,6 @@ title 'Test single AWS CloudFormation Stack'
 aws_cloudformation_stack_name = input(:aws_cloudformation_stack_name, value: '', description: 'The AWS CloudFormation stack name.')
 
 control 'aws-cloudformation-stack-1.0' do
-  impact 1.0
   title 'Ensure AWS CloudFormation Stack has the correct properties.'
 
   describe aws_cloudformation_stack(stack_name: aws_cloudformation_stack_name) do

--- a/test/integration/verify/controls/aws_cloudformation_stacks.rb
+++ b/test/integration/verify/controls/aws_cloudformation_stacks.rb
@@ -3,7 +3,6 @@ title 'Test AWS CloudFormation Stacks in bulk'
 aws_cloudformation_stack_name = input(:aws_cloudformation_stack_name, value: '', description: 'The AWS CloudFormation stack name.')
 
 control 'aws-cloudformation-stacks-1.0' do
-  impact 1.0
   title 'Ensure AWS CloudFormation Stacks has the correct properties.'
 
   aws_cloudformation_stacks.names.each do |stack|

--- a/test/integration/verify/controls/aws_cloudformation_tempate.rb
+++ b/test/integration/verify/controls/aws_cloudformation_tempate.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-cloudformation-template-1.0' do
-  impact 1.0
   title 'Ensure AWS CloudFormation Template has the correct properties using the parameter stack name.'
 
   describe aws_cloudformation_template(stack_name: 'STACK_NAME') do
@@ -32,7 +31,6 @@ skip_control 'aws-cloudformation-template-1.0' do
 end
 
 skip_control 'aws-cloudformation-template-2.0' do
-  impact 1.0
   title 'Ensure AWS CloudFormation Template has the correct properties using the parameter template url.'
 
   describe aws_cloudformation_template(template_url: 'TEMPLATE_URL') do

--- a/test/integration/verify/controls/aws_cloudfront_cache_policies.rb
+++ b/test/integration/verify/controls/aws_cloudfront_cache_policies.rb
@@ -1,7 +1,6 @@
 aws_cloudfront_cache_policy_id = input(:aws_cloudfront_cache_policy_id, value: '', description: '')
 
 control 'aws-cloudfront-cache-policies' do
-  impact 1.0
   title 'Ensure Cloudfront Cache Policies resource has the correct properties.'
 
   describe aws_cloudfront_cache_policies do

--- a/test/integration/verify/controls/aws_cloudfront_cache_policy.rb
+++ b/test/integration/verify/controls/aws_cloudfront_cache_policy.rb
@@ -1,7 +1,6 @@
 aws_cloudfront_cache_policy_id = input(:aws_cloudfront_cache_policy_id, value: '', description: '')
 
 control 'aws-cloudfront-cache-policy' do
-  impact 1.0
   title 'Ensure Cloudfront Cache Policy resource has the correct properties.'
 
   describe aws_cloudfront_cache_policy(id: aws_cloudfront_cache_policy_id) do

--- a/test/integration/verify/controls/aws_cloudfront_distribution.rb
+++ b/test/integration/verify/controls/aws_cloudfront_distribution.rb
@@ -5,7 +5,6 @@ insecure_distribution_id = input(:aws_insecure_cloudfront_distribution_id, value
 default_distribution_id = input(:aws_default_cloudfront_distribution_id, value: '', description: 'The defaultinsecure AWS Cloudfront distribution ID.')
 
 control 'aws-cloudfront-distribution-1.0' do
-  impact 1.0
   title 'Ensure AWS Cloudfront distribution has the correct properties.'
 
   describe aws_cloudfront_distribution(distribution_id: secure_distribution_id) do

--- a/test/integration/verify/controls/aws_cloudfront_distributions.rb
+++ b/test/integration/verify/controls/aws_cloudfront_distributions.rb
@@ -3,7 +3,6 @@ secure_distribution_id = input(:aws_secure_cloudfront_distribution_id, value: ''
 title 'Test plural Cloudfront distributions.'
 
 control 'aws-cloudfront-distributions-1.0' do
-  impact 1.0
   title 'Ensure AWS Cloudfront distributions resource has the correct properties.'
 
   describe aws_cloudfront_distributions do

--- a/test/integration/verify/controls/aws_cloudfront_key_group.rb
+++ b/test/integration/verify/controls/aws_cloudfront_key_group.rb
@@ -3,7 +3,6 @@ aws_cloudfront_group_name = input(:aws_cloudfront_group_name, value: '(none)', d
 aws_cloudfront_group_comment = input(:aws_cloudfront_group_comment, value: '(none)', description: '')
 
 control 'aws-cloudfront-public-key-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudfront keys group.'
   
   describe aws_cloudfront_key_group(id: aws_cloudfront_group_id) do

--- a/test/integration/verify/controls/aws_cloudfront_key_groups.rb
+++ b/test/integration/verify/controls/aws_cloudfront_key_groups.rb
@@ -2,7 +2,6 @@ aws_cloudfront_group_id = input(:aws_cloudfront_group_id, value: '', description
 aws_cloudfront_group_name = input(:aws_cloudfront_group_name, value: '(none)', description: '')
 
 control 'aws-cloudfront-key-groups-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudfront keys group.'
   
   describe aws_cloudfront_key_groups do

--- a/test/integration/verify/controls/aws_cloudfront_origin_access_identities.rb
+++ b/test/integration/verify/controls/aws_cloudfront_origin_access_identities.rb
@@ -2,7 +2,6 @@ aws_cloudfront_origin_access_identity_id = input(:aws_cloudfront_origin_access_i
 aws_cloudfront_origin_access_identity_s3_canonical_user_id = input(:aws_cloudfront_origin_access_identity_s3_canonical_user_id, value: '', description: '')
 
 control 'aws-cloudfront-origin-access-identities' do
-  impact 1.0
   title 'Ensure Cloud Front Origin Access Identities resource has the correct properties.'
 
   describe aws_cloudfront_origin_access_identities do

--- a/test/integration/verify/controls/aws_cloudfront_origin_access_identity.rb
+++ b/test/integration/verify/controls/aws_cloudfront_origin_access_identity.rb
@@ -3,7 +3,6 @@ aws_cloudfront_origin_access_identity_s3_canonical_user_id = input(:aws_cloudfro
 aws_cloudfront_origin_access_identity_caller_reference = input(:aws_cloudfront_origin_access_identity_caller_reference, value: '', description: '')
 
 control 'aws-cloudfront-origin-access-identity' do
-  impact 1.0
   title 'Ensure Cloud Front Origin Access Identity resource has the correct properties.'
 
   describe aws_cloudfront_origin_access_identity(id: aws_cloudfront_origin_access_identity_id) do

--- a/test/integration/verify/controls/aws_cloudfront_origin_request_policy.rb
+++ b/test/integration/verify/controls/aws_cloudfront_origin_request_policy.rb
@@ -3,7 +3,6 @@ request_origin_id = input(:request_origin_id, value: '', description: '')
 title 'Test Single origin request policy.'
 
 control 'aws-cloudfront-origin-request-policy-1.0' do
-  impact 1.0
   title 'Ensure AWS CloudFront origin request policy has the correct properties.'
 
   describe aws_cloudfront_origin_request_policy(id: request_origin_id) do

--- a/test/integration/verify/controls/aws_cloudfront_public_key.rb
+++ b/test/integration/verify/controls/aws_cloudfront_public_key.rb
@@ -3,7 +3,6 @@ aws_cloudfront_public_key_id = input(:aws_cloudfront_public_key_id, value: '', d
 aws_cloudfront_public_key = input(:aws_cloudfront_public_key, value: '', description: '')
 
 control 'aws_cloudfront_public_key-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudfront public key.'
   
   describe aws_cloudfront_public_key(id: aws_cloudfront_public_key_id ) do

--- a/test/integration/verify/controls/aws_cloudfront_public_keys.rb
+++ b/test/integration/verify/controls/aws_cloudfront_public_keys.rb
@@ -3,7 +3,6 @@ aws_cloudfront_public_key_id = input(:aws_cloudfront_public_key_id, value: '', d
 aws_cloudfront_public_key = input(:aws_cloudfront_public_key, value: '', description: '')
 
 control 'aws_cloudfront_public_keys-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudfront public keys.'
 
   describe aws_cloudfront_public_keys do

--- a/test/integration/verify/controls/aws_cloudfront_realtime_log_config.rb
+++ b/test/integration/verify/controls/aws_cloudfront_realtime_log_config.rb
@@ -3,7 +3,6 @@ aws_cloudfront_realtime_log_config_arn = input(:aws_cloudfront_realtime_log_conf
 aws_cloudfront_realtime_log_config_sampling_rate = input(:aws_cloudfront_realtime_log_config_sampling_rate, value: '', description: '')
 
 control 'aws-cloudfront-realtime-log-config-1.0' do
-  impact 1.0
   title 'Gets a real-time log configuration.'
 
   describe aws_cloudfront_realtime_log_config(name: aws_cloudfront_realtime_log_config_name) do

--- a/test/integration/verify/controls/aws_cloudfront_realtime_log_configs.rb
+++ b/test/integration/verify/controls/aws_cloudfront_realtime_log_configs.rb
@@ -3,7 +3,6 @@ aws_cloudfront_realtime_log_config_arn = input(:aws_cloudfront_realtime_log_conf
 aws_cloudfront_realtime_log_config_sampling_rate = input(:aws_cloudfront_realtime_log_config_sampling_rate, value: '', description: '')
 
 control 'aws-cloudfront-realtime-log-configs-1.0' do
-  impact 1.0
   title 'Gets a list of real-time log configurations.'
 
   describe aws_cloudfront_realtime_log_configs do

--- a/test/integration/verify/controls/aws_cloudfront_streaming_distribution.rb
+++ b/test/integration/verify/controls/aws_cloudfront_streaming_distribution.rb
@@ -3,7 +3,6 @@ aws_cloudfront_distribution_arn = input(:aws_cloudfront_distribution_arn, value:
 aws_cloudfront_distribution_status = input(:aws_cloudfront_distribution_status, value: '', description: '')
 
 control 'aws-cloudfront-streaming-distribution-1.0' do
-  impact 1.0
   title 'Get the information about a distribution.'
 
   describe aws_cloudfront_streaming_distribution(id: aws_cloudfront_distribution_id) do

--- a/test/integration/verify/controls/aws_cloudfront_streaming_distributions.rb
+++ b/test/integration/verify/controls/aws_cloudfront_streaming_distributions.rb
@@ -3,7 +3,6 @@ aws_cloudfront_distribution_arn = input(:aws_cloudfront_distribution_arn, value:
 aws_cloudfront_distribution_status = input(:aws_cloudfront_distribution_status, value: '', description: '')
 
 control 'aws-cloudfront-streaming-distributions-1.0' do
-  impact 1.0
   title 'List CloudFront distributions.'
 
   describe aws_cloudfront_streaming_distributions do

--- a/test/integration/verify/controls/aws_cloudtrail_trail.rb
+++ b/test/integration/verify/controls/aws_cloudtrail_trail.rb
@@ -11,7 +11,6 @@ aws_cloud_trail_cloud_watch_logs_group_arn = input(:aws_cloud_trail_cloud_watch_
 aws_cloud_trail_cloud_watch_logs_role_arn = input(:aws_cloud_trail_cloud_watch_logs_role_arn, value: '', description: 'Cloud log role ARN.')
 
 control 'aws-cloudtrail-1.0' do
-  impact 1.0
   title 'Ensure AWS Cloud Trail has the correct properties.'
 
   describe aws_cloudtrail_trail(aws_cloud_trail_name) do

--- a/test/integration/verify/controls/aws_cloudtrail_trails.rb
+++ b/test/integration/verify/controls/aws_cloudtrail_trails.rb
@@ -6,7 +6,6 @@ aws_cloud_trail_name = input(:aws_cloud_trail_name, value: '', description: 'Clo
 aws_cloud_trail_open_name = input(:aws_cloud_trail_open_name, value: '', description: 'Cloud trail only with bucket.')
 
 control 'aws-cloudtrails-1.0' do
-  impact 1.0
   title 'Ensure AWS Cloud Trail plural resource has the correct properties.'
 
   describe aws_cloudtrail_trails do

--- a/test/integration/verify/controls/aws_cloudwatch_alarm.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_alarm.rb
@@ -8,7 +8,6 @@ aws_cloud_watch_alarm_metric_name = input(:aws_cloud_watch_alarm_metric_name, va
 aws_cloud_watch_log_metric_filter_namespace = input(:aws_cloud_watch_log_metric_filter_namespace, value: '', description: 'The AWS CloudWatch namespace.')
 
 control 'aws-cloudwatch-alarm-1.0' do
-  impact 1.0
   title 'Ensure AWS CloudWatch Alarm has the correct properties.'
 
   describe aws_cloudwatch_alarm(metric_name: aws_cloud_watch_alarm_metric_name, metric_namespace: aws_cloud_watch_log_metric_filter_namespace) do

--- a/test/integration/verify/controls/aws_cloudwatch_anomaly_detector.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_anomaly_detector.rb
@@ -2,7 +2,6 @@ aws_cloudwatch_anomaly_detector_namespace = input(:aws_cloudwatch_anomaly_detect
 aws_cloudwatch_anomaly_detector_metric_name = input(:aws_cloudwatch_anomaly_detector_metric_name, value: '', description: '')
 
 control 'aws-cloudwatch-anomaly-detector-1.0' do
-  impact 1.0
   title 'Get the information about a anomaly detector.'
 
   describe aws_cloudwatch_anomaly_detector(metric_name: aws_cloudwatch_anomaly_detector_metric_name) do

--- a/test/integration/verify/controls/aws_cloudwatch_anomaly_detectors.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_anomaly_detectors.rb
@@ -2,7 +2,6 @@ aws_cloudwatch_anomaly_detector_namespace = input(:aws_cloudwatch_anomaly_detect
 aws_cloudwatch_anomaly_detector_metric_name = input(:aws_cloudwatch_anomaly_detector_metric_name, value: '', description: '')
 
 control 'aws-cloudwatch-anomaly-detectors-1.0' do
-  impact 1.0
   title 'List Anomaly Detector.'
 
   describe aws_cloudwatch_anomaly_detectors do

--- a/test/integration/verify/controls/aws_cloudwatch_composite_alarm.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_composite_alarm.rb
@@ -1,5 +1,4 @@
 control 'aws-cloudwatch-composite-alarm-1.0' do
-  impact 1.0
   title 'Get the information about a composite alarm.'
 
   describe aws_cloudwatch_composite_alarm(alarm_name: 'test1') do

--- a/test/integration/verify/controls/aws_cloudwatch_composite_alarms.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_composite_alarms.rb
@@ -1,5 +1,4 @@
 control 'aws-cloudwatch-composite-alarms-1.0' do
-  impact 1.0
   title 'List Composite Alarms.'
 
   describe aws_cloudwatch_composite_alarms do

--- a/test/integration/verify/controls/aws_cloudwatch_dashboard.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_dashboard.rb
@@ -4,7 +4,6 @@ dashboard_names = input(:dashboard_name, value: '', description: '')
 title 'Test single AWS CloudWatch Dashboard'
 
 control 'aws-cloudwatch-dashboard-1.0' do
-  impact 1.0
   title 'Ensure AWS cloudwatch dashboards has the correct properties.'
 
   describe aws_cloudwatch_dashboard(dashboard_name: dashboard_names) do

--- a/test/integration/verify/controls/aws_cloudwatch_dashboards.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_dashboards.rb
@@ -4,7 +4,6 @@ dashboard_names = input(:dashboard_name, value: '', description: 'The AWS EC2 im
 title 'Test plural AWS CloudWatch Dashboard'
 
 control 'aws-cloudwatch-dashboards-1.0' do
-  impact 1.0
   title 'Ensure AWS cloudwatch dashboards has the correct properties.'
 
   describe aws_cloudwatch_dashboards do

--- a/test/integration/verify/controls/aws_cloudwatch_insight_rules.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_insight_rules.rb
@@ -1,7 +1,6 @@
 title 'Test Multiple Metric Stream'
 
 skip_control 'aws-cloudwatch-metric-stream-1.0' do
-  impact 1.0
   title 'Ensure AWS cloudwatch metric streams has the correct properties.'
 
   describe aws_cloudwatch_insight_rules do

--- a/test/integration/verify/controls/aws_cloudwatch_log_group.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_log_group.rb
@@ -3,7 +3,6 @@ title 'Test single AWS CloudWatch Log Group'
 aws_cloud_watch_log_group_name = input(:aws_cloud_watch_log_group_name, value: '', description: 'The AWS DHCP Options ID.')
 
 control 'aws-cloudwatch-log-group-1.0' do
-  impact 1.0
   title 'Ensure AWS Cloudwatch Log Group has the correct properties.'
 
   describe aws_cloudwatch_log_group(log_group_name:  aws_cloud_watch_log_group_name) do

--- a/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
@@ -10,7 +10,6 @@ aws_cloud_watch_log_metric_filter_pattern = input(:aws_cloud_watch_log_metric_fi
 aws_cloud_watch_log_metric_filter_two_pattern = input(:aws_cloud_watch_log_metric_filter_two_pattern, value: '', description: 'The AWS Cloudwatch Log Metric Filter metric pattern.')
 
 control 'aws-cloudwatch-log-metric-filter-1.0' do
-  impact 1.0
   title 'Ensure AWS Cloudwatch Log Metric Filter has the correct properties.'
 
   describe aws_cloudwatch_log_metric_filter(filter_name: aws_cloud_watch_log_metric_filter_name, log_group_name: aws_cloud_watch_log_metric_filter_log_group_name) do

--- a/test/integration/verify/controls/aws_cloudwatch_metric_stream.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_metric_stream.rb
@@ -4,7 +4,6 @@ stream_names = input(:dashboard_name, value: '', description: '')
 title 'Test Multiple Metric Stream'
 
 control 'aws-cloudwatch-metric-stream-1.0' do
-  impact 1.0
   title 'Ensure AWS cloudwatch metric streams has the correct properties.'
 
   describe aws_cloudwatch_metric_stream(metric_stream_name: stream_names) do

--- a/test/integration/verify/controls/aws_cloudwatch_metric_streams.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_metric_streams.rb
@@ -4,7 +4,6 @@ stream_names = input(:dashboard_name, value: '', description: '')
 title 'Test Plural metric stream'
 
 control 'aws-cloudwatch-metric-streams-1.0' do
-  impact 1.0
   title 'Ensure AWS cloudwatch metric streams has the correct properties.'
 
   describe aws_cloudwatch_metric_streams do

--- a/test/integration/verify/controls/aws_cloudwatchlogs_destinantion.rb
+++ b/test/integration/verify/controls/aws_cloudwatchlogs_destinantion.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-cloudwatch-logs-destination-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudwatch destination.'
 
   describe aws_cloudwatchlogs_destinantion(destination_name_prefix: 'DESTINATION_NAME') do

--- a/test/integration/verify/controls/aws_cloudwatchlogs_destinantions.rb
+++ b/test/integration/verify/controls/aws_cloudwatchlogs_destinantions.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-cloudwatch-logs-destinations-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudwatch destinations.'
 
   describe aws_cloudwatchlogs_destinantions do

--- a/test/integration/verify/controls/aws_cloudwatchlogs_log_stream.rb
+++ b/test/integration/verify/controls/aws_cloudwatchlogs_log_stream.rb
@@ -3,7 +3,6 @@ aws_cloudwatch_log_group_name = input(:aws_cloudwatch_log_group_name, value: '',
 aws_cloudwatch_log_stream_arn = input(:aws_cloudwatch_log_stream_arn, value: '', description: '')
 
 control 'aws-cloudwatch-logs-log-stream-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudwatch logs log-stream.'
   
   describe aws_cloudwatchlogs_log_stream(log_stream_name_prefix: aws_cloudwatch_log_stream_name, log_group_name: aws_cloudwatch_log_group_name) do

--- a/test/integration/verify/controls/aws_cloudwatchlogs_log_streams.rb
+++ b/test/integration/verify/controls/aws_cloudwatchlogs_log_streams.rb
@@ -3,7 +3,6 @@ aws_cloudwatch_log_group_name = input(:aws_cloudwatch_log_group_name, value: '',
 aws_cloudwatch_log_stream_arn = input(:aws_cloudwatch_log_stream_arn, value: '', description: '')
 
 control 'aws-cloudwatch-logs-log-streams-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudwatch logs log-streams.'
   
   describe aws_cloudwatchlogs_log_streams(log_group_name: aws_cloudwatch_log_group_name) do

--- a/test/integration/verify/controls/aws_cloudwatchlogs_subscription_filter.rb
+++ b/test/integration/verify/controls/aws_cloudwatchlogs_subscription_filter.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-cloudwatchlogs-subscription-filter-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudwatch filter.'
   
   describe aws_cloudwatchlogs_subscription_filter(log_group_name: 'LOG_GROUP_NAME', filter_name_prefix: 'FILTER_NAME') do

--- a/test/integration/verify/controls/aws_cloudwatchlogs_subscription_filters.rb
+++ b/test/integration/verify/controls/aws_cloudwatchlogs_subscription_filters.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-cloudwatchlogs-subscription-filters-1.0' do
-  impact 1.0
   title 'Describes the AWS cloudwatch filters.'
   
   describe aws_cloudwatchlogs_subscription_filters(log_group_name: 'LOG_GROUP_NAME') do

--- a/test/integration/verify/controls/aws_cognito_identity_pool.rb
+++ b/test/integration/verify/controls/aws_cognito_identity_pool.rb
@@ -3,7 +3,6 @@ aws_identity_pool_name = input(:aws_identity_pool_name, value: '', description: 
 aws_allow_unauthenticated_identities = input(:aws_allow_unauthenticated_identities, value: false, description: '')
 
 control 'aws-cognito-identity-pool-1.0' do
-  impact 1.0
   title 'Ensure AWS Identity Pool has the correct properties.'
 
   describe aws_cognito_identity_pool(identity_pool_id: aws_identity_pool_id) do

--- a/test/integration/verify/controls/aws_cognito_identity_pools.rb
+++ b/test/integration/verify/controls/aws_cognito_identity_pools.rb
@@ -2,7 +2,6 @@ aws_identity_pool_id = input(:aws_identity_pool_id, value: '', description: '')
 aws_identity_pool_name = input(:aws_identity_pool_name, value: '', description: '')
 
 control 'aws-cognito-identity-pools-1.0' do
-  impact 1.0
   title 'Ensure AWS Identity Pools has the correct properties.'
 
   describe aws_cognito_identity_pools do

--- a/test/integration/verify/controls/aws_cognito_userpool.rb
+++ b/test/integration/verify/controls/aws_cognito_userpool.rb
@@ -3,7 +3,6 @@ aws_identity_pool_name = input(:aws_identity_pool_name, value: '', description: 
 
 control 'aws-cognito-user-pool-1.0' do
 
-  impact 1.0
   title 'Ensure AWS Cognito User Pool has the correct properties.'
 
   describe aws_cognito_userpool(user_pool_id: aws_user_pool_id) do

--- a/test/integration/verify/controls/aws_cognito_userpoolclient.rb
+++ b/test/integration/verify/controls/aws_cognito_userpoolclient.rb
@@ -6,7 +6,6 @@ aws_allowed_o_auth_flows_user_pool_client = input(:aws_allowed_o_auth_flows_user
 
 control 'aws-cognito-user-pool-client-1.0' do
 
-  impact 1.0
   title 'Ensure AWS Cognito User Pool Client has the correct properties.'
 
   describe aws_cognito_userpool_client(user_pool_id: aws_user_pool_id, client_id: aws_client_id) do

--- a/test/integration/verify/controls/aws_cognito_userpoolclients.rb
+++ b/test/integration/verify/controls/aws_cognito_userpoolclients.rb
@@ -3,7 +3,6 @@ aws_client_id = input(:aws_client_id, value: '', description: '')
 aws_client_name = input(:aws_client_name, value: '', description: '')
 
 control 'aws-cognito-identity-pool-clients-1.0' do
-  impact 1.0
   title 'Ensure AWS Cognito Identity Pool Clients has the correct properties.'
 
   describe aws_cognito_userpool_clients(user_pool_id: aws_user_pool_id) do

--- a/test/integration/verify/controls/aws_cognito_userpools.rb
+++ b/test/integration/verify/controls/aws_cognito_userpools.rb
@@ -2,7 +2,6 @@ aws_user_pool_id = input(:aws_user_pool_id, value: '', description: '')
 aws_identity_pool_name = input(:aws_identity_pool_name, value: '', description: '')
 
 control 'aws-cognito-user-pools-1.0' do
-  impact 1.0
   title 'Ensure AWS Cognito User Pool has the correct properties.'
   
   describe aws_cognito_userpools do

--- a/test/integration/verify/controls/aws_config_delivery_channel.rb
+++ b/test/integration/verify/controls/aws_config_delivery_channel.rb
@@ -7,7 +7,6 @@ aws_create_configuration_recorder = input(:aws_create_configuration_recorder, va
 
 control 'aws-config-delivery-channel-1.0' do
   only_if { aws_create_configuration_recorder.to_i == 1 }
-  impact 1.0
   title 'Ensure AWS Config Delivery Channel has the correct properties.'
 
   describe aws_config_delivery_channel do

--- a/test/integration/verify/controls/aws_config_recorder.rb
+++ b/test/integration/verify/controls/aws_config_recorder.rb
@@ -6,7 +6,6 @@ aws_create_configuration_recorder = input(:aws_create_configuration_recorder, va
 
 control 'aws-config-recorder-1.0' do
   only_if { aws_create_configuration_recorder.to_i == 1 }
-  impact 1.0
   title 'Ensure AWS Config Recorder has the correct properties.'
 
   describe aws_config_recorder do

--- a/test/integration/verify/controls/aws_db_parameter_group.rb
+++ b/test/integration/verify/controls/aws_db_parameter_group.rb
@@ -6,7 +6,6 @@ aws_db_parameter_group_description  = input(:aws_db_parameter_group_description,
 aws_db_parameter_group_arn = input(:aws_db_parameter_group_arn, value: '', description: 'The Amazon Resource Name (ARN) for the DB parameter group.')
 
 control 'aws-db-parameter-group-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Parameter Group has current properties'
 
   describe aws_db_parameter_group(db_parameter_group_name: aws_rds_db_parameter_group_name) do

--- a/test/integration/verify/controls/aws_db_parameter_groups.rb
+++ b/test/integration/verify/controls/aws_db_parameter_groups.rb
@@ -5,7 +5,6 @@ aws_db_parameter_group_family_name = input(:aws_db_parameter_group_family_name, 
 aws_db_parameter_group_arn = input(:aws_db_parameter_group_arn, value: '', description: 'The Amazon Resource Name (ARN) for the DB parameter group.')
 
 control 'aws-db-parameter-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Parameter groups has current properties'
 
   describe aws_db_parameter_groups do

--- a/test/integration/verify/controls/aws_db_parameter_groups_loop.rb
+++ b/test/integration/verify/controls/aws_db_parameter_groups_loop.rb
@@ -4,7 +4,6 @@ aws_rds_db_parameter_group_family   = input(:aws_rds_db_parameter_group_family, 
 aws_rds_db_parameter_group_arn      = input(:aws_rds_db_parameter_group_arn, value: '', description: 'The Amazon Resource Name (ARN) for the DB parameter group.')
 
 control 'aws-db-parameter-groups-loop-1.0' do
-  impact 1.0
   title 'Loop across AWS RDS Parameter Group resource using singular resource for detail.'
 
   aws_db_parameter_groups.db_parameter_group_names.each do |parameter_group|

--- a/test/integration/verify/controls/aws_db_subnet_group.rb
+++ b/test/integration/verify/controls/aws_db_subnet_group.rb
@@ -7,7 +7,6 @@ aws_rds_db_subnet_group_arn         = input(:aws_rds_db_subnet_group_arn, value:
 
 control 'aws-db-subnet-group-1.0' do
 
-  impact 1.0
   title 'Ensure AWS RDS Subnet Group has current properties'
 
   describe aws_db_subnet_group(db_subnet_group_name: aws_rds_db_subnet_group_name) do

--- a/test/integration/verify/controls/aws_db_subnet_groups.rb
+++ b/test/integration/verify/controls/aws_db_subnet_groups.rb
@@ -1,7 +1,6 @@
 title 'Test AWS RDS Subnet Groups in bulk'
 
 control 'aws-db-subnet-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Subnet groups has current properties'
 
   describe aws_db_subnet_groups do

--- a/test/integration/verify/controls/aws_db_subnet_groups_loop.rb
+++ b/test/integration/verify/controls/aws_db_subnet_groups_loop.rb
@@ -4,7 +4,6 @@ aws_rds_db_subnet_group_vpc_id = input(:aws_rds_db_subnet_group_vpc_id, value: '
 aws_rds_db_subnet_group_arn = input(:aws_rds_db_subnet_group_arn, value: '', description: 'The ARN for DB Subnet Group.')
 
 control 'aws-db-subnet-groups-loop-1.0' do
-  impact 1.0
   title 'Loop across AWS RDS Subnet Group resource using singular resource for detail.'
 
   aws_db_subnet_groups.db_subnet_group_names.each do |subnet_group|

--- a/test/integration/verify/controls/aws_dhcp_options.rb
+++ b/test/integration/verify/controls/aws_dhcp_options.rb
@@ -5,7 +5,6 @@ aws_vpc_dhcp_options_name = input(:aws_vpc_dhcp_options_name, value: '', descrip
 aws_vpc_id = input(:aws_vpc_id, value: '', description: 'The AWS VPC ID.')
 
 control 'aws-dhcp-options-1.0' do
-  impact 1.0
   title 'Ensure AWS DHCP Options has the correct properties.'
 
   describe aws_dhcp_options(dhcp_options_id:  aws_vpc_dhcp_options_id) do

--- a/test/integration/verify/controls/aws_dms_endpoint.rb
+++ b/test/integration/verify/controls/aws_dms_endpoint.rb
@@ -1,7 +1,6 @@
 aws_dms_endpoint_arn = input(:aws_dms_endpoint_arn, value: '', description: '')
 
 control 'aws-endpoint-1.0' do
-  impact 1.0
   title 'Ensure AWS DMS Endpoint has the correct properties.'
 
   describe aws_dms_endpoint(endpoint_arn: aws_dms_endpoint_arn) do

--- a/test/integration/verify/controls/aws_dms_endpoints.rb
+++ b/test/integration/verify/controls/aws_dms_endpoints.rb
@@ -1,5 +1,4 @@
 control 'aws-endpoints-1.0' do
-  impact 1.0
   title 'Ensure AWS DMS Endpoints has the correct properties.'
 
   describe aws_dms_endpoints do

--- a/test/integration/verify/controls/aws_dms_replication_instance.rb
+++ b/test/integration/verify/controls/aws_dms_replication_instance.rb
@@ -1,5 +1,4 @@
 control 'aws-dms-replication-instance-1.0' do
-  impact 1.0
   title 'Ensure AWS DMS Replication Instance has the correct properties.'
 
   describe aws_dms_replication_instance do

--- a/test/integration/verify/controls/aws_dms_replication_instances.rb
+++ b/test/integration/verify/controls/aws_dms_replication_instances.rb
@@ -1,5 +1,4 @@
 control 'aws-dms-replication-instances-1.0' do
-  impact 1.0
   title 'Ensure AWS DMS Replication Instances has the correct properties.'
 
   describe aws_dms_replication_instances do

--- a/test/integration/verify/controls/aws_dms_replication_subnet_group.rb
+++ b/test/integration/verify/controls/aws_dms_replication_subnet_group.rb
@@ -1,5 +1,4 @@
 control 'aws-dms-replication-subnet-group-1.0' do
-  impact 1.0
   title 'Ensure AWS DMS Replication Subnet Group has the correct properties.'
 
   describe aws_dms_replication_subnet_group(replication_subnet_group_identifier: 'test1') do

--- a/test/integration/verify/controls/aws_dms_replication_subnet_groups.rb
+++ b/test/integration/verify/controls/aws_dms_replication_subnet_groups.rb
@@ -1,5 +1,4 @@
 control 'aws-dms-replication-subnet-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS DMS Replication Subnet Groups has the correct properties.'
 
   describe aws_dms_replication_subnet_groups do

--- a/test/integration/verify/controls/aws_dynamodb_table.rb
+++ b/test/integration/verify/controls/aws_dynamodb_table.rb
@@ -5,7 +5,6 @@ aws_dynamodb_table_arn = input(:aws_dynamodb_table_arn, value: '', description: 
 
 control 'aws-dynamodb-table-1.0' do
 
-  impact 1.0
   title 'Ensure AWS Dynamodb Table has the correct properties.'
 
   describe aws_dynamodb_table(table_name: aws_dynamodb_table_name) do

--- a/test/integration/verify/controls/aws_dynamodb_tables.rb
+++ b/test/integration/verify/controls/aws_dynamodb_tables.rb
@@ -3,7 +3,6 @@ title 'Test AWS DynamoDB Tables in bulk.'
 aws_dynamodb_table_name = input(:aws_dynamodb_table_name, value: '', description: 'The AWS Dynamodb Table name.')
 
 control 'aws-dynamodb-tables-1.0' do
-  impact 1.0
   title 'Ensure AWS DynamoDB Table has current properties.'
 
   describe aws_dynamodb_tables do

--- a/test/integration/verify/controls/aws_ebs_snapshot.rb
+++ b/test/integration/verify/controls/aws_ebs_snapshot.rb
@@ -6,7 +6,6 @@ aws_ebs_encrypted_snapshot_id = input(:aws_ebs_encrypted_snapshot_id, value: '',
 title 'Test single AWS EBS Snapshot'
 
 control 'aws-ebs-snapshot-1.0' do
-  impact 1.0
   title 'Ensure AWS EBS Snapshot has the correct properties.'
 
   describe aws_ebs_snapshot(snapshot_id: aws_ebs_snapshot_id) do

--- a/test/integration/verify/controls/aws_ebs_snapshots.rb
+++ b/test/integration/verify/controls/aws_ebs_snapshots.rb
@@ -3,7 +3,6 @@ aws_ebs_snapshot_id = input(:aws_ebs_snapshot_id, value: '', description: 'The A
 title 'Test AWS EBS Snapshots in bulk'
 
 control 'aws-ebs-snapshots-1.0' do
-  impact 1.0
   title 'Ensure AWS EBS Snapshots plural resource has the correct properties.'
 
   describe aws_ebs_snapshots do

--- a/test/integration/verify/controls/aws_ebs_snapshots_loop.rb
+++ b/test/integration/verify/controls/aws_ebs_snapshots_loop.rb
@@ -5,7 +5,6 @@ aws_ebs_snapshot_owner_id = input(:aws_ebs_snapshot_owner_id, value: '', descrip
 title 'Test AWS EBS Snapshots in bulk using plural and singular resources'
 
 control 'aws-ebs-snapshots-loop-1.0' do
-  impact 1.0
   title 'Ensure AWS EBS Snapshots plural resource using singular resource for detail.'
 
   aws_ebs_snapshots.where { snapshot_id == aws_ebs_snapshot_id }.snapshot_ids.each do |snapshot|

--- a/test/integration/verify/controls/aws_ebs_volume.rb
+++ b/test/integration/verify/controls/aws_ebs_volume.rb
@@ -4,7 +4,6 @@ aws_ebs_volume_id = input(:aws_ebs_volume_id, value: '', description: 'The AWS E
 title 'Test single AWS EBS Volume'
 
 control 'aws-ebs-volume-1.0' do
-  impact 1.0
   title 'Ensure AWS EBS Volume has the correct properties.'
 
   describe aws_ebs_volume(volume_id: aws_ebs_volume_id) do

--- a/test/integration/verify/controls/aws_ebs_volumes.rb
+++ b/test/integration/verify/controls/aws_ebs_volumes.rb
@@ -7,7 +7,6 @@ aws_ebs_volume_type = input(:aws_ebs_volume_type, value: '', description: 'The t
 title 'Test AWS EBS Volumes in bulk'
 
 control 'aws-ebs-volumes-1.0' do
-  impact 1.0
   title 'Ensure AWS EBS Volumes plural resource has the correct properties.'
 
   describe aws_ebs_volumes do

--- a/test/integration/verify/controls/aws_ebs_volumes_loop.rb
+++ b/test/integration/verify/controls/aws_ebs_volumes_loop.rb
@@ -4,7 +4,6 @@ aws_ebs_volume_name = input(:aws_ebs_volume_name, value: '', description: 'The A
 title 'Test AWS EBS Volumes in bulk using plural and singular resources'
 
 control 'aws-ebs-volumes-loop-1.0' do
-  impact 1.0
   title 'Ensure AWS EBS Volumes plural resource using singular resource for detail.'
 
   aws_ebs_volumes.where { volume_id == aws_ebs_volume_id }.volume_ids.each do |volume|

--- a/test/integration/verify/controls/aws_ec2_capacity_reservation.rb
+++ b/test/integration/verify/controls/aws_ec2_capacity_reservation.rb
@@ -5,7 +5,6 @@ aws_ec2_capacity_reservation_availability_zone = input(:aws_ec2_capacity_reserva
 aws_ec2_capacity_reservation_instance_arn = input(:aws_ec2_capacity_reservation_instance_arn, value: '', description: '')
 
 control 'aws-ec2-capacity-reservation-1.0' do
-  impact 1.0
   title 'Describes one or more of your Capacity Reservations.'
 
   describe aws_ec2_capacity_reservation(capacity_reservation_id: aws_ec2_capacity_reservation_id) do

--- a/test/integration/verify/controls/aws_ec2_capacity_reservations.rb
+++ b/test/integration/verify/controls/aws_ec2_capacity_reservations.rb
@@ -5,7 +5,6 @@ aws_ec2_capacity_reservation_availability_zone = input(:aws_ec2_capacity_reserva
 aws_ec2_capacity_reservation_instance_arn = input(:aws_ec2_capacity_reservation_instance_arn, value: '', description: '')
 
 control 'aws-ec2-capacity-reservations-1.0' do
-  impact 1.0
   title 'Describes one or more of your Capacity Reservations.'
 
   describe aws_ec2_capacity_reservations do

--- a/test/integration/verify/controls/aws_ec2_carrier_gateway.rb
+++ b/test/integration/verify/controls/aws_ec2_carrier_gateway.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-ec2-carrier-gateway-1.0' do
-  impact 1.0
   title 'Describes one or more of ec2 carrier gateway.'
 
   describe aws_ec2_carrier_gateways do

--- a/test/integration/verify/controls/aws_ec2_carrier_gateways.rb
+++ b/test/integration/verify/controls/aws_ec2_carrier_gateways.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-ec2-carrier-gateways-1.0' do
-  impact 1.0
   title 'Describes one or more of ec2 carrier gateway.'
 
   describe aws_ec2_carrier_gateways do

--- a/test/integration/verify/controls/aws_ec2_client_vpn_authorization_rule.rb
+++ b/test/integration/verify/controls/aws_ec2_client_vpn_authorization_rule.rb
@@ -1,7 +1,6 @@
 client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: '')
 
 skip_control 'aws-ec2-client-vpn-authorization-rule-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn authorization rule.'
 
   describe aws_ec2_client_vpn_authorization_rule(client_vpn_endpoint_id: client_vpn_endpoint_id, group_id: 'TEST_ID') do

--- a/test/integration/verify/controls/aws_ec2_client_vpn_authorization_rules.rb
+++ b/test/integration/verify/controls/aws_ec2_client_vpn_authorization_rules.rb
@@ -1,7 +1,6 @@
 client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: '')
 
 skip_control 'aws-ec2-client-vpn-authorization-rules-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn authorization rules.'
 
   describe aws_ec2_client_vpn_authorization_rules(client_vpn_endpoint_id: client_vpn_endpoint_id) do

--- a/test/integration/verify/controls/aws_ec2_client_vpn_route.rb
+++ b/test/integration/verify/controls/aws_ec2_client_vpn_route.rb
@@ -2,7 +2,6 @@ client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: 
 target_subnet = input(:target_subnet, value: '', description: '')
 
 control 'aws-ec2-client-vpn-route-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn routes.'
 
   describe aws_ec2_client_vpn_route(client_vpn_endpoint_id:  client_vpn_endpoint_id, target_subnet: target_subnet) do

--- a/test/integration/verify/controls/aws_ec2_client_vpn_routes.rb
+++ b/test/integration/verify/controls/aws_ec2_client_vpn_routes.rb
@@ -2,7 +2,6 @@ client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: 
 target_subnet = input(:target_subnet, value: '', description: '')
 
 control 'aws-ec2-client-vpn-routes-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn routes.'
 
   describe aws_ec2_client_vpn_routes(client_vpn_endpoint_id: client_vpn_endpoint_id) do

--- a/test/integration/verify/controls/aws_ec2_client_vpn_target_network_association.rb
+++ b/test/integration/verify/controls/aws_ec2_client_vpn_target_network_association.rb
@@ -2,7 +2,6 @@ client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: 
 association_id = input(:association_id, value: '', description: '')
 
 control 'aws-ec2-client-vpn-target-network-association-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn target network association.'
 
   describe aws_ec2_client_vpn_target_network_association(client_vpn_endpoint_id: client_vpn_endpoint_id, association_id: association_id) do

--- a/test/integration/verify/controls/aws_ec2_client_vpn_target_network_associations.rb
+++ b/test/integration/verify/controls/aws_ec2_client_vpn_target_network_associations.rb
@@ -2,7 +2,6 @@ client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: 
 association_id = input(:association_id, value: '', description: '')
 
 control 'aws-ec2-client-vpn-target-network-associations-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn target network associations.'
 
   describe aws_ec2_client_vpn_target_network_associations(client_vpn_endpoint_id: client_vpn_endpoint_id) do

--- a/test/integration/verify/controls/aws_ec2_customer_gateway.rb
+++ b/test/integration/verify/controls/aws_ec2_customer_gateway.rb
@@ -1,7 +1,6 @@
 aws_customer_gateway_id = input(:aws_customer_gateway_id, value: '', description: '')
 
 control 'aws-ec2-customer-gateway-1.0' do
-  impact 1.0
   title 'Test the properties of the EC2 Customer Gateway.'
 
   describe aws_ec2_customer_gateway(customer_gateway_id: aws_customer_gateway_id) do

--- a/test/integration/verify/controls/aws_ec2_customer_gateways.rb
+++ b/test/integration/verify/controls/aws_ec2_customer_gateways.rb
@@ -1,7 +1,6 @@
 aws_customer_gateway_id = input(:aws_customer_gateway_id, value: '', description: '')
 
 control 'aws-ec2-customer-gateways-1.0' do
-  impact 1.0
   title 'Test the properties of the EC2 Customer Gateways.'
 
   describe aws_ec2_customer_gateways do

--- a/test/integration/verify/controls/aws_ec2_dhcp_option.rb
+++ b/test/integration/verify/controls/aws_ec2_dhcp_option.rb
@@ -4,7 +4,6 @@ aws_vpc_dhcp_options_id = input(:aws_vpc_dhcp_options_id, value: '', description
 aws_vpc_dhcp_options_name = input(:aws_vpc_dhcp_options_name, value: '', description: 'The AWS EC2 DHCP Option Name.')
 
 control 'aws-ec2-dhcp-option-1.0' do
-  impact 1.0
   title 'Ensure AWS EC2 DHCP Option has the correct properties.'
 
   describe aws_ec2_dhcp_option(dhcp_options_id: aws_vpc_dhcp_options_id) do

--- a/test/integration/verify/controls/aws_ec2_dhcp_options.rb
+++ b/test/integration/verify/controls/aws_ec2_dhcp_options.rb
@@ -4,7 +4,6 @@ aws_vpc_dhcp_options_id = input(:aws_vpc_dhcp_options_id, value: '', description
 aws_vpc_dhcp_options_name = input(:aws_vpc_dhcp_options_name, value: '', description: 'The AWS EC2 DHCP Options Name.')
 
 control 'aws-ec2-dhcp-options-1.0' do
-  impact 1.0
   title 'Ensure AWS EC2 DHCP Options has the correct properties.'
 
   aws_ec2_dhcp_options.each do |dhcp_option|

--- a/test/integration/verify/controls/aws_ec2_egress_only_internet_gateway.rb
+++ b/test/integration/verify/controls/aws_ec2_egress_only_internet_gateway.rb
@@ -2,7 +2,6 @@ aws_egress_only_internet_gateway_id = input(:aws_egress_only_internet_gateway_id
 aws_vpc_eoig_test1_id = input(:aws_vpc_eoig_test1_id, value: '', description: '')
 
 control 'aws-ec2-egress-only-internet-gateway-1.0' do
-  impact 1.0
   title 'Describes one or more of your egress-only internet gateways.'
 
   describe aws_ec2_egress_only_internet_gateway(egress_only_internet_gateway_id: aws_egress_only_internet_gateway_id) do

--- a/test/integration/verify/controls/aws_ec2_egress_only_internet_gateways.rb
+++ b/test/integration/verify/controls/aws_ec2_egress_only_internet_gateways.rb
@@ -1,7 +1,6 @@
 aws_egress_only_internet_gateway_id = input(:aws_egress_only_internet_gateway_id, value: '', description: '')
 
 control 'aws-ec2-egress-only-internet-gateways-1.0' do
-  impact 1.0
   title 'Describes one or more of your egress-only internet gateways.'
 
   describe aws_ec2_egress_only_internet_gateways do

--- a/test/integration/verify/controls/aws_ec2_eip.rb
+++ b/test/integration/verify/controls/aws_ec2_eip.rb
@@ -9,7 +9,6 @@ aws_private_ip_address = input(:aws_private_ip_address, value: '', description: 
 
 control 'aws-ec2-elastic-ip-1.0' do
 
-  impact 1.0
   title 'Specifies an Elastic IP (EIP) address and can, optionally, associate it with an Amazon EC2 instance.'
 
   describe aws_ec2_eip(public_ip: aws_public_ip) do

--- a/test/integration/verify/controls/aws_ec2_eip_association.rb
+++ b/test/integration/verify/controls/aws_ec2_eip_association.rb
@@ -1,7 +1,6 @@
 aws_eip_association_id = input(:aws_eip_association_id, value: '', description: '')
 
 control 'aws-ec2-eip-association-1.0' do
-  impact 1.0
   title 'Test the singular resource of EC2 EIP Association.'
 
   describe aws_ec2_eip_association(association_id: aws_eip_association_id) do

--- a/test/integration/verify/controls/aws_ec2_eip_associations.rb
+++ b/test/integration/verify/controls/aws_ec2_eip_associations.rb
@@ -1,7 +1,6 @@
 aws_eip_association_id = input(:aws_eip_association_id, value: '', description: '')
 
 control 'aws-ec2-eip-associations-1.0' do
-  impact 1.0
   title 'Test the plural resource of EC2 EIP Association.'
 
   describe aws_ec2_eip_associations do

--- a/test/integration/verify/controls/aws_ec2_eips.rb
+++ b/test/integration/verify/controls/aws_ec2_eips.rb
@@ -8,7 +8,6 @@ aws_network_interface_owner_id = input(:aws_network_interface_owner_id, value: '
 aws_private_ip_address = input(:aws_private_ip_address, value: '', description: 'The private IP address associated with the Elastic IP address.')
 
 control 'aws-ec2-elastic-ips-1.0' do
-  impact 1.0
   title 'Specifies an Elastic IP (EIP) address and can, optionally, associate it with an Amazon EC2 instance.'
 
   describe aws_ec2_eips do

--- a/test/integration/verify/controls/aws_ec2_fleet.rb
+++ b/test/integration/verify/controls/aws_ec2_fleet.rb
@@ -1,7 +1,6 @@
 aws_ec2_fleet_id = input(:aws_ec2_fleet_id, value: '', description: '')
 
 control 'aws-ec2-fleet-1.0' do
-  impact 1.0
   title 'Describes the specified EC2 Fleets or all of your EC2 Fleets.'
 
   describe aws_ec2_fleet(fleet_id: aws_ec2_fleet_id) do

--- a/test/integration/verify/controls/aws_ec2_fleets.rb
+++ b/test/integration/verify/controls/aws_ec2_fleets.rb
@@ -1,8 +1,7 @@
 aws_ec2_fleet_id = input(:aws_ec2_fleet_id, value: '', description: '')
 
 control 'aws-ec2-fleets-1.0' do
-    impact 1.0
-    title 'Describes the specified EC2 Fleets or all of your EC2 Fleets.'
+      title 'Describes the specified EC2 Fleets or all of your EC2 Fleets.'
 
     describe aws_ec2_fleets do
       it { should exist }

--- a/test/integration/verify/controls/aws_ec2_host.rb
+++ b/test/integration/verify/controls/aws_ec2_host.rb
@@ -1,7 +1,6 @@
 aws_ec2_fleet_id = input(:aws_ec2_fleet_id, value: '', description: '')
 
 control 'aws-ec2-host-1.0' do
-  impact 1.0
   title 'Describes the specified Dedicated Hosts or all your Dedicated Hosts.'
 
   describe aws_ec2_host(host_id: aws_ec2_fleet_id) do

--- a/test/integration/verify/controls/aws_ec2_hosts.rb
+++ b/test/integration/verify/controls/aws_ec2_hosts.rb
@@ -1,7 +1,6 @@
 aws_ec2_fleet_id = input(:aws_ec2_fleet_id, value: '', description: '')
 
 control 'aws-ec2-hosts-1.0' do
-  impact 1.0
   title 'Describes the specified Dedicated Hosts or all your Dedicated Hosts.'
 
   describe aws_ec2_hosts do

--- a/test/integration/verify/controls/aws_ec2_instance.rb
+++ b/test/integration/verify/controls/aws_ec2_instance.rb
@@ -7,7 +7,6 @@ aws_iam_role_name_for_ec2 = input(:aws_iam_role_name_for_ec2, value: '', descrip
 title 'Test single AWS EC2 Instance.'
 
 control 'aws-ec2-instance-1.0' do
-  impact 1.0
   title 'Ensure AWS EC2 Instance has the correct properties.'
 
   describe aws_ec2_instance(instance_id: aws_instance_id) do

--- a/test/integration/verify/controls/aws_ec2_instances.rb
+++ b/test/integration/verify/controls/aws_ec2_instances.rb
@@ -7,7 +7,6 @@ aws_vm_name = input(:aws_vm_name, value: '', description: 'The AWS EC2 Instance 
 title 'Test AWS EC2 Instances in bulk'
 
 control 'aws-ec2-instances-1.0' do
-  impact 1.0
   title 'Ensure AWS EC2 plural resource has the correct properties.'
 
   describe aws_ec2_instances do

--- a/test/integration/verify/controls/aws_ec2_instances_loop.rb
+++ b/test/integration/verify/controls/aws_ec2_instances_loop.rb
@@ -6,7 +6,6 @@ aws_vm_size = input(:aws_vm_size, value: '', description: 'The AWS EC2 Instance 
 aws_ec2_ami_id = input(:aws_ec2_ami_id, value: '', description: 'The AWS EC2 image id.')
 
 control 'aws-ec2-instances-loop-1.0' do
-  impact 1.0
   title 'Loop across AWS EC2 Instances plural resource using singular resource for detail.'
 
   aws_ec2_instances.instance_ids.each do |instance|

--- a/test/integration/verify/controls/aws_ec2_internet_gateway.rb
+++ b/test/integration/verify/controls/aws_ec2_internet_gateway.rb
@@ -4,7 +4,6 @@ aws_internet_gateway_vpc_id = input(:aws_internet_gateway_vpc_id, value: '', des
 
 control 'aws-ec2-internet-gateway-1.0' do
 
-  impact 1.0
   title 'Test a singular resource of the internet gateway.'
 
   describe aws_ec2_internet_gateway(internet_gateway_id: aws_internet_gateway_id) do

--- a/test/integration/verify/controls/aws_ec2_internet_gateways.rb
+++ b/test/integration/verify/controls/aws_ec2_internet_gateways.rb
@@ -3,7 +3,6 @@ aws_internet_gateway_owner_id = input(:aws_internet_gateway_owner_id, value: '',
 aws_internet_gateway_vpc_id = input(:aws_internet_gateway_vpc_id, value: '', description: '')
 
 control 'aws-ec2-internet-gateways-1.0' do
-  impact 1.0
   title 'Test a plural resource of the internet gateways.'
 
   describe aws_ec2_internet_gateways do

--- a/test/integration/verify/controls/aws_ec2_launch_template.rb
+++ b/test/integration/verify/controls/aws_ec2_launch_template.rb
@@ -3,7 +3,6 @@ aws_launch_template_name = input(:launch_template_name, value: '', description: 
 title 'Test aws launch template'
 
 control 'aws-launch-template-1.0' do
-  impact 1.0
   title 'Ensure AWS launch templates has the correct properties.'
 
   describe aws_ec2_launch_template(aws_launch_template_name: aws_launch_template_name) do

--- a/test/integration/verify/controls/aws_ec2_launch_templates.rb
+++ b/test/integration/verify/controls/aws_ec2_launch_templates.rb
@@ -3,7 +3,6 @@ aws_launch_template_name = input(:launch_template_name, value: '', description: 
 title 'Test AWS launch templates in bulk'
 
 control 'aws-launch-templates-1.0' do
-  impact 1.0
   title 'Ensure AWS launch templates resource has the correct properties.'
 
   describe aws_ec2_launch_templates do

--- a/test/integration/verify/controls/aws_ec2_network_insights_analysis.rb
+++ b/test/integration/verify/controls/aws_ec2_network_insights_analysis.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-ec2-network-insights-analysis-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws ec2 network insight analysis.'
 
   describe aws_ec2_network_insights_analysis(network_insights_analysis_id: 'nia-1234567890') do

--- a/test/integration/verify/controls/aws_ec2_network_insights_analysis_plural.rb
+++ b/test/integration/verify/controls/aws_ec2_network_insights_analysis_plural.rb
@@ -1,6 +1,5 @@
 skip_control 'aws-ec2-network-insights-analysis-plural-1.0' do
 
-  impact 1.0
   title 'Test a plural resource of the aws ec2 network insight analysis.'
 
   describe aws_ec2_network_insights_analysis_plural do

--- a/test/integration/verify/controls/aws_ec2_network_insights_path.rb
+++ b/test/integration/verify/controls/aws_ec2_network_insights_path.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-ec2-network-insights-path-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws ec2 network insight path.'
 
   describe aws_ec2_network_insights_path(network_insights_path_id: 'nip-1234567890') do

--- a/test/integration/verify/controls/aws_ec2_network_insights_paths.rb
+++ b/test/integration/verify/controls/aws_ec2_network_insights_paths.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-ec2-network-insights-paths-1.0' do
-  impact 1.0
   title 'Test a plural resource of the aws ec2 network insight path.'
 
   describe aws_ec2_network_insights_paths do

--- a/test/integration/verify/controls/aws_ec2_network_interface.rb
+++ b/test/integration/verify/controls/aws_ec2_network_interface.rb
@@ -1,7 +1,6 @@
 aws_network_interface_id = input(:aws_network_interface_id, value: '', description: '')
 
 control 'aws-ec2-network-interface-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws ec2 network interfaces.'
 
   describe aws_ec2_network_interface(network_interface_id: aws_network_interface_id) do

--- a/test/integration/verify/controls/aws_ec2_network_interface_attachment.rb
+++ b/test/integration/verify/controls/aws_ec2_network_interface_attachment.rb
@@ -1,7 +1,6 @@
 aws_network_interface_id = input(:aws_network_interface_id, value: '', description: '')
 
 control 'aws-ec2-network-interface-attachment-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws ec2 network interface attachments.'
 
   describe aws_ec2_network_interface_attachment(network_interface_id: aws_network_interface_id) do

--- a/test/integration/verify/controls/aws_ec2_network_interface_attachments.rb
+++ b/test/integration/verify/controls/aws_ec2_network_interface_attachments.rb
@@ -1,5 +1,4 @@
 control 'aws-ec2-network-interface-attachments-1.0' do
-  impact 1.0
   title 'Test a plural resource of the aws ec2 network interface attachments.'
 
   describe aws_ec2_network_interface_attachments do

--- a/test/integration/verify/controls/aws_ec2_network_interface_permission.rb
+++ b/test/integration/verify/controls/aws_ec2_network_interface_permission.rb
@@ -1,7 +1,6 @@
 title 'Test  a AWS Network Interface permission'
 
 skip_control 'aws-ec2-network-interface-permission-1.0' do
-  impact 1.0
   title 'Ensure AWS Network Interface permission has the correct properties.'
 
   describe aws_ec2_network_interface_permission(network_interface_permission_id: 'NetworkInterfacePermissionId') do

--- a/test/integration/verify/controls/aws_ec2_network_interface_permissions.rb
+++ b/test/integration/verify/controls/aws_ec2_network_interface_permissions.rb
@@ -1,7 +1,6 @@
 title 'Test  a AWS Network Interface permissions'
 
 skip_control 'aws-ec2-network-interface-permissions-1.0' do
-  impact 1.0
   title 'Ensure all the AWS Network Interface permissions has the correct properties.'
 
   describe aws_ec2_network_interface_permissions do

--- a/test/integration/verify/controls/aws_ec2_network_interfaces.rb
+++ b/test/integration/verify/controls/aws_ec2_network_interfaces.rb
@@ -1,5 +1,4 @@
 control 'aws-ec2-network-interfaces-1.0' do
-  impact 1.0
   title 'Test a plural resource of the aws ec2 network interfaces.'
 
   describe aws_ec2_network_interfaces do

--- a/test/integration/verify/controls/aws_ec2_network_manager_device.rb
+++ b/test/integration/verify/controls/aws_ec2_network_manager_device.rb
@@ -1,7 +1,6 @@
 title 'Test a AWS Network Device bulk'
 
 skip_control 'aws-network-manager-device-1.0' do
-  impact 1.0
   title 'Ensure AWS Network Device resource has the correct properties.'
 
   describe aws_network_manager_device(device_id: 'test1', global_network_id: 'test1') do

--- a/test/integration/verify/controls/aws_ec2_network_manager_devices.rb
+++ b/test/integration/verify/controls/aws_ec2_network_manager_devices.rb
@@ -1,7 +1,6 @@
 title 'Test a AWS Network Device in bulk'
 
 skip_control 'aws-network-manager-devices-1.0' do
-  impact 1.0
   title 'Ensure AWS Network Devices resource has the correct properties.'
 
   describe aws_network_manager_devices(global_network_id: 'test1') do

--- a/test/integration/verify/controls/aws_ec2_placement_group.rb
+++ b/test/integration/verify/controls/aws_ec2_placement_group.rb
@@ -2,7 +2,6 @@ aws_placement_group_name = input(:aws_placement_group_name, value: '', descripti
 aws_placement_group_placement_group_id = input(:aws_placement_group_placement_group_id, value: '', description: '')
 
 control 'aws-ec2-placement-group-1.0' do
-  impact 1.0
   title 'Describes the specified placement groups or all of your placement groups.'
 
   describe aws_ec2_placement_group(placement_group_name: aws_placement_group_name) do

--- a/test/integration/verify/controls/aws_ec2_placement_groups.rb
+++ b/test/integration/verify/controls/aws_ec2_placement_groups.rb
@@ -2,7 +2,6 @@ aws_placement_group_name = input(:aws_placement_group_name, value: '', descripti
 aws_placement_group_placement_group_id = input(:aws_placement_group_placement_group_id, value: '', description: '')
 
 control 'aws-ec2-placement-groups-1.0' do
-  impact 1.0
   title 'Describes the specified placement groups or all of your placement groups.'
 
   describe aws_ec2_placement_groups do

--- a/test/integration/verify/controls/aws_ec2_prefix_list.rb
+++ b/test/integration/verify/controls/aws_ec2_prefix_list.rb
@@ -1,7 +1,6 @@
 title 'Test single EC2 prefix list'
 
 skip_control 'aws-ec2-prefix-list-1.0' do
-  impact 1.0
   title 'Ensure EC2 prefix list singular resource has the correct properties.'
 
   describe aws_ec2_prefix_list(prefix_list_id: 'PrefixListID') do

--- a/test/integration/verify/controls/aws_ec2_prefix_lists.rb
+++ b/test/integration/verify/controls/aws_ec2_prefix_lists.rb
@@ -1,7 +1,6 @@
 title 'Test single EC2 prefix list'
 
 skip_control 'aws-ec2-prefix-lists-1.0' do
-  impact 1.0
   title 'Ensure EC2 prefix list plural resource has the correct properties.'
 
   describe aws_ec2_prefix_lists do

--- a/test/integration/verify/controls/aws_ec2_spot_fleet.rb
+++ b/test/integration/verify/controls/aws_ec2_spot_fleet.rb
@@ -2,7 +2,6 @@ aws_spot_fleet_request_id = input(:aws_spot_fleet_request_id, value: '', descrip
 aws_spot_fleet_request_iam_fleet_role = input(:aws_spot_fleet_request_iam_fleet_role, value: '', description: '')
 
 control 'aws-ec2-spot-fleet-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws ec2 spot fleet.'
 
   describe aws_ec2_spot_fleet(spot_fleet_request_id: aws_spot_fleet_request_id) do

--- a/test/integration/verify/controls/aws_ec2_spot_fleets.rb
+++ b/test/integration/verify/controls/aws_ec2_spot_fleets.rb
@@ -1,7 +1,6 @@
 aws_spot_fleet_request_id = input(:aws_spot_fleet_request_id, value: '', description: '')
 
 control 'aws-ec2-spot-fleets-1.0' do
-  impact 1.0
   title 'Test a plural resource of the aws ec2 spot fleet.'
 
   describe aws_ec2_spot_fleets do

--- a/test/integration/verify/controls/aws_ec2_traffic_mirror_filter.rb
+++ b/test/integration/verify/controls/aws_ec2_traffic_mirror_filter.rb
@@ -4,7 +4,6 @@ aws_traffic_filter_desc = input(:aws_traffic_filter_desc, value: '', description
 title 'Test single AWS Traffic Filter'
 
 control 'aws-traffic-filter-1.0' do
-  impact 1.0
   title 'Ensure AWS Traffic Filter resource has the correct properties.'
 
   describe aws_ec2_traffic_mirror_filter(aws_ec2_traffic_mirror_filter_id: aws_traffic_filter_id ) do

--- a/test/integration/verify/controls/aws_ec2_traffic_mirror_filters.rb
+++ b/test/integration/verify/controls/aws_ec2_traffic_mirror_filters.rb
@@ -4,7 +4,6 @@ aws_traffic_filter_desc = input(:aws_traffic_filter_desc, value: '', description
 title 'Test AWS Traffic Filters in bulk'
 
 control 'aws-traffic-filters-1.0' do
-  impact 1.0
   title 'Ensure AWS Traffic Filters resource has the correct properties.'
 
   describe aws_ec2_traffic_filters do

--- a/test/integration/verify/controls/aws_ec2_traffic_mirror_session.rb
+++ b/test/integration/verify/controls/aws_ec2_traffic_mirror_session.rb
@@ -4,7 +4,6 @@ traffic_mirror_filter_id = input(:traffic_mirror_filter_id, value: '', descripti
 network_interface_id = input(:network_interface_id, value: '', description: '')
 
 control 'aws-ec2-traffic-mirror-sessions-1.0' do
-  impact 1.0
   title 'Describes single Traffic Mirror Session.'
 
   describe aws_ec2_traffic_mirror_session(traffic_mirror_session_id:  traffic_mirror_session_id) do

--- a/test/integration/verify/controls/aws_ec2_traffic_mirror_sessions.rb
+++ b/test/integration/verify/controls/aws_ec2_traffic_mirror_sessions.rb
@@ -4,7 +4,6 @@ traffic_mirror_filter_id = input(:traffic_mirror_filter_id, value: '', descripti
 network_interface_id = input(:network_interface_id, value: '', description: '')
 
 control 'aws-ec2-traffic-mirror-session-1.0' do
-  impact 1.0
   title 'Describes single Traffic Mirror Session.'
 
   describe aws_ec2_traffic_mirror_sessions do

--- a/test/integration/verify/controls/aws_ec2_traffic_mirror_target.rb
+++ b/test/integration/verify/controls/aws_ec2_traffic_mirror_target.rb
@@ -1,7 +1,6 @@
 traffic_mirror_target_id = input(:traffic_mirror_target_id, value: '', description: '')
 
 control 'aws-ec2-traffic-mirror-target-1.0' do
-  impact 1.0
   title 'Describes single Traffic Mirror Target.'
   
   describe aws_ec2_traffic_mirror_target(traffic_mirror_target_id: traffic_mirror_target_id) do

--- a/test/integration/verify/controls/aws_ec2_traffic_mirror_targets.rb
+++ b/test/integration/verify/controls/aws_ec2_traffic_mirror_targets.rb
@@ -1,7 +1,6 @@
 traffic_mirror_target_id = input(:traffic_mirror_target_id, value: '', description: '')
 
 control 'aws-ec2-traffic-mirror-targets-1.0' do
-  impact 1.0
   title 'Describes single Traffic Mirror Target.'
     
   describe aws_ec2_traffic_mirror_targets do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_attachment.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_attachment.rb
@@ -3,7 +3,6 @@ aws_transit_gateway_id = input(:aws_transit_gateway_id, value: '', description: 
 aws_transit_gateway_owner_id = input(:aws_transit_gateway_owner_id, value: '', description: 'The ID of the AWS account that owns the transit gateway.')
 
 control 'aws-transit-gateway-attachment-1.0' do
-  impact 1.0
   title 'Describes one or more attachments between resources and transit gateways. By default, all attachments are described. Alternatively, you can filter the results by attachment ID, attachment state, resource ID, or resource owner.'
 
   describe aws_ec2_transit_gateway_attachment(transit_gateway_attachment_id: aws_transit_gateway_attachment_id) do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_attachments.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_attachments.rb
@@ -3,7 +3,6 @@ aws_transit_gateway_id = input(:aws_transit_gateway_id, value: '', description: 
 aws_transit_gateway_owner_id = input(:aws_transit_gateway_owner_id, value: '', description: 'The ID of the AWS account that owns the transit gateway.')
 
 control 'aws-transit-gateway-attachments-1.0' do
-  impact 1.0
   title 'Describes one or more attachments between resources and transit gateways. By default, all attachments are described. Alternatively, you can filter the results by attachment ID, attachment state, resource ID, or resource owner.'
 
   describe aws_ec2_transit_gateway_attachments do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_route_table.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_route_table.rb
@@ -5,7 +5,6 @@ default_association_route_table = true
 default_propagation_route_table = true
 
 control 'aws-transit-gateway-route-tables-1.0' do
-  impact 1.0
   title 'Describes one or more transit gateway route tables. By default, all transit gateway route tables are described. Alternatively, you can filter the results.'
 
   describe aws_ec2_transit_gateway_route_table(transit_gateway_route_table_id: transit_gateway_route_table_id) do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_association.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_association.rb
@@ -3,7 +3,6 @@ aws_resource_id = input(:aws_transit_gateway_attachment_vpc_id_association, valu
 aws_transit_gateway_route_table_id = input(:aws_transit_gateway_route_table_id_association, value: '', description: 'The ID of the route table for the transit gateway.')
 
 control 'aws-ec2-transit-gateway-route-table-association-1.0' do
-  impact 1.0
   title 'Gets information about the associations for the specified transit gateway route table.'
 
   describe aws_ec2_transit_gateway_route_table_association(transit_gateway_route_table_id: aws_transit_gateway_route_table_id) do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_associations.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_associations.rb
@@ -3,7 +3,6 @@ aws_resource_id = input(:aws_transit_gateway_attachment_vpc_id_association, valu
 aws_transit_gateway_route_table_id = input(:aws_transit_gateway_route_table_id_association, value: '', description: 'The ID of the route table for the transit gateway.')
 
 control 'aws-ec2-transit-gateway-route-table-associations-1.0' do
-  impact 1.0
   title 'Gets information about the associations for the specified transit gateway route table.'
 
   describe aws_ec2_transit_gateway_route_table_associations(transit_gateway_route_table_id: aws_transit_gateway_route_table_id) do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_propagation.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_propagation.rb
@@ -2,7 +2,6 @@ transit_gateway_route_table_id = input(:transit_gateway_route_table_id, value: '
 aws_transit_gateway_attachment_id = input(:aws_transit_gateway_attachment_id1, value: '', description: 'The IDs of the attachments.')
 
 control 'aws-ec2-transit-gateway-route-table-propagation-1.0' do
-  impact 1.0
   title 'Describes information about the route table propagations for the specified transit gateway route table.'
 
   describe aws_ec2_transit_gateway_route_table_propagation(transit_gateway_route_table_id: transit_gateway_route_table_id, transit_gateway_attachment_id: aws_transit_gateway_attachment_id) do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_propagations.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_route_table_propagations.rb
@@ -2,7 +2,6 @@ transit_gateway_route_table_id = input(:transit_gateway_route_table_id, value: '
 aws_transit_gateway_attachment_id = input(:aws_transit_gateway_attachment_id1, value: '', description: 'The IDs of the attachments.')
 
 control 'aws-ec2-transit-gateway-route-table-propagations-1.0' do
-  impact 1.0
   title 'Lists information about the route table propagations for the specified transit gateway route table.'
 
   describe aws_ec2_transit_gateway_route_table_propagations(transit_gateway_route_table_id: transit_gateway_route_table_id) do

--- a/test/integration/verify/controls/aws_ec2_transit_gateway_route_tables.rb
+++ b/test/integration/verify/controls/aws_ec2_transit_gateway_route_tables.rb
@@ -7,8 +7,7 @@ creation_time = input(:creation_time, value: '', description: 'The creation time
 tags = input(:tags, value: '', description: 'The tags of the transit gateway route table.')
 
 control 'aws-transit-gateway-route-tables-1.0' do
-    impact 1.0
-    title 'Describes one or more transit gateway route tables. By default, all transit gateway route tables are described. Alternatively, you can filter the results.'
+      title 'Describes one or more transit gateway route tables. By default, all transit gateway route tables are described. Alternatively, you can filter the results.'
     
     describe aws_ec2_transit_gateway_route_tables do
         it { should exist }

--- a/test/integration/verify/controls/aws_ec2_volume_attachment.rb
+++ b/test/integration/verify/controls/aws_ec2_volume_attachment.rb
@@ -2,7 +2,6 @@ aws_volume_attachment_instance_device_name = input(:aws_volume_attachment_instan
 aws_volume_attachment_instance_volume_id = input(:aws_volume_attachment_instance_volume_id, value: '', description: '')
 
 control 'aws-ec2-volume-attachment-1.0' do
-  impact 1.0
   title 'Test the properties of the aws ec2 volume attachment.'
 
   describe aws_ec2_volume_attachment(volume_id: aws_volume_attachment_instance_volume_id) do

--- a/test/integration/verify/controls/aws_ec2_volume_attachments.rb
+++ b/test/integration/verify/controls/aws_ec2_volume_attachments.rb
@@ -2,7 +2,6 @@ aws_volume_attachment_instance_device_name = input(:aws_volume_attachment_instan
 aws_volume_attachment_instance_volume_id = input(:aws_volume_attachment_instance_volume_id, value: '', description: '')
 
 control 'aws-ec2-volume-attachments-1.0' do
-  impact 1.0
   title 'Test the properties of the aws ec2 volume attachments.'
 
   describe aws_ec2_volume_attachments do

--- a/test/integration/verify/controls/aws_ec2_vpc_peering_connection.rb
+++ b/test/integration/verify/controls/aws_ec2_vpc_peering_connection.rb
@@ -3,7 +3,6 @@ aws_vpc_peering_test1_id = input(:aws_vpc_peering_test1_id, value: '', descripti
 aws_vpc_peering_test2_id = input(:aws_vpc_peering_test2_id, value: '', description: '')
 
 control 'aws-ec2-vpc-peering-connection-1.0' do
-  impact 1.0
   title 'Test the properties of the aws ec2 vpc peer connection.'
 
   describe aws_ec2_vpc_peering_connection(vpc_peering_connection_id: aws_vpc_peering_connection_id) do

--- a/test/integration/verify/controls/aws_ec2_vpc_peering_connections.rb
+++ b/test/integration/verify/controls/aws_ec2_vpc_peering_connections.rb
@@ -1,7 +1,6 @@
 aws_vpc_peering_connection_id = input(:aws_vpc_peering_connection_id, value: '', description: '')
 
 control 'aws-ec2-vpc-peering-connections-1.0' do
-  impact 1.0
   title 'Test the properties of the aws ec2 vpc peer connections.'
 
   describe aws_ec2_vpc_peering_connections do

--- a/test/integration/verify/controls/aws_ec2_vpn_connection_routes.rb
+++ b/test/integration/verify/controls/aws_ec2_vpn_connection_routes.rb
@@ -1,7 +1,6 @@
 aws_vpn_connection_id = input(:aws_vpn_connection_id, value: '', description: '')
 
 control 'aws-ec2_vpn-connection-routes-1.0' do
-  impact 1.0
   title 'Test the properties of the aws ec2 VPN connection routes.'
 
   describe aws_ec2_vpn_connection_routes(vpn_connection_id: aws_vpn_connection_id) do

--- a/test/integration/verify/controls/aws_ec2_vpn_endpoint.rb
+++ b/test/integration/verify/controls/aws_ec2_vpn_endpoint.rb
@@ -1,7 +1,6 @@
 client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: '')
 
 skip_control 'aws-ec2-client-vpn-endpoint-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn endpoint.'
 
   describe aws_ec2_client_vpn_endpoint(client_vpn_endpoint_id: client_vpn_endpoint_id) do

--- a/test/integration/verify/controls/aws_ec2_vpn_endpoints.rb
+++ b/test/integration/verify/controls/aws_ec2_vpn_endpoints.rb
@@ -1,7 +1,6 @@
 client_vpn_endpoint_id = input(:client_vpn_endpoint_id, value: '', description: '')
 
 skip_control 'aws-ec2-client-vpn-endpoints-1.0' do
-  impact 1.0
   title 'Test the properties of the vpn endpoints.'
 
   describe aws_ec2_client_vpn_endpoints do

--- a/test/integration/verify/controls/aws_ec2_vpn_gateway_route_propagation.rb
+++ b/test/integration/verify/controls/aws_ec2_vpn_gateway_route_propagation.rb
@@ -1,7 +1,6 @@
 aws_route_table_first_id = input(:aws_route_table_first_id, value: '', description: 'The AWS route table ID.')
 
 control 'aws-ec2-vpn-gateway-route-propagation-1.0' do
-  impact 1.0
   title 'Describes a virtual private gateway (VGW) to propagate routes to the specified route table of a VPC.'
 
   describe aws_ec2_vpn_gateway_route_propagation(route_table_id: aws_route_table_first_id) do

--- a/test/integration/verify/controls/aws_ec2_vpn_gateway_route_propagations.rb
+++ b/test/integration/verify/controls/aws_ec2_vpn_gateway_route_propagations.rb
@@ -1,7 +1,6 @@
 aws_route_table_first_id = input(:aws_route_table_first_id, value: '', description: 'The AWS route table ID.')
 
 control 'aws-ec2-vpn-gateway-route-propagations-1.0' do
-  impact 1.0
   title 'List the virtual private gateway (VGW) to propagate routes to the specified route table of a VPC.'
 
   describe aws_ec2_vpn_gateway_route_propagations do

--- a/test/integration/verify/controls/aws_ecr.rb
+++ b/test/integration/verify/controls/aws_ecr.rb
@@ -3,7 +3,6 @@ title 'Test single AWS ECR'
 aws_ecr_name = input(:aws_ecr_name, value: '', description: 'The AWS ECR name.')
 
 control 'aws-ecr-1.0' do
-  impact 1.0
   title 'Ensure AWS ECR has the correct properties.'
 
   describe aws_ecr(repository_name: aws_ecr_name) do

--- a/test/integration/verify/controls/aws_ecr_image.rb
+++ b/test/integration/verify/controls/aws_ecr_image.rb
@@ -3,7 +3,6 @@ aws_ecr_repository_name = input(:aws_ecr_repository_name, value: '', description
 title 'Test single AWS ECR Image in a repository'
 
 control 'aws-ecr-image-1.0' do
-  impact 1.0
   title 'Check AWS ECR image has the correct properties.'
 
   describe aws_ecr_image(repository_name: aws_ecr_repository_name, image_tag: 'latest') do

--- a/test/integration/verify/controls/aws_ecr_images.rb
+++ b/test/integration/verify/controls/aws_ecr_images.rb
@@ -3,7 +3,6 @@ aws_ecr_repository_name = input(:aws_ecr_repository_name, value: '', description
 title 'Test Multiple AWS ECR Images in a Repository'
 
 control 'aws-ecr-images-1.0' do
-  impact 1.0
   title 'Check AWS ECR images has the correct properties.'
 
   describe aws_ecr_images(repository_name: aws_ecr_repository_name) do

--- a/test/integration/verify/controls/aws_ecr_repositories.rb
+++ b/test/integration/verify/controls/aws_ecr_repositories.rb
@@ -7,7 +7,6 @@ aws_ecr_repository_scan_on_push_enabled = input(:aws_ecr_repository_scan_on_push
 title 'Test multiple AWS ECR Repositories'
 
 control 'aws-ecr-repositories-1.0' do
-  impact 1.0
   title 'Check AWS ECR repositories has the correct properties.'
 
   describe aws_ecr_repositories do

--- a/test/integration/verify/controls/aws_ecr_repository.rb
+++ b/test/integration/verify/controls/aws_ecr_repository.rb
@@ -7,7 +7,6 @@ aws_ecr_repository_scan_on_push_enabled = input(:aws_ecr_repository_scan_on_push
 title 'Test single AWS ECR Repository'
 
 control 'aws-ecr-repository-1.0' do
-  impact 1.0
   title 'Check AWS ECR repository has the correct properties.'
 
   describe aws_ecr_repository(repository_name: aws_ecr_repository_name) do

--- a/test/integration/verify/controls/aws_ecr_repository_policy.rb
+++ b/test/integration/verify/controls/aws_ecr_repository_policy.rb
@@ -4,7 +4,6 @@ aws_ecr_repo_name = input(:aws_ecr_repo_name, value: '', description: 'The ECR r
 aws_iam_user_policy_name = input(:aws_iam_user_policy_name, value: '', description: 'The AWS Iam User Inline Policy.')
 
 control 'aws-ecr-repo-policy-1.0' do
-  impact 1.0
   title 'Ensure ECR repo Policy has the correct properties.'
  
   describe aws_ecr_repository_policy(aws_ecr_repo_name) do

--- a/test/integration/verify/controls/aws_ecrpublic_repositories.rb
+++ b/test/integration/verify/controls/aws_ecrpublic_repositories.rb
@@ -3,7 +3,6 @@ aws_ecrpublic_repository_name = input(:aws_ecrpublic_repository_name, value: '',
 title 'Test multiple AWS ECR public Repositories'
 
 control 'aws-ecrpublic-repositories-1.0' do
-  impact 1.0
   title 'Check AWS ECR public repositories has the correct properties.'
 
   describe aws_ecrpublic_repositories do

--- a/test/integration/verify/controls/aws_ecrpublic_repository.rb
+++ b/test/integration/verify/controls/aws_ecrpublic_repository.rb
@@ -3,7 +3,6 @@ aws_ecrpublic_repository_name = input(:aws_ecrpublic_repository_name, value: '',
 title 'Test single AWS ECR public Repository'
 
 control 'aws-ecrpublic-repository-1.0' do
-  impact 1.0
   title 'Check AWS ECR public repository has the correct properties.'
 
   describe aws_ecrpublic_repository(repository_name: aws_ecrpublic_repository_name) do

--- a/test/integration/verify/controls/aws_ecs_cluster.rb
+++ b/test/integration/verify/controls/aws_ecs_cluster.rb
@@ -3,7 +3,6 @@ title 'Test single AWS ECS Cluster'
 aws_ecs_cluster_name = input(:aws_ecs_cluster_name, value: '', description: 'The AWS ECS Cluster name.')
 
 control 'aws-ecs-cluster-1.0' do
-  impact 1.0
   title 'Ensure AWS ECS Cluster has the correct properties.'
 
   describe aws_ecs_cluster(cluster_name: aws_ecs_cluster_name) do

--- a/test/integration/verify/controls/aws_ecs_clusters.rb
+++ b/test/integration/verify/controls/aws_ecs_clusters.rb
@@ -3,7 +3,6 @@ title 'Test a collection of AWS ECS Clusters'
 aws_ecs_cluster_name = input(:aws_ecs_cluster_name, value: '', description: 'The ECS Cluster name.')
 
 control 'aws-ecs-clusters-1.0' do
-  impact 1.0
   title 'Ensure AWS ECS Cluster plural resource has the correct properties.'
 
   describe aws_ecs_clusters do

--- a/test/integration/verify/controls/aws_ecs_service.rb
+++ b/test/integration/verify/controls/aws_ecs_service.rb
@@ -4,7 +4,6 @@ aws_service_name = input(:aws_ecs_service_name, value: '', description: '')
 aws_cluster_arn = input(:aws_cluster_arn, value: '', description: '')
 
 control 'aws-ecs-service-1.0' do
-  impact 1.0
   title 'Ensure AWS ECS Service has the correct properties.'
 
   describe aws_ecs_service(cluster: aws_cluster_name, services: aws_service_name ) do

--- a/test/integration/verify/controls/aws_ecs_services.rb
+++ b/test/integration/verify/controls/aws_ecs_services.rb
@@ -4,7 +4,6 @@ aws_service_name = input(:aws_ecs_service_name, value: '', description: '')
 aws_cluster_arn = input(:aws_cluster_arn, value: '', description: '')
 
 control 'aws-ecs-services-1.0' do
-  impact 1.0
   title 'Ensure AWS ECS Services has the correct properties.'
 
   describe aws_ecs_services(cluster: aws_cluster_names) do

--- a/test/integration/verify/controls/aws_ecs_task_definition.rb
+++ b/test/integration/verify/controls/aws_ecs_task_definition.rb
@@ -2,7 +2,6 @@ aws_ecs_task_definition_arn = input(:aws_ecs_task_definition_arn, value: '', des
 aws_ecs_task_definition_revision = input(:aws_ecs_task_definition_revision, value: '', description: '')
 
 control 'aws-ec2-task-definition-1.0' do
-  impact 1.0
   title 'Ensure EC2 Task Definition has the correct properties.'
 
   describe aws_ecs_task_definition(task_definition: 'service:'+aws_ecs_task_definition_revision) do

--- a/test/integration/verify/controls/aws_ecs_task_definitions.rb
+++ b/test/integration/verify/controls/aws_ecs_task_definitions.rb
@@ -1,5 +1,4 @@
 control 'aws-ec2-task-definitions-1.0' do
-  impact 1.0
   title 'Ensure EC2 Task Definitions has the correct properties.'
   
   describe aws_ecs_task_definitions do

--- a/test/integration/verify/controls/aws_efs_file_system.rb
+++ b/test/integration/verify/controls/aws_efs_file_system.rb
@@ -7,7 +7,6 @@ aws_efs_throughput_mode = input(:aws_efs_throughput_mode, value: '', description
 aws_efs_name = input(:aws_efs_name, value: '', description: 'The EFS File System name.')
 
 control 'aws-efs-file-system-1.0' do
-  impact 1.0
   title 'Check AWS EFS File System has the correct properties.'
 
   describe aws_efs_file_system(creation_token: aws_efs_creation_token) do

--- a/test/integration/verify/controls/aws_efs_file_systems.rb
+++ b/test/integration/verify/controls/aws_efs_file_systems.rb
@@ -7,7 +7,6 @@ aws_efs_company_name = input(:aws_efs_company_name, value: '', description: 'The
 aws_efs_count = input(:aws_efs_count, value: '', description: 'The number of EFS File Systems.')
 
 control 'aws-efs-file-systems-1.0' do
-  impact 1.0
   title 'Ensure AWS EFS File System plural resource has the correct properties.'
 
   describe aws_efs_file_systems do

--- a/test/integration/verify/controls/aws_efs_mount_target.rb
+++ b/test/integration/verify/controls/aws_efs_mount_target.rb
@@ -4,7 +4,6 @@ aws_subnet_mt_id = input(:aws_subnet_mt_id, value: '', description: '')
 aws_vpc_mt_id = input(:aws_vpc_mt_id, value: '', description: '')
 
 control 'aws-efs-mount-target-1.0' do
-  impact 1.0
   title 'Ensure AWS EFS Mount Target has the correct properties.'
   
   describe aws_efs_mount_target(mount_target_id: aws_mount_target_mt_id) do

--- a/test/integration/verify/controls/aws_efs_mount_targets.rb
+++ b/test/integration/verify/controls/aws_efs_mount_targets.rb
@@ -4,7 +4,6 @@ aws_subnet_mt_id = input(:aws_subnet_mt_id, value: '', description: '')
 aws_vpc_mt_id = input(:aws_vpc_mt_id, value: '', description: '')
 
 control 'aws-efs-mount-targets-1.0' do
-  impact 1.0
   title 'Ensure AWS EFS Mount Targets has the correct properties.'
   
   describe aws_efs_mount_targets(file_system_id: aws_file_system_mt_id) do

--- a/test/integration/verify/controls/aws_eks_cluster.rb
+++ b/test/integration/verify/controls/aws_eks_cluster.rb
@@ -3,7 +3,6 @@ title 'Test a single AWS EKS Cluster'
 cluster_name = input(:aws_eks_cluster_name, value: '', description: 'The AWS EKS Cluster name.')
 
 control 'aws-eks-cluster-1.0' do
-  impact 1.0
   title 'Ensure AWS EKS Cluster has the correct properties.'
 
   describe aws_eks_cluster(cluster_name: cluster_name) do

--- a/test/integration/verify/controls/aws_eks_clusters.rb
+++ b/test/integration/verify/controls/aws_eks_clusters.rb
@@ -3,7 +3,6 @@ title 'Test a collection of AWS EKS Clusters'
 cluster_name = input(:aws_eks_cluster_name, value: '', description: 'The AWS EKS Cluster name.')
 
 control 'aws-eks-clusters-1.0' do
-  impact 1.0
   title 'Ensure AWS EKS Clusters have the correct properties.'
 
   describe aws_eks_clusters do

--- a/test/integration/verify/controls/aws_elasticache_cluster.rb
+++ b/test/integration/verify/controls/aws_elasticache_cluster.rb
@@ -8,7 +8,6 @@ aws_elasticache_cluster_parameter_group_name = input(:aws_elasticache_cluster_pa
 title 'Test single AWS ElastiCache Cluster'
 
 control 'aws-elasticache-cluster-1.0' do
-  impact 1.0
   title 'Ensure AWS ElastiCache Cluster has the correct properties.'
 
   describe aws_elasticache_cluster(cache_cluster_id: aws_elasticache_cluster_id) do

--- a/test/integration/verify/controls/aws_elasticache_cluster_node.rb
+++ b/test/integration/verify/controls/aws_elasticache_cluster_node.rb
@@ -4,7 +4,6 @@ aws_elasticache_cluster_id = input(:aws_elasticache_cluster_id, value: '', descr
 aws_elasticache_cluster_port = input(:aws_elasticache_cluster_port, value: '', description: 'The AWS ElastiCache Cluster port number.')
 
 control 'aws-elasticache-cluster-node-1.0' do
-  impact 1.0
   title 'Ensure AWS ElastiCache Cluster node has the correct properties.'
 
   aws_elasticache_cluster(cache_cluster_id: aws_elasticache_cluster_id).node_ids.each do |node_id|

--- a/test/integration/verify/controls/aws_elasticache_clusters.rb
+++ b/test/integration/verify/controls/aws_elasticache_clusters.rb
@@ -4,7 +4,6 @@ aws_elasticache_cluster_engine = input(:aws_elasticache_cluster_engine, value: '
 title 'Test multiple AWS ElastiCache Clusters'
 
 control 'aws-elasticache-clusters-1.0' do
-  impact 1.0
   title 'Ensure AWS ElastiCache Clusters have the correct properties.'
 
   describe aws_elasticache_clusters do

--- a/test/integration/verify/controls/aws_elasticache_replication_group.rb
+++ b/test/integration/verify/controls/aws_elasticache_replication_group.rb
@@ -4,7 +4,6 @@ aws_elasticache_replication_group_node_type = input(:aws_elasticache_replication
 title 'Test single AWS ElastiCache Replication Group'
 
 control 'aws-elasticache-replication-group-1.0' do
-  impact 1.0
   title 'Ensure AWS ElastiCache Replication Group has the correct properties.'
 
   describe aws_elasticache_replication_group(replication_group_id: aws_elasticache_replication_group_id) do

--- a/test/integration/verify/controls/aws_elasticache_replication_groups.rb
+++ b/test/integration/verify/controls/aws_elasticache_replication_groups.rb
@@ -3,7 +3,6 @@ aws_elasticache_replication_group_id = input(:aws_elasticache_replication_group_
 title 'Test multiple AWS ElastiCache Replication Group'
 
 control 'aws-elasticache-replication-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS ElastiCache Replication Groups has the correct properties.'
 
   describe aws_elasticache_replication_groups do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_listener.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_listener.rb
@@ -2,7 +2,6 @@ aws_ebs2_lb_arn = input(:aws_ebs2_lb_arn, value: '', description: '')
 aws_ebs2_lb_listener_arn = input(:aws_ebs2_lb_listener_arn, value: '', description: '')
 
 control 'aws-elbv2-listener-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBv2 listener has the correct properties.'
   
   describe aws_elasticloadbalancingv2_listener(listener_arn: aws_ebs2_lb_listener_arn) do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_certificate.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_certificate.rb
@@ -2,7 +2,6 @@ aws_elb2_listener_arn = input(:aws_elb2_listener_arn, value: '', description: ''
 aws_elb2_certificate_arn = input(:aws_elb2_certificate_arn, value: '', description: '')
 
 control 'aws-elb2-listener-certificate-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBV2 Listener Certificate has the correct properties.'
 
   describe aws_elasticloadbalancingv2_listener_certificate(listener_arn: aws_elb2_listener_arn) do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_certificates.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_certificates.rb
@@ -2,7 +2,6 @@ aws_elb2_listener_arn = input(:aws_elb2_listener_arn, value: '', description: ''
 aws_elb2_certificate_arn = input(:aws_elb2_certificate_arn, value: '', description: '')
 
 control 'aws-elb2-listener-certificates-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBV2 Listener Certificates has the correct properties.'
 
   describe aws_elasticloadbalancingv2_listener_certificates(listener_arn: aws_elb2_listener_arn) do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_rule.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_rule.rb
@@ -1,7 +1,6 @@
 aws_elbv2_rule_arn = input(:aws_elbv2_rule_arn, value: '', description: '')
 
 control 'aws-elbv2-listener-rule-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBv2 Listener Rule has the correct properties.'
 
   describe aws_elasticloadbalancingv2_listener_rule(rule_arns: aws_elbv2_rule_arn) do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_rules.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_listener_rules.rb
@@ -1,7 +1,6 @@
 listener_arn = input(:listener_arn, value: '', description: '')
 
 control 'aws-elbv2-listener-rules-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBv2 Listener Rules has the correct properties.'
 
   describe aws_elasticloadbalancingv2_listener_rules(listener_arn: listener_arn) do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_listeners.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_listeners.rb
@@ -2,7 +2,6 @@ listener_arn = input(:listener_arn, value: '', description: '')
 load_balancer_arn = input(:load_balancer_arn, value: '', description: '')
 
 control 'aws-elbv2-listeners-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBv2 listeners has the correct properties.'
   
   describe aws_elasticloadbalancingv2_listeners(load_balancer_arn: load_balancer_arn) do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_target_group.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_target_group.rb
@@ -1,7 +1,6 @@
 aws_target_group_arn = input(:aws_target_group_arn, value: '', description: '')
 
 control 'aws-elbv2-target-group-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBv2 Target Group has the correct properties.'
 
   describe aws_elasticloadbalancingv2_target_group(target_group_arns: aws_target_group_arn) do

--- a/test/integration/verify/controls/aws_elasticloadbalancingv2_target_groups.rb
+++ b/test/integration/verify/controls/aws_elasticloadbalancingv2_target_groups.rb
@@ -1,7 +1,6 @@
 aws_target_group_arn = input(:aws_target_group_arn, value: '', description: '')
 
 control 'aws-elbv2-target-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBv2 Target Groups has the correct properties.'
 
   describe aws_elasticloadbalancingv2_target_groups do

--- a/test/integration/verify/controls/aws_elasticsearchservice_domain.rb
+++ b/test/integration/verify/controls/aws_elasticsearchservice_domain.rb
@@ -5,7 +5,6 @@ aws_elasticsearch_version = input(:aws_elasticsearch_version, value: '', descrip
 aws_elasticsearch_instance_type = input(:aws_elasticsearch_instance_type, value: '', description: '')
 
 control 'aws-elasticsearch-domain-1.0' do
-  impact 1.0
   title 'Ensure AWS Elastic Search Domain has the correct properties.'
 
   describe aws_elasticsearchservice_domain(domain_name: aws_elasticsearch_domain_name) do

--- a/test/integration/verify/controls/aws_elasticsearchservice_domains.rb
+++ b/test/integration/verify/controls/aws_elasticsearchservice_domains.rb
@@ -1,7 +1,6 @@
 aws_elasticsearch_domain_name = input(:aws_elasticsearch_domain_name, value: '', description: '')
 
 control 'aws-elasticsearch-domains-1.0' do
-  impact 1.0
   title 'Ensure AWS Elastic Search Domains has the correct properties.'
 
   describe aws_elasticsearchservice_domains do

--- a/test/integration/verify/controls/aws_elb.rb
+++ b/test/integration/verify/controls/aws_elb.rb
@@ -3,7 +3,6 @@ title 'Test single AWS ELB'
 aws_elb_name = input(:aws_elb_name, value: '', description: 'The AWS ELB name.')
 
 control 'aws-elb-1.0' do
-  impact 1.0
   title 'Ensure AWS ELB has the correct properties.'
 
   describe aws_elb(load_balancer_name: aws_elb_name) do

--- a/test/integration/verify/controls/aws_elbs.rb
+++ b/test/integration/verify/controls/aws_elbs.rb
@@ -3,7 +3,6 @@ title 'Test a collection of AWS ELBs'
 aws_elb_name = input(:aws_elb_name, value: '', description: 'The AWS ELB name.')
 
 control 'aws-elbs-1.0' do
-  impact 1.0
   title 'Ensure AWS ELBs have the correct properties.'
 
   describe aws_elbs do

--- a/test/integration/verify/controls/aws_emr_cluster.rb
+++ b/test/integration/verify/controls/aws_emr_cluster.rb
@@ -10,7 +10,6 @@ aws_emr_cluster_visible_to_all_users = (aws_emr_cluster_visible_to_all_users.dow
 aws_emr_cluster_release_label = input(:aws_emr_cluster_release_label, value: '', description: 'Release label for the Amazon EMR release.')
 
 control 'aws-emr-cluster-1.0' do
-  impact 1.0
   title 'Test single AWS EMR Cluster'
 
   describe aws_emr_cluster(cluster_id: aws_emr_cluster_id) do

--- a/test/integration/verify/controls/aws_emr_clusters.rb
+++ b/test/integration/verify/controls/aws_emr_clusters.rb
@@ -11,7 +11,6 @@ aws_emr_cluster_release_label = input(:aws_emr_cluster_release_label, value: '',
 aws_emr_cluster_release_label.gsub!('"', '')
 
 control 'aws-emr-clusters-1.0' do
-  impact 1.0
   title 'Test AWS EMR Cluster in bulk'
 
   describe aws_emr_clusters do

--- a/test/integration/verify/controls/aws_emr_security_configuration.rb
+++ b/test/integration/verify/controls/aws_emr_security_configuration.rb
@@ -14,7 +14,6 @@ local_disk_encryption = !parsed_json['EncryptionConfiguration']['AtRestEncryptio
                           !parsed_json['EncryptionConfiguration']['AtRestEncryptionConfiguration']['LocalDiskEncryptionConfiguration'].empty?
 
 control 'aws-emr-security-configuration-1.0' do
-  impact 1.0
   title 'Test single AWS EMR Security Configuration'
 
   describe aws_emr_security_configuration(security_configuration_name: aws_emr_security_configuration_name) do

--- a/test/integration/verify/controls/aws_emr_security_configurations.rb
+++ b/test/integration/verify/controls/aws_emr_security_configurations.rb
@@ -13,7 +13,6 @@ local_disk_encryption = !parsed_json['EncryptionConfiguration']['AtRestEncryptio
                           !parsed_json['EncryptionConfiguration']['AtRestEncryptionConfiguration']['LocalDiskEncryptionConfiguration'].empty?
 
 control 'aws-emr-security-configurations-1.0' do
-  impact 1.0
   title 'Test AWS EMR Security Configuration in bulk'
 
   describe aws_emr_security_configurations do

--- a/test/integration/verify/controls/aws_eventbridge_rule.rb
+++ b/test/integration/verify/controls/aws_eventbridge_rule.rb
@@ -1,7 +1,6 @@
 aws_cloudwatch_event_rule_arn = input(:aws_cloudwatch_event_rule_arn, value: '', description: '')
 
 control 'aws-event-rule-1.0' do
-  impact 1.0
   title 'Ensure AWS Event Rule has the correct properties.'
 
   describe aws_eventbridge_rule(name: 'test_rule') do

--- a/test/integration/verify/controls/aws_eventbridge_rules.rb
+++ b/test/integration/verify/controls/aws_eventbridge_rules.rb
@@ -1,7 +1,6 @@
 aws_cloudwatch_event_rule_arn = input(:aws_cloudwatch_event_rule_arn, value: '', description: '')
 
 control 'aws-event-rules-1.0' do
-  impact 1.0
   title 'Ensure AWS Event Rules has the correct properties.'
 
   describe aws_eventbridge_rules do

--- a/test/integration/verify/controls/aws_flow_log.rb
+++ b/test/integration/verify/controls/aws_flow_log.rb
@@ -4,7 +4,6 @@ aws_vpc_flow_log_id = input(:aws_vpc_flow_log_id, value: '', description: 'The A
 aws_flow_log_id = input(:aws_flow_log_id, value: '', description: 'The AWS flow log ID.')
 
 control 'aws-flow-log-1.0' do
-  impact 1.0
   title 'Ensure AWS Flow Log has the correct properties.'
 
   describe aws_flow_log(vpc_id: aws_vpc_flow_log_id) do

--- a/test/integration/verify/controls/aws_glue_crawler.rb
+++ b/test/integration/verify/controls/aws_glue_crawler.rb
@@ -1,7 +1,6 @@
 aws_crawler_name = input(:aws_crawler_name, value: '', description: '')
 
 control 'aws-glue-crawler-1.0' do
-  impact 1.0
   title 'Ensure AWS Glue Crawler has the correct properties.'
 
   describe aws_glue_crawler(name: aws_crawler_name) do

--- a/test/integration/verify/controls/aws_glue_crawlers.rb
+++ b/test/integration/verify/controls/aws_glue_crawlers.rb
@@ -1,7 +1,6 @@
 aws_crawler_name = input(:aws_crawler_name, value: '', description: '')
 
 control 'aws-glue-crawlers-1.0' do
-  impact 1.0
   title 'Ensure AWS Glue Crawlers has the correct properties.'
 
   describe aws_glue_crawlers do

--- a/test/integration/verify/controls/aws_glue_database.rb
+++ b/test/integration/verify/controls/aws_glue_database.rb
@@ -1,5 +1,4 @@
 control 'aws-glue-database-1.0' do
-  impact 1.0
   title 'Ensure AWS Glue Database singular resource have the correct properties.'
 
   describe aws_glue_database(name: 'sampledb') do

--- a/test/integration/verify/controls/aws_glue_databases.rb
+++ b/test/integration/verify/controls/aws_glue_databases.rb
@@ -1,5 +1,4 @@
 control 'aws-glue-databases-1.0' do
-  impact 1.0
   title 'Ensure AWS Glue Databases plural resource have the correct properties.'
 
   describe aws_glue_databases do
@@ -17,5 +16,4 @@ control 'aws-glue-databases-1.0' do
     its('catalog_ids') { should_not include '112758395563' }
   end
 end
-  
   

--- a/test/integration/verify/controls/aws_guardduty_detector.rb
+++ b/test/integration/verify/controls/aws_guardduty_detector.rb
@@ -4,7 +4,6 @@ aws_guardduty_detector_id = input(:aws_guardduty_detector_id, value: '', descrip
 aws_guardduty_detector_publishing_frequency = input(:aws_guardduty_detector_publishing_frequency, value: '', description: '')
 
 control 'aws-guardduty-detector-1.0' do
-  impact 1.0
   title 'Ensure AWS GuardDuty Detector has current properties'
 
   describe aws_guardduty_detector(detector_id: aws_guardduty_detector_id) do

--- a/test/integration/verify/controls/aws_guardduty_detectors.rb
+++ b/test/integration/verify/controls/aws_guardduty_detectors.rb
@@ -4,7 +4,6 @@ aws_guardduty_detector_id = input(:aws_guardduty_detector_id, value: '', descrip
 aws_guardduty_detector_publishing_frequency = input(:aws_guardduty_detector_publishing_frequency, value: '', description: '')
 
 control 'aws-guardduty-detectors-1.0' do
-  impact 1.0
   title 'Ensure AWS GuardDuty Detector has current properties'
 
   describe aws_guardduty_detectors do

--- a/test/integration/verify/controls/aws_hosted_zone.rb
+++ b/test/integration/verify/controls/aws_hosted_zone.rb
@@ -1,7 +1,6 @@
 hosted_zone_name = input(:aws_route_53_zone, value: '', description: '')
 
 control 'Hosted zone validation' do
-  impact 1.0
   title 'Hosted zone validation'
   desc 'Confirm hosted zone tests are correct'
 

--- a/test/integration/verify/controls/aws_hosted_zones.rb
+++ b/test/integration/verify/controls/aws_hosted_zones.rb
@@ -4,7 +4,6 @@ aws_route53_zone_name = input(:aws_route53_zone_name, value: '', description: ''
 title 'Ensure the hosted zone have the correct properties.'
 
 control 'aws-hosted-zones-1.0' do
-  impact 1.0
   title 'Ensure the hosted zone have the correct properties.'
 
   describe aws_hosted_zones do

--- a/test/integration/verify/controls/aws_iam_access_key.rb
+++ b/test/integration/verify/controls/aws_iam_access_key.rb
@@ -4,7 +4,6 @@ invalid_username = 'i-do-not-exist'
 invalid_key_id = 'AKIA1111111111111111'
 
 control 'aws-iam-access-key-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Access Key has the correct properties.'
 
   # Neither user nor access key ID exist

--- a/test/integration/verify/controls/aws_iam_access_keys.rb
+++ b/test/integration/verify/controls/aws_iam_access_keys.rb
@@ -3,7 +3,6 @@ aws_iam_access_key = input(:aws_iam_access_key_id, value: '', description: 'The 
 invalid_username = 'i-do-not-exist'
 
 control 'aws-iam-access-keys-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Access Key has the correct properties.'
 
   describe aws_iam_access_keys do

--- a/test/integration/verify/controls/aws_iam_account_alias.rb
+++ b/test/integration/verify/controls/aws_iam_account_alias.rb
@@ -1,5 +1,4 @@
 control 'aws-iam-account-alias-1.0' do
-  impact 1.0
   title 'Test the AWS IAM Account Alias'
 
   describe aws_iam_account_alias do

--- a/test/integration/verify/controls/aws_iam_group.rb
+++ b/test/integration/verify/controls/aws_iam_group.rb
@@ -3,7 +3,6 @@ title 'Test single AWS Group'
 aws_iam_group_name = input(:aws_iam_group_name, value: '', description: 'The AWS Iam Group name.')
 
 control 'aws-iam-group-1.0' do
-  impact 1.0
   title 'Ensure AWS Iam Group has the correct properties.'
 
   describe aws_iam_group(group_name: aws_iam_group_name) do

--- a/test/integration/verify/controls/aws_iam_groups.rb
+++ b/test/integration/verify/controls/aws_iam_groups.rb
@@ -3,7 +3,6 @@ title 'Test a collection AWS Groups'
 aws_iam_group_name = input(:aws_iam_group_name, value: '', description: 'The AWS Iam Group name.')
 
 control 'aws-iam-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS Iam Groups have the correct properties.'
 
   describe aws_iam_groups do

--- a/test/integration/verify/controls/aws_iam_inline_policy.rb
+++ b/test/integration/verify/controls/aws_iam_inline_policy.rb
@@ -13,7 +13,6 @@ aws_iam_group_name = input(:aws_iam_group_name, value: '', description: 'The AWS
 aws_iam_group_policy_name = input(:aws_iam_group_policy_name, value: '', description: 'The AWS Iam Group Inline Policy.')
 
 control 'aws-iam-inline-policy-1.0' do
-  impact 1.0
   title 'Ensure AWS Iam Inline Policy has the correct properties.'
 
   # IAM User inline policy 

--- a/test/integration/verify/controls/aws_iam_instance_profile.rb
+++ b/test/integration/verify/controls/aws_iam_instance_profile.rb
@@ -6,7 +6,6 @@ aws_iam_role_id = input(:aws_iam_role_id, value: '', description: '')
 aws_iam_role_arn = input(:aws_iam_role_arn, value: '', description: '')
 
 control 'aws-iam-instance-profile-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Instance Profile has the correct properties.'
 
   describe aws_iam_instance_profile(instance_profile_name: aws_iam_instance_profile_name) do

--- a/test/integration/verify/controls/aws_iam_instance_profiles.rb
+++ b/test/integration/verify/controls/aws_iam_instance_profiles.rb
@@ -2,7 +2,6 @@ aws_iam_instance_profile_name = input(:aws_iam_instance_profile_name1, value: ''
 aws_iam_instance_profile_arn = input(:aws_iam_instance_profile_arn, value: '', description: '')
 
 control 'aws-iam-instance-profiles-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Instance Profiles has the correct properties.'
 
   describe aws_iam_instance_profiles do

--- a/test/integration/verify/controls/aws_iam_managed_policies.rb
+++ b/test/integration/verify/controls/aws_iam_managed_policies.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-managed-policies-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Managed Policy Plural resource has the correct properties.'
 
   describe aws_iam_managed_policies do

--- a/test/integration/verify/controls/aws_iam_managed_policy.rb
+++ b/test/integration/verify/controls/aws_iam_managed_policy.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-managed-policy-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Managed Policy Singular resource has the correct properties.'
 
   describe aws_iam_managed_policy(policy_arn: 'arn:aws:iam::aws:policy/aws-service-role/ClientVPNServiceRolePolicy') do

--- a/test/integration/verify/controls/aws_iam_oidc_provider.rb
+++ b/test/integration/verify/controls/aws_iam_oidc_provider.rb
@@ -3,7 +3,6 @@ open_id_connect_provider_arn = input(:oidc_arn, value: '', description: '')
 title 'Test an IAM OIDC Provider'
 
 control 'aws-iam-oidc-provider-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM OIDC Provider has the correct properties.'
 
   describe aws_iam_oidc_provider(open_id_connect_provider_arn: open_id_connect_provider_arn) do

--- a/test/integration/verify/controls/aws_iam_oidc_providers.rb
+++ b/test/integration/verify/controls/aws_iam_oidc_providers.rb
@@ -3,7 +3,6 @@ open_id_connect_provider_arn = input(:oidc_arn, value: '', description: '')
 title 'Test an IAM OIDC Providers'
 
 control 'aws-iam-oidc-providers-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM OIDC Providers has the correct properties.'
 
   describe aws_iam_oidc_providers do

--- a/test/integration/verify/controls/aws_iam_password_policy.rb
+++ b/test/integration/verify/controls/aws_iam_password_policy.rb
@@ -1,7 +1,6 @@
 title 'Test an IAM Password Policy'
 
 control 'aws-iam-password-policy-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Password Policy has the correct properties.'
 
   describe aws_iam_password_policy do

--- a/test/integration/verify/controls/aws_iam_policies.rb
+++ b/test/integration/verify/controls/aws_iam_policies.rb
@@ -4,7 +4,6 @@ aws_iam_policy_arn = input(:aws_iam_policy_arn, value: '', description: 'The AWS
 aws_iam_attached_policy_arn = input(:aws_iam_attached_policy_arn, value: '', description: 'The AWS Iam Policy arn.')
 
 control 'aws-iam-policies-1.0' do
-  impact 1.0
   title 'Ensure AWS Iam Policies have the correct properties.'
 
   describe aws_iam_policies do

--- a/test/integration/verify/controls/aws_iam_policy.rb
+++ b/test/integration/verify/controls/aws_iam_policy.rb
@@ -7,7 +7,6 @@ aws_iam_user_name = input(:aws_iam_user_name, value: '', description: 'The Attac
 aws_iam_role_generic_name = input(:aws_iam_role_generic_name, value: '', description: 'The AWS Iam Role.')
 
 control 'aws-iam-policy-1.0' do
-  impact 1.0
   title 'Ensure AWS Iam Policy has the correct properties.'
 
   describe aws_iam_policy(policy_arn: aws_iam_policy_arn) do

--- a/test/integration/verify/controls/aws_iam_role.rb
+++ b/test/integration/verify/controls/aws_iam_role.rb
@@ -4,7 +4,6 @@ aws_iam_role_attached_policy_name = input(:aws_iam_attached_policy_name, value: 
 aws_iam_role_attached_policy_arn = input(:aws_iam_attached_policy_arn, value: '', description: 'The AWS IAM Role attached policy name.')
 
 control 'AWS IAM Role search for default AWS role' do
-  impact 1.0
   title 'Test the AWS IAM Role'
   
   describe aws_iam_role(role_name: aws_iam_role_name) do

--- a/test/integration/verify/controls/aws_iam_roles.rb
+++ b/test/integration/verify/controls/aws_iam_roles.rb
@@ -1,7 +1,6 @@
 aws_iam_role_name = input(:aws_iam_role_generic_name, value: '', description: 'The AWS IAM Role name.')
 
 control 'AWS IAM Role search for default AWS role' do
-  impact 1.0
   title 'Test the AWS IAM Roles'
   
   describe aws_iam_roles do

--- a/test/integration/verify/controls/aws_iam_root_user.rb
+++ b/test/integration/verify/controls/aws_iam_root_user.rb
@@ -1,5 +1,4 @@
 control 'aws-iam-root-user-1.0' do
-  impact 1.0
   title 'Test the AWS IAM Root User'
 
   describe aws_iam_root_user do

--- a/test/integration/verify/controls/aws_iam_server_certificate.rb
+++ b/test/integration/verify/controls/aws_iam_server_certificate.rb
@@ -2,7 +2,6 @@ server_certificate_name = input(:server_certificate_name, value: '', description
 server_certificate_id = input(:server_certificate_id, value: '', description: '')
 
 control 'aws_iam_server_certificate-1.0' do
-  impact 1.0
   title 'Ensure the server certificate have the correct properties.'
 
   describe aws_iam_server_certificate(server_certificate_name: server_certificate_name) do

--- a/test/integration/verify/controls/aws_iam_server_certificates.rb
+++ b/test/integration/verify/controls/aws_iam_server_certificates.rb
@@ -2,7 +2,6 @@ server_certificate_name = input(:server_certificate_name, value: '', description
 server_certificate_id = input(:server_certificate_id, value: '', description: '')
 
 control 'aws_iam_server_certificates-1.0' do
-  impact 1.0
   title 'Ensure the server certificates have the correct properties.'
 
   describe aws_iam_server_certificates do

--- a/test/integration/verify/controls/aws_iam_service_linked_role_deletion_status.rb
+++ b/test/integration/verify/controls/aws_iam_service_linked_role_deletion_status.rb
@@ -1,5 +1,4 @@
 skip_control 'service-linked-role-deletion-status' do
-  impact 1.0
   title 'Test the deletion status of serviced linked role'
   
   describe aws_iam_service_linked_role_deletion_status(deletion_task_id: 'dummy-value') do

--- a/test/integration/verify/controls/aws_iam_ssh_public_key.rb
+++ b/test/integration/verify/controls/aws_iam_ssh_public_key.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-iam-ssh-public-key-1.0' do
-  impact 1.0
   title 'Test the properties of the iam ssh public key.'
 
   describe aws_iam_ssh_public_key(user_name: 'USER_NAME', ssh_public_key_id: 'SSH_PUBLIC_KEY_ID', encoding: 'SSH') do

--- a/test/integration/verify/controls/aws_iam_ssh_public_keys.rb
+++ b/test/integration/verify/controls/aws_iam_ssh_public_keys.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-iam-ssh-public-keys-1.0' do
-  impact 1.0
   title 'Test the properties of the iam ssh public keys.'
 
   describe aws_iam_ssh_public_keys(username: 'USER_NAME') do

--- a/test/integration/verify/controls/aws_iam_user.rb
+++ b/test/integration/verify/controls/aws_iam_user.rb
@@ -3,7 +3,6 @@ title 'Test single AWS IAM User'
 aws_iam_user_name = input(:aws_iam_user_name, value: '', description: 'The AWS IAM Username.')
 
 control 'aws-iam-user-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM User has the correct properties.'
 
   describe aws_iam_user(aws_iam_user_name) do

--- a/test/integration/verify/controls/aws_iam_users.rb
+++ b/test/integration/verify/controls/aws_iam_users.rb
@@ -3,7 +3,6 @@ title 'Test a collection of AWS IAM Users'
 aws_iam_user_name = input(:aws_iam_user_name, value: '', description: 'The User Name')
 
 control 'aws-iam-users-1.0' do
-  impact 1.0
   title 'Ensure AWS IAM Users plural resource has the correct properties.'
 
   describe aws_iam_users do

--- a/test/integration/verify/controls/aws_iam_virtual_mfa_devices.rb
+++ b/test/integration/verify/controls/aws_iam_virtual_mfa_devices.rb
@@ -1,7 +1,6 @@
 title 'Test single AWS IAM Virtual MFA Devices'
 
 skip_control 'aws-iam-virtual-mfa-devices-1.0' do
-  impact 1.0
   title 'Check AWS IAM Virtual MFA Devices has the correct properties.'
 
   describe aws_iam_virtual_mfa_devices do

--- a/test/integration/verify/controls/aws_internet_gateway.rb
+++ b/test/integration/verify/controls/aws_internet_gateway.rb
@@ -3,7 +3,6 @@ aws_internet_gateway_name_tag = input(:aws_internet_gateway_name_tag, value: '',
 title 'Test single AWS Internet Gateway'
 
 control 'aws-internet-gateway-1.0' do
-  impact 1.0
   title 'Check AWS internet gateway has the correct properties.'
 
   describe aws_internet_gateway(name: aws_internet_gateway_name_tag) do

--- a/test/integration/verify/controls/aws_internet_gateways.rb
+++ b/test/integration/verify/controls/aws_internet_gateways.rb
@@ -3,7 +3,6 @@ aws_internet_gateway_name_tag = input(:aws_internet_gateway_name_tag, value: '',
 title 'Test multiple AWS Internet Gateways'
 
 control 'aws-internet-gateways-1.0' do
-  impact 1.0
   title 'Check AWS internet gateways have the correct properties.'
 
   describe aws_internet_gateways do

--- a/test/integration/verify/controls/aws_kms_key.rb
+++ b/test/integration/verify/controls/aws_kms_key.rb
@@ -8,7 +8,6 @@ aws_key_description_enabled = input(:aws_key_description_enabled, value: '', des
 aws_key_description_disabled = input(:aws_key_description_disabled, value: '', description: 'The AWS KMS key description.')
 
 control 'aws-kms-key-1.0' do
-  impact 1.0
   title 'Ensure AWS KMS Key has the correct properties.'
 
   describe aws_kms_key(aws_kms_key_enabled_id) do

--- a/test/integration/verify/controls/aws_kms_keys.rb
+++ b/test/integration/verify/controls/aws_kms_keys.rb
@@ -6,7 +6,6 @@ aws_kms_key_disabled_id = input(:aws_kms_key_disabled_id, value: '', description
 aws_kms_key_disabled_arn = input(:aws_kms_key_disabled_arn, value: '', description: 'The AWS KMS key ARN.')
 
 control 'aws-kms-keys-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC plural resource has the correct properties.'
 
   describe aws_kms_keys do

--- a/test/integration/verify/controls/aws_lambda.rb
+++ b/test/integration/verify/controls/aws_lambda.rb
@@ -1,7 +1,6 @@
 title 'AWS Lambda compliance Tests'
 
 control 'Check that lambda is correctly configured' do
-  impact 1.0
   title 'Lambda tests'
   desc 'Ensure that our lambda is correctly deployed'
 

--- a/test/integration/verify/controls/aws_lambda_alias.rb
+++ b/test/integration/verify/controls/aws_lambda_alias.rb
@@ -4,7 +4,6 @@ aws_lambda_alias_arn = input(:aws_lambda_alias_arn, value: '', description: '')
 aws_lambda_alias_description = input(:aws_lambda_alias_description, value: '', description: '')
 
 control 'aws-lambda-alias-1.0' do
-  impact 1.0
   title 'Test the properties of the lambda alias.'
 
   describe aws_lambda_alias(function_name: aws_lambda_alias_function_name, function_alias_name: aws_lambda_alias_name) do

--- a/test/integration/verify/controls/aws_lambda_aliases.rb
+++ b/test/integration/verify/controls/aws_lambda_aliases.rb
@@ -4,7 +4,6 @@ aws_lambda_alias_arn = input(:aws_lambda_alias_arn, value: '', description: '')
 aws_lambda_alias_description = input(:aws_lambda_alias_description, value: '', description: '')
 
 control 'aws-lambda-aliases-1.0' do
-  impact 1.0
   title 'Test the properties of the lambda aliases.'
 
   describe aws_lambda_aliases(function_name: aws_lambda_alias_function_name) do

--- a/test/integration/verify/controls/aws_lambda_code_signing_config.rb
+++ b/test/integration/verify/controls/aws_lambda_code_signing_config.rb
@@ -4,7 +4,6 @@ aws_lambda_code_signing_config_description = input(:aws_lambda_code_signing_conf
 aws_lambda_code_signing_config_last_modified = input(:aws_lambda_code_signing_config_last_modified, value: '', description: '')
 
 control 'aws-lambda-alias-1.0' do
-  impact 1.0
   title 'Test the properties of the lambda alias.'
 
   describe aws_lambda_code_signing_config(code_signing_config_arn: aws_lambda_code_signing_config_arn) do

--- a/test/integration/verify/controls/aws_lambda_code_signing_configs.rb
+++ b/test/integration/verify/controls/aws_lambda_code_signing_configs.rb
@@ -4,7 +4,6 @@ aws_lambda_code_signing_config_description = input(:aws_lambda_code_signing_conf
 aws_lambda_code_signing_config_last_modified = input(:aws_lambda_code_signing_config_last_modified, value: '', description: '')
 
 control 'aws-lambda-code-signing-configs-1.0' do
-  impact 1.0
   title 'Test the properties of the lambda code signing configs.'
 
   describe aws_lambda_code_signing_configs do

--- a/test/integration/verify/controls/aws_lambda_event_source_mapping.rb
+++ b/test/integration/verify/controls/aws_lambda_event_source_mapping.rb
@@ -7,7 +7,6 @@ aws_lambda_event_source_mapping_state_transition_reason = input(:aws_lambda_even
 title 'Test single AWS Lambda Source Mapping'
 
 control 'aws-lambda-source-mapping-1.0' do
-  impact 1.0
   title 'Ensure AWS Lambda Source Mapping has the correct properties.'
 
   describe aws_lambda_event_source_mapping(uuid: aws_lambda_event_source_mapping_uuid) do

--- a/test/integration/verify/controls/aws_lambda_event_source_mappings.rb
+++ b/test/integration/verify/controls/aws_lambda_event_source_mappings.rb
@@ -7,7 +7,6 @@ aws_lambda_event_source_mapping_state_transition_reason = input(:aws_lambda_even
 title 'Test single AWS Lambda Source Mappings'
 
 control 'aws-lambda-source-mappings-1.0' do
-  impact 1.0
   title 'Ensure AWS Lambda Source Mappings has the correct properties.'
 
   describe aws_lambda_event_source_mappings do

--- a/test/integration/verify/controls/aws_lambda_layer_version_permission.rb
+++ b/test/integration/verify/controls/aws_lambda_layer_version_permission.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-lambda-event-invoke-config-1.0' do
-  impact 1.0
   title 'Retrieves the configuration for asynchronous invocation for a function, version, or alias.'
 
   describe aws_lambda_layer_version_permission(layer_name: 'LayerName', version_number: 1) do

--- a/test/integration/verify/controls/aws_lambda_permission.rb
+++ b/test/integration/verify/controls/aws_lambda_permission.rb
@@ -1,7 +1,6 @@
 aws_lambda_function_arn = input(:lambda_function_arn, value: '', description: '')
 
 control 'aws-lambda-function-permission-1.0' do
-  impact 1.0
   title 'Describes the permission of the lambda function.'
 
   describe aws_lambda_permission(function_name: 'test_Lambda', Sid: 'AllowExecutionFromSqs') do

--- a/test/integration/verify/controls/aws_lambda_permissions.rb
+++ b/test/integration/verify/controls/aws_lambda_permissions.rb
@@ -1,7 +1,6 @@
 aws_lambda_function_arn = input(:lambda_function_arn, value: '', description: '')
 
 control 'aws-lambda-function-permissions-1.0' do
-  impact 1.0
   title 'List all the permissions of a lambda function.'
 
   describe aws_lambda_permissions(function_name: 'test_Lambda') do

--- a/test/integration/verify/controls/aws_lambda_version.rb
+++ b/test/integration/verify/controls/aws_lambda_version.rb
@@ -6,7 +6,6 @@ aws_lambda_layer_version_source_code_size = input(:aws_lambda_layer_version_sour
 aws_lambda_layer_version = input(:aws_lambda_layer_version, value: '', description: '')
 
 control 'aws-lambda-version-1.0' do
-  impact 1.0
   title 'Test the properties of the lambda version.'
 
   describe aws_lambda_version(layer_name: 'lambda_layer_name', version_number: 4) do

--- a/test/integration/verify/controls/aws_lambda_versions.rb
+++ b/test/integration/verify/controls/aws_lambda_versions.rb
@@ -3,7 +3,6 @@ aws_lambda_layer_version_created_date = input(:aws_lambda_layer_version_created_
 aws_lambda_layer_version = input(:aws_lambda_layer_version, value: '', description: '')
 
 control 'aws-lambda-versions-1.0' do
-  impact 1.0
   title 'Test the properties of the lambda versions.'
 
   describe aws_lambda_versions(layer_name: 'lambda_layer_name') do

--- a/test/integration/verify/controls/aws_lambdas.rb
+++ b/test/integration/verify/controls/aws_lambdas.rb
@@ -1,7 +1,6 @@
 title 'AWS Lambdas compliance Tests'
 
 control 'Check that any lambdas are correctly configured' do
-  impact 1.0
   title 'Lambda tests'
   desc 'Ensure that our lambdas are correctly deployed'
 

--- a/test/integration/verify/controls/aws_launch_configuration.rb
+++ b/test/integration/verify/controls/aws_launch_configuration.rb
@@ -3,7 +3,6 @@ title 'Test single AWS Launch Configuration'
 config_name = input(:aws_launch_configuration_name, value: '', description: 'The AWS launch configuration name.')
 
 control 'aws-launch-configuration-1.0' do
-  impact 1.0
   title 'Ensure AWS Launch Configuration has the correct properties.'
 
   describe aws_launch_configuration(launch_configuration_name: config_name) do

--- a/test/integration/verify/controls/aws_launch_configurations.rb
+++ b/test/integration/verify/controls/aws_launch_configurations.rb
@@ -3,7 +3,6 @@ title 'Test collection of AWS Launch Configurations'
 config_name = input(:aws_launch_configuration_name, value: '', description: 'The AWS launch configuration name.')
 
 control 'aws-launch-configurations-1.0' do
-  impact 1.0
   title 'Ensure AWS Launch Configuration plural resource have the correct properties.'
 
   describe aws_launch_configurations() do

--- a/test/integration/verify/controls/aws_logs_metric_filter.rb
+++ b/test/integration/verify/controls/aws_logs_metric_filter.rb
@@ -1,5 +1,4 @@
 control 'aws-logs-metric-filter-1.0' do
-  impact 1.0
   title 'Describes the metric filter of the logs.'
 
   describe aws_logs_metric_filter(filter_name: 'TestMetricFilter') do

--- a/test/integration/verify/controls/aws_logs_metric_filters.rb
+++ b/test/integration/verify/controls/aws_logs_metric_filters.rb
@@ -1,5 +1,4 @@
 control 'aws-logs-metric-filters-1.0' do
-  impact 1.0
   title 'Describes the metric filters of the logs.'
 
   describe aws_logs_metric_filters do

--- a/test/integration/verify/controls/aws_mq_broker.rb
+++ b/test/integration/verify/controls/aws_mq_broker.rb
@@ -4,7 +4,6 @@ broker_arn = input(:broker_arn, value: '', description: '')
 title 'Test a AWS MQ Broker.'
 
 control 'aws_mq_broker-1.0' do
-  impact 1.0
   title 'Ensure AWS MQ Broker has the correct properties.'
 
   describe aws_mq_broker(broker_id: broker_id) do

--- a/test/integration/verify/controls/aws_mq_brokers.rb
+++ b/test/integration/verify/controls/aws_mq_brokers.rb
@@ -3,7 +3,6 @@ broker_arn = input(:broker_arn, value: '', description: '')
 title 'Test AWS MQ Broker in bulk.'
 
 control 'aws_mq_brokers-1.0' do
-  impact 1.0
   title 'Ensure AWS MQ Brokers has the correct properties.'
   
   describe aws_mq_brokers do

--- a/test/integration/verify/controls/aws_mq_configuration.rb
+++ b/test/integration/verify/controls/aws_mq_configuration.rb
@@ -4,7 +4,6 @@ configuration_arn = input(:configuration_arn, value: '', description: 'configura
 title 'Test a AWS MQ Configuration.'
 
 control 'aws_mq_configuration-1.0' do
-  impact 1.0
   title 'Ensure AWS MQ Broker has the correct properties.'
 
   describe aws_mq_configuration(configuration_id: configuration_id) do

--- a/test/integration/verify/controls/aws_mq_configurations.rb
+++ b/test/integration/verify/controls/aws_mq_configurations.rb
@@ -4,7 +4,6 @@ configuration_arn = input(:configuration_arn, value: '', description: 'configura
 title 'Test a AWS MQ Configuration.'
 
 control 'aws-mq-configuration-1.0' do
-  impact 1.0
   title 'Ensure AWS MQ configuration has the correct properties.'
 
   describe aws_mq_configuration(configuration_id: configuration_id) do

--- a/test/integration/verify/controls/aws_multi_region_config_recorder.rb
+++ b/test/integration/verify/controls/aws_multi_region_config_recorder.rb
@@ -1,7 +1,6 @@
 title 'Test AWS Configuration Recorder Across All Regions'
 
 control 'aws-multi-region-config-recorder-1.0' do
-  impact 1.0
   title 'Ensure at least one AWS Configuration Recorder exists across all regions.'
 
   aws_regions.region_names.each do |region|

--- a/test/integration/verify/controls/aws_multi_region_security_group.rb
+++ b/test/integration/verify/controls/aws_multi_region_security_group.rb
@@ -1,7 +1,6 @@
 title 'Test AWS Security Groups Across All Regions'
 
 control 'aws-multi-region-security-group-1.0' do
-  impact 1.0
   title 'Ensure AWS Security Groups across all regions have the correct properties.'
 
   aws_regions.region_names.each do |region|

--- a/test/integration/verify/controls/aws_nat_gateway.rb
+++ b/test/integration/verify/controls/aws_nat_gateway.rb
@@ -9,7 +9,6 @@ aws_nat_gateway_public_ip = input(:aws_nat_gateway_public_ip, value: '', descrip
 title 'Test single AWS Nat Gateway'
 
 control 'aws-nat-gateway-1.0' do
-  impact 1.0
   title 'Check AWS nat gateway has the correct properties.'
 
   describe aws_nat_gateway(name: aws_nat_gateway_name) do

--- a/test/integration/verify/controls/aws_nat_gateways.rb
+++ b/test/integration/verify/controls/aws_nat_gateways.rb
@@ -9,7 +9,6 @@ aws_nat_gateway_public_ip = input(:aws_nat_gateway_public_ip, value: '', descrip
 title 'Test multiple AWS NAT Gateways'
 
 control 'aws-nat-gateways-1.0' do
-  impact 1.0
   title 'Check AWS NAT gateways have the correct properties.'
 
   describe aws_nat_gateways do

--- a/test/integration/verify/controls/aws_network_acl.rb
+++ b/test/integration/verify/controls/aws_network_acl.rb
@@ -6,7 +6,6 @@ vpc_id = input(:input, value: '', description: 'The ID of the VPC for the networ
 title 'Test single AWS Network ACL'
 
 control 'aws-network-acl-1.0' do
-  impact 1.0
   title 'Check AWS Network ACL has the correct properties.'
 
   describe aws_network_acl(network_acl_id: network_acl_id) do

--- a/test/integration/verify/controls/aws_network_acls.rb
+++ b/test/integration/verify/controls/aws_network_acls.rb
@@ -8,7 +8,6 @@ ingress_rule_number = input(:acl_ingress_rule_number, value: '', description: 'T
 title 'Test multiple AWS Network ACLs'
 
 control 'aws-network-ACLs-1.0' do
-  impact 1.0
   title 'Check AWS Network ACLs have the correct properties.'
 
   describe aws_network_acls.where { entries_cidr_blocks.include?(acl_cidr_block) } do

--- a/test/integration/verify/controls/aws_network_firewall_firewall.rb
+++ b/test/integration/verify/controls/aws_network_firewall_firewall.rb
@@ -3,7 +3,6 @@ aws_networkfirewall_firewall_name = input(:aws_networkfirewall_firewall_name, va
 aws_networkfirewall_firewall_vpc_id = input(:aws_networkfirewall_firewall_vpc_id, value: '', description: '')
 
 control 'aws-network-firewall-firewall-1.0' do
-  impact 1.0
   title 'Test the properties of the aws network firewall firewall.'
 
   describe aws_network_firewall_firewall(firewall_name: aws_networkfirewall_firewall_name) do

--- a/test/integration/verify/controls/aws_network_firewall_firewall_policies.rb
+++ b/test/integration/verify/controls/aws_network_firewall_firewall_policies.rb
@@ -2,7 +2,6 @@ aws_networkfirewall_firewall_policy_name = input(:aws_networkfirewall_firewall_p
 aws_networkfirewall_firewall_arn = input(:aws_networkfirewall_firewall_arn, value: '', description: '')
 
 control 'aws-ec2-network-firewall-policies-1.0' do
-  impact 1.0
   title 'Test a plural resource of the aws network firewall policy.'
 
   describe aws_network_firewall_policies do

--- a/test/integration/verify/controls/aws_network_firewall_firewall_policy.rb
+++ b/test/integration/verify/controls/aws_network_firewall_firewall_policy.rb
@@ -4,7 +4,6 @@ aws_networkfirewall_firewall_arn = input(:aws_networkfirewall_firewall_arn, valu
 aws_networkfirewall_firewall_policy_id = input(:aws_networkfirewall_firewall_policy_id, value: '', description: '')
 
 control 'aws-network-firewall-policy-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws network firewall policy.'
 
   describe aws_network_firewall_policy(firewall_policy_name: aws_networkfirewall_firewall_name) do

--- a/test/integration/verify/controls/aws_network_firewall_firewalls.rb
+++ b/test/integration/verify/controls/aws_network_firewall_firewalls.rb
@@ -2,7 +2,6 @@ aws_networkfirewall_firewall_policy_arn = input(:aws_networkfirewall_firewall_po
 aws_networkfirewall_firewall_name = input(:aws_networkfirewall_firewall_name, value: '', description: '')
 
 control 'aws-network-firewall-firewalls-1.0' do
-  impact 1.0
   title 'Test the properties of the aws network firewall firewalls.'
 
   describe aws_network_firewall_firewalls do

--- a/test/integration/verify/controls/aws_network_firewall_logging_configuration.rb
+++ b/test/integration/verify/controls/aws_network_firewall_logging_configuration.rb
@@ -2,7 +2,6 @@ aws_networkfirewall_firewall_name = input(:aws_networkfirewall_firewall_name, va
 aws_networkfirewall_firewall_arn = input(:aws_networkfirewall_firewall_arn, value: '', description: '')
 
 control 'aws-network-firewall-logging-configuration-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws network firewall logging configuration.'
 
   describe aws_network_firewall_logging_configuration(firewall_name: aws_networkfirewall_firewall_name) do

--- a/test/integration/verify/controls/aws_network_firewall_rule_group.rb
+++ b/test/integration/verify/controls/aws_network_firewall_rule_group.rb
@@ -4,7 +4,6 @@ aws_networkfirewall_rule_group_capacity = input(:aws_networkfirewall_rule_group_
 aws_networkfirewall_rule_group_type = input(:aws_networkfirewall_rule_group_type, value: '', description: '')
 
 control 'aws-network-firewall-rule-group-1.0' do
-  impact 1.0
   title 'Test a singular resource of the aws network firewall rule group.'
 
   describe aws_network_firewall_rule_group(rule_group_arn: aws_networkfirewall_rule_group_arn) do

--- a/test/integration/verify/controls/aws_network_firewall_rule_groups.rb
+++ b/test/integration/verify/controls/aws_network_firewall_rule_groups.rb
@@ -2,7 +2,6 @@ aws_networkfirewall_rule_group_arn = input(:aws_networkfirewall_rule_group_arn, 
 aws_networkfirewall_rule_group_name = input(:aws_networkfirewall_rule_group_name, value: '', description: '')
 
 control 'aws-ec2-network-firewall-rule-groups-1.0' do
-  impact 1.0
   title 'Test a plural resource of the aws network firewall rule group.'
 
   describe aws_network_firewall_rule_groups do

--- a/test/integration/verify/controls/aws_network_manager_customer_gateway_association.rb
+++ b/test/integration/verify/controls/aws_network_manager_customer_gateway_association.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-network-manager-customer-gateway-association-1.0' do
-  impact 1.0
   title 'Test the properties of the aws network manager customer gateway association.'
 
   describe aws_network_manager_customer_gateway_association(global_network_id: 'GlobalNetworkID', customer_gateway_arn: 'CustomerGatewayARN') do

--- a/test/integration/verify/controls/aws_network_manager_customer_gateway_associations.rb
+++ b/test/integration/verify/controls/aws_network_manager_customer_gateway_associations.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-network-manager-customer-gateway-associations-1.0' do
-  impact 1.0
   title 'Test the properties of the aws network manager customer gateway associations.'
 
   describe aws_network_manager_customer_gateway_associations(global_network_id: 'GlobalNetworkID') do

--- a/test/integration/verify/controls/aws_network_manager_global_network.rb
+++ b/test/integration/verify/controls/aws_network_manager_global_network.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-network-manager-global-network-1.0' do
-  impact 1.0
   title 'Verifies the settings of the network manager global network.'
 
   describe aws_network_manager_global_network(global_network_id: 'GlobalNetworkID') do

--- a/test/integration/verify/controls/aws_network_manager_global_networks.rb
+++ b/test/integration/verify/controls/aws_network_manager_global_networks.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-network-manager-global-networks-1.0' do
-  impact 1.0
   title 'Verifies the settings of the network manager global network.'
 
   describe aws_network_manager_global_networks do

--- a/test/integration/verify/controls/aws_organizations_member.rb
+++ b/test/integration/verify/controls/aws_organizations_member.rb
@@ -1,5 +1,4 @@
 control 'aws-organizations-member-1.0' do
-  impact 1.0
   title 'Ensure the current AWS Account is not the Master Account'
 
   describe aws_organizations_member do

--- a/test/integration/verify/controls/aws_ram_resource_share.rb
+++ b/test/integration/verify/controls/aws_ram_resource_share.rb
@@ -1,7 +1,6 @@
 aws_ram_resource_share_arn = input(:aws_ram_resource_share_arn, value: '', description: '')
 
 control 'aws-ram-resource-share-1.0' do
-  impact 1.0
   title 'Describes the resource share of the ram.'
 
   describe aws_ram_resource_share(resource_owner: 'SELF', resource_share_arn: aws_ram_resource_share_arn) do

--- a/test/integration/verify/controls/aws_ram_resource_shares.rb
+++ b/test/integration/verify/controls/aws_ram_resource_shares.rb
@@ -1,7 +1,6 @@
 aws_ram_resource_share_arn = input(:aws_ram_resource_share_arn, value: '', description: '')
 
 control 'aws-ram-resource-shares-1.0' do
-  impact 1.0
   title 'Lists the resources that you added to a resource shares or the resources that are shared with you.'
 
   describe aws_ram_resource_shares(resource_owner: 'SELF') do

--- a/test/integration/verify/controls/aws_rds_cluster.rb
+++ b/test/integration/verify/controls/aws_rds_cluster.rb
@@ -9,7 +9,6 @@ aws_rds_cluster_engine_version = input(:aws_rds_cluster_engine_version, value: '
 aws_rds_cluster_master_user = input(:aws_rds_cluster_master_user, value: '', description: 'The AWS RDS Cluster username.')
 
 control 'aws-rds-cluster-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Cluster has the correct properties.'
 
   describe aws_rds_cluster(db_cluster_identifier: aws_rds_cluster_identifier) do

--- a/test/integration/verify/controls/aws_rds_clusters.rb
+++ b/test/integration/verify/controls/aws_rds_clusters.rb
@@ -1,7 +1,6 @@
 title 'Test multiple AWS RDS Clusters'
 
 control 'aws-rds-clusters-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Clusters has the correct properties.'
 
   describe aws_rds_clusters do

--- a/test/integration/verify/controls/aws_rds_db_cluster_snapshot.rb
+++ b/test/integration/verify/controls/aws_rds_db_cluster_snapshot.rb
@@ -9,7 +9,6 @@ aws_db_cluster_snapshot_storage_encrypted = input(:aws_db_cluster_snapshot_stora
 aws_db_cluster_snapshot_source_db_cluster_snapshot_arn = input(:aws_db_cluster_snapshot_source_db_cluster_snapshot_arn, value: '', description: '')
 
 control 'aws-rds-db-cluster-snapshot-1.0' do
-  impact 1.0
   title 'Test the properties of the rds db cluster snapshot.'
 
   describe aws_rds_db_cluster_snapshot(db_cluster_snapshot_id: aws_db_cluster_snapshot_id ) do

--- a/test/integration/verify/controls/aws_rds_db_cluster_snapshots.rb
+++ b/test/integration/verify/controls/aws_rds_db_cluster_snapshots.rb
@@ -8,7 +8,6 @@ aws_db_cluster_snapshot_vpc_id = input(:aws_db_cluster_snapshot_vpc_id, value: '
 aws_db_cluster_snapshot_storage_encrypted = input(:aws_db_cluster_snapshot_storage_encrypted, value: '', description: '')
 
 control 'aws-rds-db-cluster-snapshots-1.0' do
-  impact 1.0
   title 'Test the properties of the rds db cluster snapshots.'
 
   describe aws_rds_db_cluster_snapshots do

--- a/test/integration/verify/controls/aws_rds_db_proxy.rb
+++ b/test/integration/verify/controls/aws_rds_db_proxy.rb
@@ -1,7 +1,6 @@
 aws_proxy_name = input(:aws_proxy_name, value: '', description: '')
 
 control 'aws-rds-db-proxy-1.0' do
-  impact 1.0
   title 'Test the properties of the rds db proxy.'
 
   describe aws_rds_db_proxy(db_proxy_name: aws_proxy_name) do

--- a/test/integration/verify/controls/aws_rds_db_proxy_endpoint.rb
+++ b/test/integration/verify/controls/aws_rds_db_proxy_endpoint.rb
@@ -2,7 +2,6 @@ aws_proxy_name = input(:aws_proxy_name, value: '', description: '')
 proxy_endpoint_name = input(:proxy_endpoint_name, value: '', description: '')
 
 control 'aws-rds-db-proxy-endpoint-1.0' do
-  impact 1.0
   title 'Test the properties of the rds db proxy endpoint.'
 
   describe aws_rds_db_proxy_endpoint(db_proxy_name: aws_proxy_name, db_proxy_endpoint_name: proxy_endpoint_name) do

--- a/test/integration/verify/controls/aws_rds_db_proxy_endpoints.rb
+++ b/test/integration/verify/controls/aws_rds_db_proxy_endpoints.rb
@@ -2,7 +2,6 @@ aws_proxy_name = input(:aws_proxy_name, value: '', description: '')
 proxy_endpoint_name = input(:proxy_endpoint_name, value: '', description: '')
 
 control 'aws-rds-db-proxy-endpoints-1.0' do
-  impact 1.0
   title 'Test the properties of the rds db proxy endpoints.'
 
   describe aws_rds_db_proxy_endpoints(db_proxy_name: aws_proxy_name) do

--- a/test/integration/verify/controls/aws_rds_db_proxy_target_group.rb
+++ b/test/integration/verify/controls/aws_rds_db_proxy_target_group.rb
@@ -2,7 +2,6 @@ db_proxy_name = input(:aws_proxy_name, value: '', description: '')
 target_group_name = input(:aws_proxy_name, value: '', description: '')
 
 control 'aws-rds-db-proxy-target-group-1.0' do
-  impact 1.0
   title 'Test the properties of the RDS DB Proxy Target Group.'
 
   describe aws_rds_db_proxy_target_group(db_proxy_name: db_proxy_name, target_group_name: target_group_name) do

--- a/test/integration/verify/controls/aws_rds_db_proxy_target_groups.rb
+++ b/test/integration/verify/controls/aws_rds_db_proxy_target_groups.rb
@@ -1,7 +1,6 @@
 db_proxy_name = input(:aws_proxy_name, value: '', description: '')
 
 control 'aws-rds-db-proxy-target-groups-1.0' do
-  impact 1.0
   title 'Test the properties of the RDS DB Proxy Target Groups.'
 
   describe aws_rds_db_proxy_target_groups(db_proxy_name: db_proxy_name) do

--- a/test/integration/verify/controls/aws_rds_db_security_group.rb
+++ b/test/integration/verify/controls/aws_rds_db_security_group.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-rds-db-security-group-1.0' do
-  impact 1.0
   title 'Test the properties of Security Group.'
 
   describe aws_rds_db_security_group(db_security_group_name: 'TEST_SEC_GROUP') do

--- a/test/integration/verify/controls/aws_rds_db_security_groups.rb
+++ b/test/integration/verify/controls/aws_rds_db_security_groups.rb
@@ -1,5 +1,4 @@
 skip_control 'aws-rds-db-security-groups-1.0' do
-  impact 1.0
   title 'Test the properties of Security Groups.'
 
   describe aws_rds_db_security_groups do

--- a/test/integration/verify/controls/aws_rds_event_subscription.rb
+++ b/test/integration/verify/controls/aws_rds_event_subscription.rb
@@ -1,7 +1,6 @@
 subscription_name = input(:subscription_name, value: '', description: '')
 
 control 'aws_rds_event_subscription-1.0' do
-  impact 1.0
   title 'Test the properties of Event Subscription.'
   
   describe aws_rds_event_subscription(subscription_name: subscription_name) do

--- a/test/integration/verify/controls/aws_rds_event_subscriptions.rb
+++ b/test/integration/verify/controls/aws_rds_event_subscriptions.rb
@@ -1,7 +1,6 @@
 subscription_name = input(:subscription_name, value: '', description: '')
 
 control 'aws_rds_event_subscriptions-1.0' do
-  impact 1.0
   title 'Test the properties of Event Subscriptions.'
   
   describe aws_rds_event_subscriptions do

--- a/test/integration/verify/controls/aws_rds_global_cluster.rb
+++ b/test/integration/verify/controls/aws_rds_global_cluster.rb
@@ -1,7 +1,6 @@
 global_cluster_identifier = input(:global_cluster_identifier, value: '', description: '')
 
 control 'aws_rds_global_cluster-1.0' do
-  impact 1.0
   title 'Test the properties of a Global cluster.'
   
   describe aws_rds_global_cluster(global_cluster_identifier: global_cluster_identifier) do

--- a/test/integration/verify/controls/aws_rds_global_clusters.rb
+++ b/test/integration/verify/controls/aws_rds_global_clusters.rb
@@ -1,7 +1,6 @@
 global_cluster_identifier = input(:global_cluster_identifier, value: '', description: '')
 
 control 'aws_rds_global_clusters-1.0' do
-  impact 1.0
   title 'Test the properties of all the Global cluster.'
   
   describe aws_rds_global_clusters do

--- a/test/integration/verify/controls/aws_rds_instance.rb
+++ b/test/integration/verify/controls/aws_rds_instance.rb
@@ -8,7 +8,6 @@ aws_rds_db_master_user = input(:aws_rds_db_master_user, value: '', description: 
 title 'Test single AWS RDS Instance'
 
 control 'aws-rds-instance-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Instance has the correct properties.'
 
   describe aws_rds_instance(aws_rds_db_identifier) do

--- a/test/integration/verify/controls/aws_rds_instances.rb
+++ b/test/integration/verify/controls/aws_rds_instances.rb
@@ -3,7 +3,6 @@ aws_rds_db_identifier = input(:aws_rds_db_identifier, value: '', description: 'T
 title 'Test multiple AWS RDS instances'
 
 control 'aws-rds-instances-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Instances has the correct properties.'
 
   describe aws_rds_instances do

--- a/test/integration/verify/controls/aws_rds_option_group.rb
+++ b/test/integration/verify/controls/aws_rds_option_group.rb
@@ -5,7 +5,6 @@ aws_db_option_group_engine_name= input(:aws_db_option_group_engine_name, value: 
 aws_db_option_group_description= input(:aws_db_option_group_description, value: '', description: '')
 
 control 'aws-rds-option-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Option Groups has the correct properties.'
   
   describe aws_rds_option_group(option_group_name: aws_option_group_name ) do

--- a/test/integration/verify/controls/aws_rds_option_groups.rb
+++ b/test/integration/verify/controls/aws_rds_option_groups.rb
@@ -5,7 +5,6 @@ aws_db_option_group_engine_name= input(:aws_db_option_group_engine_name, value: 
 aws_db_option_group_description= input(:aws_db_option_group_description, value: '', description: '')
 
 control 'aws-rds-option-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Option Groups has the correct properties.'
   
   describe aws_rds_option_groups do

--- a/test/integration/verify/controls/aws_rds_snapshot.rb
+++ b/test/integration/verify/controls/aws_rds_snapshot.rb
@@ -6,7 +6,6 @@ aws_rds_snapshot_storage_type = input(:aws_rds_snapshot_storage_type, value: '',
 title 'Test single AWS RDS Snapshot'
 
 control 'aws-rds-snapshot-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Snapshot has the correct properties.'
 
   describe aws_rds_snapshot(db_snapshot_identifier: aws_rds_snapshot_identifier) do

--- a/test/integration/verify/controls/aws_rds_snapshots.rb
+++ b/test/integration/verify/controls/aws_rds_snapshots.rb
@@ -3,7 +3,6 @@ aws_rds_snapshot_identifier = input(:aws_rds_snapshot_identifier, value: '', des
 title 'Test multiple AWS RDS snapshots'
 
 control 'aws-rds-snapshots-1.0' do
-  impact 1.0
   title 'Ensure AWS RDS Snapshots has the correct properties.'
 
   describe aws_rds_snapshots do

--- a/test/integration/verify/controls/aws_redshift_cluster.rb
+++ b/test/integration/verify/controls/aws_redshift_cluster.rb
@@ -1,7 +1,6 @@
 aws_redshift_db_identifier = input(:aws_redshift_cluster_identifier, value: '', description: 'The AWS Reddhift DB identifier.')
 
 control 'aws_redshift_cluster-1.0' do
-  impact 1.0
   title 'Ensure AWS redshift cluster has the correct properties.'
 
   describe aws_redshift_cluster(cluster_identifier: aws_redshift_db_identifier) do

--- a/test/integration/verify/controls/aws_redshift_cluster_parameter_group.rb
+++ b/test/integration/verify/controls/aws_redshift_cluster_parameter_group.rb
@@ -2,7 +2,6 @@ aws_parameter_group_name = input(:aws_redshift_parameter_group_name, value: '', 
 aws_parameter_group_family = input(:aws_redshift_parameter_group_family, value: '', description: 'The family of the parameter group.')
 
 control 'aws-redshift-parameter-group-1.0' do
-  impact 1.0
   title 'Ensure AWS Redshift Parameter Group singular resouce has the correct properties.'
   
   describe aws_redshift_cluster_parameter_group(parameter_group_name: aws_parameter_group_name) do

--- a/test/integration/verify/controls/aws_redshift_cluster_parameter_groups.rb
+++ b/test/integration/verify/controls/aws_redshift_cluster_parameter_groups.rb
@@ -2,7 +2,6 @@ aws_parameter_group_name = input(:aws_redshift_parameter_group_name, value: '', 
 aws_parameter_group_family = input(:aws_redshift_parameter_group_family, value: '', description: 'The family of the parameter group.')
 
 control 'aws-redshift-parameter-groups-1.0' do
-  impact 1.0
   title 'Ensure AWS Redshift Parameter Group plural resource has the correct properties.'
   
   describe aws_redshift_cluster_parameter_groups do

--- a/test/integration/verify/controls/aws_redshift_clusters.rb
+++ b/test/integration/verify/controls/aws_redshift_clusters.rb
@@ -1,5 +1,4 @@
 control 'aws_redshift_clusters-1.0' do
-  impact 1.0
   title 'Ensure AWS redshift clusters has the correct properties.'
 
   describe aws_redshift_clusters do

--- a/test/integration/verify/controls/aws_region.rb
+++ b/test/integration/verify/controls/aws_region.rb
@@ -4,7 +4,6 @@ aws_region_exists = input(:aws_region_exists, value: 'eu-west-2', description: '
 aws_region_endpoint_exists = input(:aws_region_endpoint_exists, value: 'ec2.eu-west-2.amazonaws.com', description: 'An AWS region.')
 
 control 'aws-region-1.0' do
-  impact 1.0
   title 'Ensure AWS region has the correct properties.'
 
   describe aws_region(region_name: aws_region_exists) do

--- a/test/integration/verify/controls/aws_regions.rb
+++ b/test/integration/verify/controls/aws_regions.rb
@@ -1,7 +1,6 @@
 title 'Test AWS Regions in bulk'
 
 control 'aws-regions-1.0' do
-  impact 1.0
   title 'Ensure AWS regions plural resource has the correct properties.'
 
   describe aws_regions do

--- a/test/integration/verify/controls/aws_route53_record_set.rb
+++ b/test/integration/verify/controls/aws_route53_record_set.rb
@@ -4,7 +4,6 @@ hosted_zone_id = input(:aws_route53_hosted_zone_id, value: '', description: '')
 start_record_name = input(:aws_route52_record_set_name, value: '', description: 'The AWS Route53 record set identifier.')
 
 control 'aws-route53-record-set-1.0' do
-  impact 1.0
   title 'Ensure AWS Route53 record set has the correct properties.'
 
   describe aws_route53_record_set(hosted_zone_id: hosted_zone_id, start_record_name: start_record_name) do

--- a/test/integration/verify/controls/aws_route53_record_sets.rb
+++ b/test/integration/verify/controls/aws_route53_record_sets.rb
@@ -3,7 +3,6 @@ title 'Test Plural AWS Route53 record set'
 hosted_zone_id = input(:aws_route53_hosted_zone_id, value: '', description: '')
 
 control 'aws-route53-record-sets-1.0' do
-  impact 1.0
   title 'Ensure AWS Route53 record sets has the correct properties.'
   
   describe aws_route53_record_sets(hosted_zone_id: hosted_zone_id) do

--- a/test/integration/verify/controls/aws_route53_resolver_resolver_endpoint.rb
+++ b/test/integration/verify/controls/aws_route53_resolver_resolver_endpoint.rb
@@ -4,7 +4,6 @@ aws_resolver_endpoint_name = input(:aws_resolver_endpoint_name, value: '', descr
 aws_resolver_endpoint_arn = input(:aws_resolver_endpoint_arn, value: '', description: '')
 
 control 'aws-route53-resolver-resolver-endpoint-1.0' do
-  impact 1.0
   title 'Describes the endpoint of the route53 resolver.'
   
   describe aws_route53resolver_resolver_endpoint(resolver_endpoint_id: resolver_endpoint_id) do

--- a/test/integration/verify/controls/aws_route53_resolver_resolver_endpoints.rb
+++ b/test/integration/verify/controls/aws_route53_resolver_resolver_endpoints.rb
@@ -4,7 +4,6 @@ aws_resolver_endpoint_name = input(:aws_resolver_endpoint_name, value: '', descr
 aws_resolver_endpoint_arn = input(:aws_resolver_endpoint_arn, value: '', description: '')
 
 control 'aws-route53-resolver-resolver-endpoints-1.0' do
-  impact 1.0
   title 'Describes the endpoints of the route53 resolver.'
   
   describe aws_route53resolver_resolver_endpoints do

--- a/test/integration/verify/controls/aws_route53_resolver_resolver_rule.rb
+++ b/test/integration/verify/controls/aws_route53_resolver_resolver_rule.rb
@@ -3,7 +3,6 @@ resolver_rule_arn = input(:resolver_rule_arn, value: '', description: '')
 resolver_rule_type = input(:resolver_rule_type, value: '', description: '')
 
 control 'aws-route53-resolver-resolver-rule-1.0' do
-  impact 1.0
   title 'Describes the resolver rule of the route53.'
   
   describe aws_route53resolver_resolver_rule(resolver_rule_id: resolver_rule_id) do

--- a/test/integration/verify/controls/aws_route53_resolver_resolver_rule_association.rb
+++ b/test/integration/verify/controls/aws_route53_resolver_resolver_rule_association.rb
@@ -3,7 +3,6 @@ resolver_rule_id = input(:resolver_rule_id, value: '', description: '')
 re_vpc_id = input(:re_vpc_id, value: '', description: '')
 
 control 'aws-route53-resolver-resolver-rule-association-1.0' do
-  impact 1.0
   title 'Describes the rule association of the route53 resolver.'
   
   describe aws_route53resolver_resolver_rule_association(resolver_rule_association_id: resolver_rule_association_id) do

--- a/test/integration/verify/controls/aws_route53_resolver_resolver_rule_associations.rb
+++ b/test/integration/verify/controls/aws_route53_resolver_resolver_rule_associations.rb
@@ -3,7 +3,6 @@ resolver_rule_id = input(:resolver_rule_id, value: '', description: '')
 re_vpc_id = input(:re_vpc_id, value: '', description: '')
 
 control 'aws-route53-resolver-resolver-rule-associations-1.0' do
-  impact 1.0
   title 'List all the endpoint of the route53 resolver rule associations.'
   
   describe aws_route53resolver_resolver_rule_associations do

--- a/test/integration/verify/controls/aws_route53_resolver_resolver_rules.rb
+++ b/test/integration/verify/controls/aws_route53_resolver_resolver_rules.rb
@@ -3,7 +3,6 @@ resolver_rule_arn = input(:resolver_rule_arn, value: '', description: '')
 resolver_rule_type = input(:resolver_rule_type, value: '', description: '')
 
 control 'aws-route53-resolver-resolver-resolver-rules-1.0' do
-  impact 1.0
   title 'List all resolver rules of the route53 resolver.'
   
   describe aws_route53resolver_resolver_rules do

--- a/test/integration/verify/controls/aws_route_table.rb
+++ b/test/integration/verify/controls/aws_route_table.rb
@@ -5,7 +5,6 @@ aws_route_table_first_id = input(:aws_route_table_first_id, value: '', descripti
 aws_route_table_second_id = input(:aws_route_table_second_id, value: '', description: 'The AWS route table ID.')
 
 control 'aws-route-table-1.0' do
-  impact 1.0
   title 'Ensure AWS AWS Route Table has the correct properties.'
   
   describe aws_route_table(route_table_id: aws_route_table_first_id) do
@@ -44,7 +43,6 @@ aws_route_table_association_id = input(:aws_route_table_association_id, value: '
 aws_route_table_associated_subnet = input(:aws_route_table_associated_subnet, value: '', description: 'The associated routed table subnet ID')
 
 control 'aws-route-1.0' do
-  impact 1.0
   title 'Ensure AWS AWS Route has the correct properties.'
   
   describe aws_route_table(route_table_id: 'rtb-0801bea66842eac41') do

--- a/test/integration/verify/controls/aws_route_tables.rb
+++ b/test/integration/verify/controls/aws_route_tables.rb
@@ -5,7 +5,6 @@ aws_route_table_first_id = input(:aws_route_table_first_id, value: '', descripti
 aws_route_table_second_id = input(:aws_route_table_second_id, value: '', description: 'The AWS route table ID.')
 
 control 'aws-route-tables-1.0' do
-  impact 1.0
   title 'Ensure AWS Route Tables plural resource has the correct properties.'
   
   describe aws_route_tables do
@@ -37,7 +36,6 @@ aws_route_table_associated_subnet = input(:aws_route_table_associated_subnet, va
 
 
 control 'aws-routes-1.0' do
-  impact 1.0
   title 'Ensure AWS Route Tables plural resource has the correct properties.'
   
   describe aws_route_tables do

--- a/test/integration/verify/controls/aws_s3_access_point.rb
+++ b/test/integration/verify/controls/aws_s3_access_point.rb
@@ -1,7 +1,6 @@
 title 'Test the properties of S3 Access Point'
 
 skip_control 'aws-s3-access-point-1.0' do
-  impact 1.0
   title 'Test the properties of S3 Access Point'
 
   describe aws_s3_access_point(bucket_name: 'BucketName', metrics_id: 'MetricsId') do

--- a/test/integration/verify/controls/aws_s3_access_points.rb
+++ b/test/integration/verify/controls/aws_s3_access_points.rb
@@ -1,7 +1,6 @@
 title 'Test the properties of S3 Access Point'
 
 skip_control 'aws-s3-access-points-1.0' do
-  impact 1.0
   title 'Test the properties of S3 Access Point'
 
   describe aws_s3_access_points(bucket_name: 'BucketName') do

--- a/test/integration/verify/controls/aws_s3_bucket.rb
+++ b/test/integration/verify/controls/aws_s3_bucket.rb
@@ -13,7 +13,6 @@ aws_bucket_versioning_enabled = input(:aws_bucket_versioning_enabled, value: '',
 aws_bucket_versioning_disabled = input(:aws_bucket_versioning_disabled, value: '', description: 'The AWS bucket versioning enabled value.')
 
 control 'aws-s3-bucket-1.0' do
-  impact 1.0
   title 'Ensure AWS S3 bucket has the correct properties.'
 
   describe aws_s3_bucket(bucket_name: aws_bucket_public_name) do

--- a/test/integration/verify/controls/aws_s3_bucket_object.rb
+++ b/test/integration/verify/controls/aws_s3_bucket_object.rb
@@ -5,7 +5,6 @@ aws_s3_bucket_object_private = input(:aws_s3_bucket_object_private, value: '', d
 aws_bucket_public_objects_name = input(:aws_bucket_public_objects_name, value: '', description: 'The AWS bucket.')
 
 control 'aws-s3-bucket-object-1.0' do
-  impact 1.0
   title 'Ensure AWS S3 Bucket Object has the correct properties.'
 
   describe aws_s3_bucket_object(bucket_name: aws_bucket_public_objects_name, key: aws_s3_bucket_object_public) do

--- a/test/integration/verify/controls/aws_s3_bucket_objects.rb
+++ b/test/integration/verify/controls/aws_s3_bucket_objects.rb
@@ -2,7 +2,6 @@ aws_s3_bucket_object_public = input(:aws_s3_bucket_object_public, value: '', des
 aws_bucket_public_objects_name = input(:aws_bucket_public_objects_name, value: '', description: 'The AWS bucket.')
 
 control 'aws-s3-bucket-objects-1.0' do
-  impact 1.0
   title 'Ensure AWS S3 Bucket Objects has the correct properties.'
 
   describe aws_s3_bucket_objects(bucket_name: aws_bucket_public_objects_name) do

--- a/test/integration/verify/controls/aws_s3_bucket_policy.rb
+++ b/test/integration/verify/controls/aws_s3_bucket_policy.rb
@@ -1,7 +1,6 @@
 bucket_name = input(:bucket_name, value: '', description: '')
 
 control 'aws-s3-bucket-policy-1.0' do
-  impact 1.0
   title 'Test the properties of an S3 Bucket Policy.'
   
   describe aws_s3_bucket_policy(bucket: bucket_name) do

--- a/test/integration/verify/controls/aws_s3_buckets.rb
+++ b/test/integration/verify/controls/aws_s3_buckets.rb
@@ -4,7 +4,6 @@ aws_bucket_public_name = input(:aws_bucket_public_name, value: '', description: 
 aws_bucket_private_name = input(:aws_bucket_private_name, value: '', description: 'The AWS bucket name.')
 
 control 'aws-s3-buckets-1.0' do
-  impact 1.0
   title 'Ensure AWS S3 Buckets plural resource has the correct properties.'
 
   describe aws_s3_buckets do

--- a/test/integration/verify/controls/aws_sdb_domains.rb
+++ b/test/integration/verify/controls/aws_sdb_domains.rb
@@ -3,7 +3,6 @@ title 'Test AWS SimpleDB Domains'
 domain_names_sdb = input(:domain_names_sdb , value: '', description: '')
 
 control 'aws-sdb-domains-1.0' do
-  impact 1.0
   title 'Ensure AWS Simple DB.'
   
   describe aws_sdb_domains do

--- a/test/integration/verify/controls/aws_secretsmanager_secret.rb
+++ b/test/integration/verify/controls/aws_secretsmanager_secret.rb
@@ -2,7 +2,6 @@ aws_secretsmanager_secret_sm_id = input(:aws_secretsmanager_secret_sm_id, value:
 aws_secretsmanager_secret_sm_arn = input(:aws_secretsmanager_secret_sm_arn, value: '', description: '')
 
 control 'aws-secretsmanager-secret-1.0' do
-  impact 1.0
   title 'Lists all of the secrets that are stored by Secrets Manager in the AWS account.'
 
   describe aws_secretsmanager_secret(secret_id: aws_secretsmanager_secret_sm_id) do

--- a/test/integration/verify/controls/aws_secretsmanager_secrets.rb
+++ b/test/integration/verify/controls/aws_secretsmanager_secrets.rb
@@ -1,7 +1,6 @@
 aws_secretsmanager_secret_sm_arn = input(:aws_secretsmanager_secret_sm_arn, value: '', description: '')
 
 control 'aws-secretsmanager-secrets-1.0' do
-  impact 1.0
   title 'Lists all of the secrets that are stored by Secrets Manager in the AWS account.'
 
   describe aws_secretsmanager_secrets do

--- a/test/integration/verify/controls/aws_security_group.rb
+++ b/test/integration/verify/controls/aws_security_group.rb
@@ -15,7 +15,6 @@ aws_security_group_omega_id = input(:aws_security_group_omega_id, value: '', des
 aws_security_group_omega = input(:aws_security_group_omega, value: '', description: 'AWS Security Group name.')
 
 control 'aws-security-group-1.0' do
-  impact 1.0
   title 'Ensure AWS Security Group has the correct properties.'
 
   describe aws_security_group(aws_security_group_default_id) do

--- a/test/integration/verify/controls/aws_security_groups.rb
+++ b/test/integration/verify/controls/aws_security_groups.rb
@@ -14,7 +14,6 @@ aws_security_group_omega = input(:aws_security_group_omega, value: '', descripti
 
 control 'aws-security-groups-1.0' do
 
-  impact 1.0
   title 'Ensure AWS Security Groups plural resource has the correct properties.'
 
   describe aws_security_groups do

--- a/test/integration/verify/controls/aws_securityhub_hub.rb
+++ b/test/integration/verify/controls/aws_securityhub_hub.rb
@@ -1,5 +1,4 @@
 skip_control 'aws_securityhub_hub-1.0' do
-  impact 1.0
   title 'Test the properties of a Security Hub.'
   
   describe aws_securityhub_hub(hub_arn: '') do

--- a/test/integration/verify/controls/aws_servicecatalog_clould_formation_product.rb
+++ b/test/integration/verify/controls/aws_servicecatalog_clould_formation_product.rb
@@ -1,7 +1,6 @@
 aws_servicecatalog_product_sm_id = input(:aws_servicecatalog_product_sm_id, value: '', description: '')
 
 control 'aws-service-catalog-product-1.0' do
-  impact 1.0
   title 'Describes the product of the service catalog.'
 
   describe aws_servicecatalog_cloud_formation_product(name: 'ProductTest') do

--- a/test/integration/verify/controls/aws_servicecatalog_launch_role_constraint.rb
+++ b/test/integration/verify/controls/aws_servicecatalog_launch_role_constraint.rb
@@ -2,7 +2,6 @@ aws_servicecatalog_portfolio_sm_id = input(:aws_servicecatalog_portfolio_sm_id, 
 aws_servicecatalog_portfolio_sm_arn = input(:aws_servicecatalog_portfolio_sm_arn, value: '', description: '')
 
 control 'aws-service-catalog-launch-role-constraint-1.0' do
-  impact 1.0
   title 'Describes the launch role constraint of the service catalog.'
 
   describe aws_servicecatalog_launch_role_constraint(id: aws_servicecatalog_portfolio_sm_id) do

--- a/test/integration/verify/controls/aws_servicecatalog_launch_role_constraints.rb
+++ b/test/integration/verify/controls/aws_servicecatalog_launch_role_constraints.rb
@@ -3,7 +3,6 @@ aws_servicecatalog_portfolio_sm_id = input(:aws_servicecatalog_portfolio_sm_id, 
 aws_servicecatalog_constraint_sm_id = input(:aws_servicecatalog_constraint_sm_id, value: '', description: '')
 
 control 'aws-service-catalog-launch-role-constraints-1.0' do
-  impact 1.0
   title 'Lists the constraints for the specified portfolio and product.'
 
   describe aws_servicecatalog_launch_role_constraints(portfolio_id: aws_servicecatalog_portfolio_sm_id) do

--- a/test/integration/verify/controls/aws_servicecatalog_portfolio_principal_association.rb
+++ b/test/integration/verify/controls/aws_servicecatalog_portfolio_principal_association.rb
@@ -2,7 +2,6 @@ aws_servicecatalog_portfolio_sm_id = input(:aws_servicecatalog_portfolio_sm_id, 
 aws_iam_role_sc_test_sm_arn = input(:aws_iam_role_sc_test_sm_arn, value: '', description: '')
 
 control 'aws-service-catalog-principal-association-1.0' do
-  impact 1.0
   title 'Describes a principal ARNs associated with the specified portfolio.'
 
   describe aws_servicecatalog_portfolio_principal_association(portfolio_id: aws_servicecatalog_portfolio_sm_id) do

--- a/test/integration/verify/controls/aws_servicecatalog_portfolio_principal_associations.rb
+++ b/test/integration/verify/controls/aws_servicecatalog_portfolio_principal_associations.rb
@@ -2,7 +2,6 @@ aws_servicecatalog_portfolio_sm_id = input(:aws_servicecatalog_portfolio_sm_id, 
 aws_iam_role_sc_test_sm_arn = input(:aws_iam_role_sc_test_sm_arn, value: '', description: '')
 
 control 'aws-service-catalog-principal-associations-1.0' do
-  impact 1.0
   title 'Lists all principal ARNs associated with the specified portfolio.'
 
   describe aws_servicecatalog_portfolio_principal_associations(portfolio_id: aws_servicecatalog_portfolio_sm_id) do

--- a/test/integration/verify/controls/aws_servicecatalog_portfolio_product_association.rb
+++ b/test/integration/verify/controls/aws_servicecatalog_portfolio_product_association.rb
@@ -3,7 +3,6 @@ aws_servicecatalog_portfolio_sm_id = input(:aws_servicecatalog_portfolio_sm_id, 
 aws_servicecatalog_portfolio_sm_arn = input(:aws_servicecatalog_portfolio_sm_id, value: '', description: '')
 
 control 'aws-service-catalog-product-portfolio-association-1.0' do
-  impact 1.0
   title 'Describes a principal ARNs associated with the specified portfolio.'
 
   describe aws_servicecatalog_portfolio_product_association(product_id: aws_servicecatalog_product_sm_id) do

--- a/test/integration/verify/controls/aws_servicecatalog_portfolio_product_associations.rb
+++ b/test/integration/verify/controls/aws_servicecatalog_portfolio_product_associations.rb
@@ -3,7 +3,6 @@ aws_servicecatalog_portfolio_sm_id = input(:aws_servicecatalog_portfolio_sm_id, 
 aws_servicecatalog_portfolio_sm_arn = input(:aws_servicecatalog_portfolio_sm_id, value: '', description: '')
 
 control 'aws-service-catalog-product-portfolio-associations-1.0' do
-  impact 1.0
   title 'Lists all principal ARNs associated with the specified portfolio.'
 
   describe aws_servicecatalog_portfolio_product_associations(product_id: aws_servicecatalog_product_sm_id) do

--- a/test/integration/verify/controls/aws_ses_receipt_rule.rb
+++ b/test/integration/verify/controls/aws_ses_receipt_rule.rb
@@ -2,7 +2,6 @@ aws_ses_receipt_rule_name = input(:aws_ses_receipt_rule_name, value: '', descrip
 aws_ses_receipt_rule_rule_set_name = input(:aws_ses_receipt_rule_rule_set_name, value: '', description: '')
 
 control 'aws-ses-receipt-rule-1.0' do
-  impact 1.0
   title 'Test the properties of the ses receipt rule.'
 
   describe aws_ses_receipt_rule(rule_set_name: aws_ses_receipt_rule_rule_set_name, rule_name: aws_ses_receipt_rule_name) do

--- a/test/integration/verify/controls/aws_ses_receipt_rule_set.rb
+++ b/test/integration/verify/controls/aws_ses_receipt_rule_set.rb
@@ -2,7 +2,6 @@ aws_ses_receipt_rule_set_name = input(:aws_ses_receipt_rule_set_name, value: '',
 aws_ses_receipt_rule_name = input(:aws_ses_receipt_rule_name, value: '', description: '')
 
 control 'aws-ses-receipt-rule-set-1.0' do
-  impact 1.0
   title 'Test the properties of the ses receipt rules.'
 
   describe aws_ses_receipt_rule_set(rule_set_name: aws_ses_receipt_rule_set_name) do

--- a/test/integration/verify/controls/aws_ses_receipt_rule_sets.rb
+++ b/test/integration/verify/controls/aws_ses_receipt_rule_sets.rb
@@ -1,7 +1,6 @@
 aws_ses_receipt_rule_set_name = input(:aws_ses_receipt_rule_set_name, value: '', description: '')
 
 control 'aws-ses-receipt-rule-sets-1.0' do
-  impact 1.0
   title 'Test the properties of the ses receipt rules.'
 
   describe aws_ses_receipt_rule_sets do

--- a/test/integration/verify/controls/aws_ses_template.rb
+++ b/test/integration/verify/controls/aws_ses_template.rb
@@ -4,7 +4,6 @@ aws_ses_template_text = input(:aws_ses_template_text, value: '', description: ''
 aws_ses_template_html = input(:aws_ses_template_html, value: '', description: '')
 
 control 'aws-ses-template-1.0' do
-  impact 1.0
   title 'Test the properties of the ses receipt rules.'
 
   describe aws_ses_template(template_name: aws_ses_template_name) do

--- a/test/integration/verify/controls/aws_ses_templates.rb
+++ b/test/integration/verify/controls/aws_ses_templates.rb
@@ -1,7 +1,6 @@
 aws_ses_template_name = input(:aws_ses_template_name, value: '', description: '')
 
 control 'aws-ses-templates-1.0' do
-  impact 1.0
   title 'Test the properties of the ses receipt rules.'
 
   describe aws_ses_templates do

--- a/test/integration/verify/controls/aws_signer_profile_permissions.rb
+++ b/test/integration/verify/controls/aws_signer_profile_permissions.rb
@@ -4,7 +4,6 @@ aws_signer_signing_profile_permission_principal = input(:aws_signer_signing_prof
 aws_signer_signing_profile_permission_statement_id = input(:aws_signer_signing_profile_permission_statement_id, value: '', description: '')
 
 control 'aws_signer_profile_permissions-1.0' do
-  impact 1.0
   title 'Test the properties of the ses receipt rules.'
 
   describe aws_signer_profile_permissions(profile_name: aws_signer_signing_profile_permission_profile_name) do

--- a/test/integration/verify/controls/aws_signer_signing_profile.rb
+++ b/test/integration/verify/controls/aws_signer_signing_profile.rb
@@ -5,7 +5,6 @@ aws_signer_signing_profile_version_arn = input(:aws_signer_signing_profile_versi
 aws_signer_signing_profile_version = input(:aws_signer_signing_profile_version, value: '', description: '')
 
 control 'aws-signer-signing-profile-1.0' do
-  impact 1.0
   title 'Test the singular resource of the Signing Profile.'
 
   describe aws_signer_signing_profile(profile_name: aws_signer_signing_profile_name) do

--- a/test/integration/verify/controls/aws_signer_signing_profiles.rb
+++ b/test/integration/verify/controls/aws_signer_signing_profiles.rb
@@ -5,7 +5,6 @@ aws_signer_signing_profile_version_arn = input(:aws_signer_signing_profile_versi
 aws_signer_signing_profile_version = input(:aws_signer_signing_profile_version, value: '', description: '')
 
 control 'aws-signer-signing-profiles-1.0' do
-  impact 1.0
   title 'Test the plural resource of the Signing Profile.'
 
   describe aws_signer_signing_profiles do

--- a/test/integration/verify/controls/aws_sns_subscription.rb
+++ b/test/integration/verify/controls/aws_sns_subscription.rb
@@ -6,7 +6,6 @@ aws_sns_topic_with_subscription_arn = input(:aws_sns_topic_with_subscription_arn
 sns_sqs_queue_arn = input(:sns_sqs_queue_arn, value: '', description: 'The SNS SQS Queue ARN.')
 
 control 'aws-sns-subscription-1.0' do
-  impact 1.0
   title 'Ensure AWS SNS Subscription has the correct properties.'
 
   describe aws_sns_subscription(subscription_arn: aws_sns_subscription_arn) do

--- a/test/integration/verify/controls/aws_sns_subscriptions.rb
+++ b/test/integration/verify/controls/aws_sns_subscriptions.rb
@@ -4,7 +4,6 @@ sns_sqs_queue_arn = input(:sns_sqs_queue_arn, value: '', description: 'The SNS S
 aws_sns_topic_with_subscription_arn = input(:aws_sns_topic_with_subscription_arn, value: '', description: 'The AWS SNS topic ARN.')
 
 control 'aws-sns-subscriptions-1.0' do
-  impact 1.0
   title 'Ensure AWS SNS Subscriptions has the correct properties.'
 
   describe aws_sns_subscriptions do

--- a/test/integration/verify/controls/aws_sns_topic.rb
+++ b/test/integration/verify/controls/aws_sns_topic.rb
@@ -8,7 +8,6 @@ aws_sns_topic_with_encryption_arn = input(:aws_sns_topic_with_encryption_arn, va
 kms_master_key_id = input(:aws_sns_topic_kms_master_key_id, value: '', description: 'The AWS SNS topic kms master key id.')
 
 control 'aws-sns-topic-1.0' do
-  impact 1.0
   title 'Ensure AWS SNS Topic has the correct properties.'
 
   describe aws_sns_topic(arn: aws_sns_topic_with_subscription_arn) do

--- a/test/integration/verify/controls/aws_sns_topics.rb
+++ b/test/integration/verify/controls/aws_sns_topics.rb
@@ -6,7 +6,6 @@ aws_sns_topic_with_subscription_arn = input(:aws_sns_topic_with_subscription_arn
 aws_sns_topic_no_subscription_arn = input(:aws_sns_topic_no_subscription_arn, value: '', description: 'The SNS topic ARN.')
 
 control 'aws-sns-topics-1.0' do
-  impact 1.0
   title 'Ensure AWS SNS Topic plural resource has the correct properties.'
 
   describe aws_sns_topics do

--- a/test/integration/verify/controls/aws_sqs_queue.rb
+++ b/test/integration/verify/controls/aws_sqs_queue.rb
@@ -14,7 +14,6 @@ else
 end
 
 control 'aws-sqs-queue-1.0' do
-  impact 1.0
   title 'Ensure AWS SQS Queue has the correct properties.'
 
   describe aws_sqs_queue(queue_url: aws_sqs_queue_url) do

--- a/test/integration/verify/controls/aws_sqs_queues.rb
+++ b/test/integration/verify/controls/aws_sqs_queues.rb
@@ -12,7 +12,6 @@ else
 end
 
 control 'aws-sqs-queues-1.0' do
-  impact 1.0
   title 'Ensure AWS SQS Queues plural resource has the correct properties.'
 
   describe aws_sqs_queues do

--- a/test/integration/verify/controls/aws_ssm_activation.rb
+++ b/test/integration/verify/controls/aws_ssm_activation.rb
@@ -1,7 +1,6 @@
 title 'Test a single AWS SSM Activation'
 
 control 'aws-ssm-activation-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Activation has current properties'
 
   describe aws_ssm_activation(activation_id: 'dummy') do

--- a/test/integration/verify/controls/aws_ssm_association.rb
+++ b/test/integration/verify/controls/aws_ssm_association.rb
@@ -1,7 +1,6 @@
 title 'Test a single AWS SSM Association'
 
 control 'aws-ssm-association-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Association has current properties'
 
   describe aws_ssm_association(association_id: 'dummy') do

--- a/test/integration/verify/controls/aws_ssm_document.rb
+++ b/test/integration/verify/controls/aws_ssm_document.rb
@@ -4,7 +4,6 @@ aws_ssm_document_name = input(:aws_ssm_document_name, value: '', description: 'T
 aws_ssm_document_document_type = input(:aws_ssm_document_document_type, value: '', description: 'The AWS SSM Document Command')
 
 control 'aws-ssm-document-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Document has current properties'
 
   describe aws_ssm_document(name: aws_ssm_document_name) do

--- a/test/integration/verify/controls/aws_ssm_documents.rb
+++ b/test/integration/verify/controls/aws_ssm_documents.rb
@@ -4,7 +4,6 @@ aws_ssm_document_name = input(:aws_ssm_document_name, value: '', description: 'T
 aws_ssm_document_document_type = input(:aws_ssm_document_document_type, value: '', description: 'The AWS SSM Document Command')
 
 control 'aws-ssm-documents-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Document has current properties'
 
   describe aws_ssm_documents do

--- a/test/integration/verify/controls/aws_ssm_maintenance_window.rb
+++ b/test/integration/verify/controls/aws_ssm_maintenance_window.rb
@@ -1,7 +1,6 @@
 aws_ssm_maintenance_window_id = input(:aws_ssm_maintenance_window_id, value: '', description: '')
 
 control 'aws-ssm-maintenance-window-1.0' do
-  impact 1.0
   title 'Test the properties of the ses maintenance window.'
 
   describe aws_ssm_maintenance_window(window_id: aws_ssm_maintenance_window_id) do

--- a/test/integration/verify/controls/aws_ssm_maintenance_window_target.rb
+++ b/test/integration/verify/controls/aws_ssm_maintenance_window_target.rb
@@ -4,7 +4,6 @@ aws_ssm_maintenance_window_target_id = input(:aws_ssm_maintenance_window_target_
 aws_ssm_maintenance_window_target_name = input(:aws_ssm_maintenance_window_target_id, value: '', description: '')
 
 control 'aws-ssm-maintenance-window-target-1.0' do
-  impact 1.0
   title 'Test the properties of the ssm maintenance window target.'
 
   describe aws_ssm_maintenance_window_target(window_id: aws_ssm_maintenance_window_id, window_target_id: aws_ssm_maintenance_window_target_id) do

--- a/test/integration/verify/controls/aws_ssm_maintenance_window_targets.rb
+++ b/test/integration/verify/controls/aws_ssm_maintenance_window_targets.rb
@@ -4,7 +4,6 @@ aws_ssm_maintenance_window_target_id = input(:aws_ssm_maintenance_window_target_
 aws_ssm_maintenance_window_target_name = input(:aws_ssm_maintenance_window_target_id, value: '', description: '')
 
 control 'aws-ssm-maintenance-window-targets-1.0' do
-  impact 1.0
   title 'Test the properties of the ssm maintenance window targets.'
 
   describe aws_ssm_maintenance_window_targets(window_id: aws_ssm_maintenance_window_id) do

--- a/test/integration/verify/controls/aws_ssm_maintenance_window_task.rb
+++ b/test/integration/verify/controls/aws_ssm_maintenance_window_task.rb
@@ -4,7 +4,6 @@ aws_ssm_maintenance_window_task_task_arn = input(:aws_ssm_maintenance_window_tas
 aws_ssm_maintenance_window_task_task_type = input(:aws_ssm_maintenance_window_task_task_type, value: '', description: '')
 
 control 'aws-ssm-maintenance-window-task-1.0' do
-  impact 1.0
   title 'Test the properties of the ssm maintenance window task.'
 
   describe aws_ssm_maintenance_window_task(window_id: aws_ssm_maintenance_window_id, window_task_id: aws_ssm_maintenance_window_task_id) do

--- a/test/integration/verify/controls/aws_ssm_maintenance_window_tasks.rb
+++ b/test/integration/verify/controls/aws_ssm_maintenance_window_tasks.rb
@@ -4,7 +4,6 @@ aws_ssm_maintenance_window_task_task_arn = input(:aws_ssm_maintenance_window_tas
 aws_ssm_maintenance_window_task_task_type = input(:aws_ssm_maintenance_window_task_task_type, value: '', description: '')
 
 control 'aws-ssm-maintenance-window-tasks-1.0' do
-  impact 1.0
   title 'Test the properties of the ssm maintenance window tasks.'
 
   describe aws_ssm_maintenance_window_tasks(window_id: aws_ssm_maintenance_window_id) do

--- a/test/integration/verify/controls/aws_ssm_maintenance_windows.rb
+++ b/test/integration/verify/controls/aws_ssm_maintenance_windows.rb
@@ -1,7 +1,6 @@
 aws_ssm_maintenance_window_id = input(:aws_ssm_maintenance_window_id, value: '', description: '')
 
 control 'aws-ssm-maintenance-windows-1.0' do
-  impact 1.0
   title 'Test the properties of the ses maintenance windows.'
 
   describe aws_ssm_maintenance_windows do

--- a/test/integration/verify/controls/aws_ssm_parameter.rb
+++ b/test/integration/verify/controls/aws_ssm_parameter.rb
@@ -6,7 +6,6 @@ aws_ssm_parameter_value = input(:aws_ssm_parameter_value, value: '', description
 aws_ssm_parameter_arn = input(:aws_ssm_parameter_arn, value: '', description: 'The AWS SSM Parameter ARN.')
 
 control 'aws-ssm-parameter-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Parameter has current properties'
 
   describe aws_ssm_parameter(name: aws_ssm_parameter_name) do

--- a/test/integration/verify/controls/aws_ssm_parameters.rb
+++ b/test/integration/verify/controls/aws_ssm_parameters.rb
@@ -3,7 +3,6 @@ title 'Test AWS SSM Parameters in bulk'
 aws_ssm_parameter_name = input(:aws_ssm_parameter_name, value: '', description: 'The AWS SSM Parameter Name')
 
 control 'aws-ssm-parameters-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Parameter has current properties'
 
   describe aws_ssm_parameters do

--- a/test/integration/verify/controls/aws_ssm_patch_baseline.rb
+++ b/test/integration/verify/controls/aws_ssm_patch_baseline.rb
@@ -2,7 +2,6 @@ aws_ssm_patch_baseline_id = input(:aws_ssm_patch_baseline_id, value: '', descrip
 aws_ssm_patch_baseline_name = input(:aws_ssm_patch_baseline_name, value: '', description: '')
 
 control 'aws-ssm-patch-baseline-1.0' do
-  impact 1.0
   title 'Test the properties of the ssm patch baseline.'
 
   describe aws_ssm_patch_baseline(baseline_id: aws_ssm_patch_baseline_id) do

--- a/test/integration/verify/controls/aws_ssm_patch_baselines.rb
+++ b/test/integration/verify/controls/aws_ssm_patch_baselines.rb
@@ -2,7 +2,6 @@ aws_ssm_patch_baseline_id = input(:aws_ssm_patch_baseline_id, value: '', descrip
 aws_ssm_patch_baseline_name = input(:aws_ssm_patch_baseline_name, value: '', description: '')
 
 control 'aws-ssm-patch-baselines-1.0' do
-  impact 1.0
   title 'Test the properties of the ssm patch baselines.'
 
   describe aws_ssm_patch_baselines do

--- a/test/integration/verify/controls/aws_ssm_resource_compliance_summaries.rb
+++ b/test/integration/verify/controls/aws_ssm_resource_compliance_summaries.rb
@@ -1,7 +1,6 @@
 title 'Test AWS SSM Resource Compliance Summaries in bulk'
 
 control 'aws-ssm-resource-compliance-summaries-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Resource Compliance Summary has current properties'
 
   describe.one do

--- a/test/integration/verify/controls/aws_ssm_resource_compliance_summary.rb
+++ b/test/integration/verify/controls/aws_ssm_resource_compliance_summary.rb
@@ -1,7 +1,6 @@
 title 'Test a single AWS SSM Resource Compliance Summary'
 
 control 'aws-ssm-resource-compliance-summary-1.0' do
-  impact 1.0
   title 'Ensure AWS SSM Resource Compliance Summary has current properties'
 
   describe aws_ssm_resource_compliance_summary(resource_id: "dummy") do

--- a/test/integration/verify/controls/aws_ssm_resource_data_syncs.rb
+++ b/test/integration/verify/controls/aws_ssm_resource_data_syncs.rb
@@ -1,7 +1,6 @@
 aws_ssm_resource_data_sync_name = input(:aws_ssm_resource_data_sync_name, value: '', description: '')
 
 control 'aws_ssm_resource_data_syncs-1.0' do
-  impact 1.0
   title 'Test the properties of the ssm resource data syncs.'
 
   describe aws_ssm_resource_data_syncs do

--- a/test/integration/verify/controls/aws_stepfunctions_activities.rb
+++ b/test/integration/verify/controls/aws_stepfunctions_activities.rb
@@ -2,7 +2,6 @@ aws_sfn_activity_id = input(:aws_sfn_activity_id, value: '', description: '')
 aws_sfn_activity_name = input(:aws_sfn_activity_name, value: '', description: '')
 
 control 'aws-stepfunctions-activities-1.0' do
-  impact 1.0
   title 'Test the properties of the stepfunctions activities.'
 
   describe aws_stepfunctions_activities do

--- a/test/integration/verify/controls/aws_stepfunctions_activity.rb
+++ b/test/integration/verify/controls/aws_stepfunctions_activity.rb
@@ -2,7 +2,6 @@ aws_sfn_activity_id = input(:aws_sfn_activity_id, value: '', description: '')
 aws_sfn_activity_name = input(:aws_sfn_activity_name, value: '', description: '')
 
 control 'aws-stepfunctions-activity-1.0' do
-  impact 1.0
   title 'Test the properties of the stepfunctions activity.'
 
   describe aws_stepfunctions_activity(activity_arn: aws_sfn_activity_id) do

--- a/test/integration/verify/controls/aws_stepfunctions_state_machine.rb
+++ b/test/integration/verify/controls/aws_stepfunctions_state_machine.rb
@@ -3,7 +3,6 @@ aws_sfn_state_machine_arn = input(:aws_sfn_state_machine_arn, value: '', descrip
 aws_sfn_state_machine_role_arn = input(:aws_sfn_state_machine_role_arn, value: '', description: '')
 
 control 'aws-state-resource-state-machine-1.0' do
-  impact 1.0
   title 'Ensure AWS State Resource State Machine has current properties'
 
   describe aws_stepfunctions_state_machine(state_machine_arn: aws_sfn_state_machine_arn) do

--- a/test/integration/verify/controls/aws_stepfunctions_state_machines.rb
+++ b/test/integration/verify/controls/aws_stepfunctions_state_machines.rb
@@ -2,7 +2,6 @@ aws_sfn_state_machine_name = input(:aws_sfn_state_machine_name, value: '', descr
 aws_sfn_state_machine_arn = input(:aws_sfn_state_machine_arn, value: '', description: '')
 
 control 'aws-state-resource-state-machines-1.0' do
-  impact 1.0
   title 'Ensure AWS State Resource State Machines has current properties'
 
   describe aws_stepfunctions_state_machines do

--- a/test/integration/verify/controls/aws_sts_caller_identity.rb
+++ b/test/integration/verify/controls/aws_sts_caller_identity.rb
@@ -1,7 +1,6 @@
 title 'Ensure AWS credentials being used for the Inspec scan have the correct properties.'
 
 control 'aws-sts-caller-identity-1.0' do
-  impact 1.0
   title 'Make sure we are not on GovCloud'
 
   describe aws_sts_caller_identity do

--- a/test/integration/verify/controls/aws_subnet.rb
+++ b/test/integration/verify/controls/aws_subnet.rb
@@ -7,7 +7,6 @@ aws_vpc_id = input(:aws_vpc_id, value: '', description: 'The AWS VPC ID.')
 aws_availability_zone = input(:aws_availability_zone, value: '', description: 'The AWS AZ.')
 
 control 'aws-subnet-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC Subnet has the correct properties.'
 
   describe aws_subnet(subnet_id: aws_subnet_id) do

--- a/test/integration/verify/controls/aws_subnets.rb
+++ b/test/integration/verify/controls/aws_subnets.rb
@@ -5,7 +5,6 @@ aws_subnet_cidr_block = input(:aws_subnet_cidr_block, value: '', description: 'T
 aws_vpc_id = input(:aws_vpc_id, value: '', description: 'The AWS VPC ID.')
 
 control 'aws-subnets-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC Subnets plural resource has the correct properties.'
 
   describe aws_subnets do

--- a/test/integration/verify/controls/aws_subnets_loop.rb
+++ b/test/integration/verify/controls/aws_subnets_loop.rb
@@ -7,7 +7,6 @@ aws_vpc_id = input(:aws_vpc_id, value: '', description: 'The AWS VPC ID.')
 aws_availability_zone = input(:aws_availability_zone, value: '', description: 'The AWS AZ.')
 
 control 'aws-subnets-loop-1.0' do
-  impact 1.0
   title 'Loop across AWS VPC Subnets plural resource using singular resource for detail.'
 
   aws_subnets.subnet_ids.each do |subnet|

--- a/test/integration/verify/controls/aws_synthetics_canaries.rb
+++ b/test/integration/verify/controls/aws_synthetics_canaries.rb
@@ -1,7 +1,6 @@
 aws_synthetics_canary_name = input(:aws_synthetics_canary_name, value: "", description: "")
 
 control 'aws_synthetics_canaries-1.0' do
-  impact 1.0
   title 'Test the properties of the synthetics canaries.'
 
   describe aws_synthetics_canaries do

--- a/test/integration/verify/controls/aws_synthetics_canary.rb
+++ b/test/integration/verify/controls/aws_synthetics_canary.rb
@@ -6,7 +6,6 @@ aws_synthetics_canary_engine_arn = input(:aws_synthetics_canary_engine_arn, valu
 aws_synthetics_canary_artifact_s3_location = input(:aws_synthetics_canary_artifact_s3_location, value: "", description: "")
 
 control 'aws_synthetics_canary-1.0' do
-  impact 1.0
   title 'Test the properties of the synthetics canary.'
 
   describe aws_synthetics_canary(name: aws_synthetics_canary_name) do

--- a/test/integration/verify/controls/aws_transfer_user.rb
+++ b/test/integration/verify/controls/aws_transfer_user.rb
@@ -3,8 +3,7 @@ aws_transfer_server_id = input(:aws_transfer_server_id, value: '', description: 
 aws_transfer_user_arn = input(:aws_transfer_user_arn, value: '', description: '')
 
 control 'aws-transfer-user-1.0' do
-    impact 1.0
-    title 'Ensure AWS CloudFormation Transfer User has the correct properties.'
+      title 'Ensure AWS CloudFormation Transfer User has the correct properties.'
 
     describe aws_transfer_user(server_id: aws_transfer_server_id, user_name: aws_transfer_user_name) do
         it { should exist }

--- a/test/integration/verify/controls/aws_transfer_users.rb
+++ b/test/integration/verify/controls/aws_transfer_users.rb
@@ -3,8 +3,7 @@ aws_transfer_server_id = input(:aws_transfer_server_id, value: '', description: 
 aws_transfer_user_arn = input(:aws_transfer_user_arn, value: '', description: '')
 
 control 'aws-transfer-users-1.0' do
-    impact 1.0
-    title 'Ensure AWS CloudFormation Transfer Users has the correct properties.'
+      title 'Ensure AWS CloudFormation Transfer Users has the correct properties.'
 
     describe aws_transfer_users(server_id: aws_transfer_server_id) do
         it { should exist }

--- a/test/integration/verify/controls/aws_transit_gateway.rb
+++ b/test/integration/verify/controls/aws_transit_gateway.rb
@@ -3,7 +3,6 @@ title 'Test AWS Transit Gateway'
 aws_transit_gateway_id = input(:aws_transit_gateway_id, value: '', description: 'The AWS Transit Gateway ID.')
 
 control 'aws-transit-gateway-1.0' do
-  impact 1.0
   title 'Ensure AWS Transit gateway is configured correctly.'
 
   describe aws_transit_gateway(transit_gateway_id: aws_transit_gateway_id) do

--- a/test/integration/verify/controls/aws_transit_gateway_connect.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_connect.rb
@@ -1,5 +1,4 @@
 skip_control 'aws_transit_gateway_connect' do
-  impact 1.0
   title 'Describes one or more Connect attachments.'
 
   describe aws_transit_gateway_connect(transit_gateway_attachment_id: 'tgw-attach-1234567890') do

--- a/test/integration/verify/controls/aws_transit_gateway_connects.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_connects.rb
@@ -1,5 +1,4 @@
 skip_control 'aws_transit_gateway_connects' do
-  impact 1.0
   title 'Describes one or more Connect attachments.'
 
   describe aws_transit_gateway_connects do

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_domain.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_domain.rb
@@ -1,6 +1,5 @@
 skip_control 'aws_transit_gateway_multicast_domain' do
 
-  impact 1.0
   title 'Describes one or more transit gateway multicast domains.'
   describe aws_transit_gateway_multicast_domain(transit_gateway_multicast_domain_id: "tgw-mcast-domain-1234567890") do
     it { should exist }

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_domain_association.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_domain_association.rb
@@ -1,6 +1,5 @@
 skip_control 'aws_transit_gateway_multicast_domain_association' do
 
-  impact 1.0
   title 'Gets information about the associations for the transit gateway multicast domain.'
 
   describe aws_transit_gateway_multicast_domain_association(transit_gateway_multicast_domain_id: 'tgw-mcast-domain-1234567890') do

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_domain_associations.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_domain_associations.rb
@@ -1,6 +1,5 @@
 skip_control 'aws_transit_gateway_multicast_domain_associations' do
 
-  impact 1.0
   title 'Gets information about the associations for the transit gateway multicast domain.'
 
   describe aws_transit_gateway_multicast_domain_associations(transit_gateway_multicast_domain_id: "tgw-mcast-domain-1234567890") do

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_domains.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_domains.rb
@@ -1,6 +1,5 @@
 skip_control 'aws_transit_gateway_multicast_domains' do
 
-  impact 1.0
   title 'Describes one or more transit gateway multicast domains.'
   describe aws_transit_gateway_multicast_domains do
     it { should exist }

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_group_member.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_group_member.rb
@@ -1,6 +1,5 @@
 control 'aws_transit_gateway_multicast_group_member' do
 
-  impact 1.0
   title 'Gets information about the associations for the transit gateway multicast domain.'
 
   describe aws_transit_gateway_multicast_group_member(transit_gateway_multicast_domain_id: '') do

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_group_members.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_group_members.rb
@@ -1,6 +1,5 @@
 control 'aws_transit_gateway_multicast_group_members' do
 
-  impact 1.0
   title 'Gets information about the associations for the transit gateway multicast domain.'
 
   describe aws_transit_gateway_multicast_group_members(transit_gateway_multicast_domain_id: "") do

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_group_source.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_group_source.rb
@@ -1,5 +1,4 @@
 control 'aws_transit_gateway_multicast_group_source' do
-  impact 1.0
   title 'Gets information about the associations for the transit gateway multicast domain.'
 
   describe aws_transit_gateway_multicast_group_source(transit_gateway_multicast_domain_id: '') do

--- a/test/integration/verify/controls/aws_transit_gateway_multicast_group_sources.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_multicast_group_sources.rb
@@ -1,5 +1,4 @@
 control 'aws_transit_gateway_multicast_group_sources' do
-  impact 1.0
   title 'Gets information about the associations for the transit gateway multicast domain.'
 
   describe aws_transit_gateway_multicast_group_sources(transit_gateway_multicast_domain_id: "") do

--- a/test/integration/verify/controls/aws_transit_gateway_route.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_route.rb
@@ -4,7 +4,6 @@ transit_gateway_route_table_id = input(:aws_transit_gateway_route_table_id, valu
 cidr_block = input(:tgw_route_cidr_block, value: '', description: 'CIDR Block for the route')
 
 control 'aws-transit-gateway-route-1.0' do
-  impact 1.0
   title 'Ensure AWS Transit Gateway Route is configured correctly.'
 
   describe aws_transit_gateway_route(transit_gateway_route_table_id: transit_gateway_route_table_id, cidr_block: cidr_block) do

--- a/test/integration/verify/controls/aws_transit_gateway_routes.rb
+++ b/test/integration/verify/controls/aws_transit_gateway_routes.rb
@@ -4,7 +4,6 @@ transit_gateway_route_table_id = input(:aws_transit_gateway_route_table_id, valu
 cidr_block = input(:tgw_route_cidr_block, value: '', description: 'CIDR Block for the route')
 
 control 'aws-transit-gateway-routes-1.0' do
-  impact 1.0
   title 'Ensure AWS Transit Gateway Route is configured correctly.'
 
   describe aws_transit_gateway_routes(transit_gateway_route_table_id: transit_gateway_route_table_id).where(static: true) do

--- a/test/integration/verify/controls/aws_vpc.rb
+++ b/test/integration/verify/controls/aws_vpc.rb
@@ -8,7 +8,6 @@ aws_vpc_dhcp_options_id = input(:aws_vpc_dhcp_options_id, value: '', description
 aws_vpc_name = input(:aws_vpc_name, value: '', description: 'The AWS VPC name.')
 
 control 'aws-vpc-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC has the correct properties.'
 
   describe aws_vpc(vpc_id: aws_vpc_id) do

--- a/test/integration/verify/controls/aws_vpc_endpoint.rb
+++ b/test/integration/verify/controls/aws_vpc_endpoint.rb
@@ -7,7 +7,6 @@ aws_vpce_service_name = input(:aws_vpce_service_name, value: '', description: 'T
 aws_route_table_first_id = input(:aws_route_table_first_id, value: '', description: 'The VPC Endpoint Route Table ID')
 
 control 'aws-vpcendpoint-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC Endpoint single resource has the correct properties.'
 
   describe aws_vpc_endpoint(vpc_endpoint_id: aws_vpce_id) do

--- a/test/integration/verify/controls/aws_vpc_endpoint_service.rb
+++ b/test/integration/verify/controls/aws_vpc_endpoint_service.rb
@@ -5,7 +5,6 @@ aws_vpc_endpoint_service_id = input(:aws_vpc_endpoint_service_id, value: '', des
 aws_vpc_base_endpoint_dns_names = input(:aws_vpc_base_endpoint_dns_names, value: '', description: 'The VPC base endpoint DNS names')
 
 control 'aws-vpc-endpoint-service-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC Endpoint Service single resource has the correct properties.'
   
   describe aws_vpc_endpoint_service(service_name: aws_vpc_service_name) do

--- a/test/integration/verify/controls/aws_vpc_endpoint_service_permission.rb
+++ b/test/integration/verify/controls/aws_vpc_endpoint_service_permission.rb
@@ -4,7 +4,6 @@ aws_vpc_endpoint_service_id = input(:aws_vpc_endpoint_service_id, value: '', des
 aws_vpc_endpoint_service_allowed_principal_arn = input(:aws_vpc_endpoint_service_allowed_principal_arn, value: '', description: 'AWS ARN of the user/account to allow permissions')
 
 control 'aws-vpc-endpoint-service-permission-1.0' do
-  impact 1.0
   title 'Ensure AWS VPN Endpoint Service Permission has the correct properties.'
 
   describe aws_vpc_endpoint_service_permission(service_id: aws_vpc_endpoint_service_id, principal: aws_vpc_endpoint_service_allowed_principal_arn) do

--- a/test/integration/verify/controls/aws_vpc_endpoint_service_permissions.rb
+++ b/test/integration/verify/controls/aws_vpc_endpoint_service_permissions.rb
@@ -4,7 +4,6 @@ aws_vpc_endpoint_service_id = input(:aws_vpc_endpoint_service_id, value: '', des
 aws_vpc_endpoint_service_allowed_principal_arn = input(:aws_vpc_endpoint_service_allowed_principal_arn, value: '', description: 'AWS ARN of the user/account to allow permissions')
 
 control 'aws-vpc-endpoint-service-permissions-1.0' do
-  impact 1.0
   title 'Ensure AWS VPN Endpoint Service Permissions has the correct properties.'
 
   describe aws_vpc_endpoint_service_permissions(service_id: aws_vpc_endpoint_service_id) do

--- a/test/integration/verify/controls/aws_vpc_endpoint_services.rb
+++ b/test/integration/verify/controls/aws_vpc_endpoint_services.rb
@@ -3,7 +3,6 @@ title 'Test All AWS VPC Endpoint Services'
 aws_vpc_service_name = input(:aws_vpc_endpoint_service_name, value: '', description: 'The VPC Endpoint service name')
 
 control 'aws-vpc-endpoint-services-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC Endpoint Services resource has the correct properties.'
 
   describe aws_vpc_endpoint_services do

--- a/test/integration/verify/controls/aws_vpc_endpoints.rb
+++ b/test/integration/verify/controls/aws_vpc_endpoints.rb
@@ -7,7 +7,6 @@ aws_vpce_service_name = input(:aws_vpce_service_name, value: '', description: 'T
 aws_route_table_first_id = input(:aws_route_table_first_id, value: '', description: 'The VPC Endpoint Route Table ID')
 
 control 'aws-vpcendpoints-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC Endpoint plural resource has the correct properties.'
 
   describe aws_vpc_endpoints do

--- a/test/integration/verify/controls/aws_vpcs.rb
+++ b/test/integration/verify/controls/aws_vpcs.rb
@@ -7,7 +7,6 @@ aws_vpc_dhcp_options_id = input(:aws_vpc_dhcp_options_id, value: '', description
 aws_vpc_name = input(:aws_vpc_name, value: '', description: 'The AWS VPC name.')
 
 control 'aws-vpcs-1.0' do
-  impact 1.0
   title 'Ensure AWS VPC plural resource has the correct properties.'
 
   describe aws_vpcs do

--- a/test/integration/verify/controls/aws_vpcs_loop.rb
+++ b/test/integration/verify/controls/aws_vpcs_loop.rb
@@ -6,7 +6,6 @@ aws_vpc_instance_tenancy = input(:aws_vpc_instance_tenancy, value: '', descripti
 aws_vpc_dhcp_options_id = input(:aws_vpc_dhcp_options_id, value: '', description: 'The AWS VPC DHCP options ID.')
 
 control 'aws-vpcs-loop-1.0' do
-  impact 1.0
   title 'Loop across AWS VPCs plural resource using singular resource for detail.'
 
   aws_vpcs.vpc_ids.each do |vpc|

--- a/test/integration/verify/controls/aws_vpn_connection.rb
+++ b/test/integration/verify/controls/aws_vpn_connection.rb
@@ -5,7 +5,6 @@ aws_vpn_gateway_id = input(:aws_vpn_gateway_id, value: '', description: 'The AWS
 aws_vpn_customer_gateway_id = input(:aws_vpn_customer_gateway_id, value: '', description: 'The AWS VPN Customer Gateway ID.')
 
 control 'aws-vpn-connection-1.0' do
-  impact 1.0
   title 'Ensure AWS VPN Connection has the correct properties.'
   
   describe aws_vpn_connection(aws_vpn_connection_id) do

--- a/test/integration/verify/controls/aws_vpn_connections.rb
+++ b/test/integration/verify/controls/aws_vpn_connections.rb
@@ -4,7 +4,6 @@ aws_vpn_connection_id = input(:aws_vpn_connection_id, value: '', description: 'T
 aws_vpn_gateway_id = input(:aws_vpn_gateway_id, value: '', description: 'The AWS VPN Gateway ID.')
 
 control 'aws-vpn-connections-1.0' do
-  impact 1.0
   desc 'Ensure AWS VPN Connections has the correct properties.'
   
   describe aws_vpn_connections do

--- a/test/integration/verify/controls/aws_vpn_gateway.rb
+++ b/test/integration/verify/controls/aws_vpn_gateway.rb
@@ -5,7 +5,6 @@ aws_amazon_side_asn = input(:aws_amazon_side_asn, value: '', description: 'The A
 aws_vpn_gw_name = input(:aws_vpn_gw_name, value: '', description: 'The AWS VPN Gateway Name')
 
 control 'aws-vpn-gateway-1.0' do
-  impact 1.0
   title 'Ensure AWS VPN Gateway has the correct properties.'
 
   describe aws_vpn_gateway(vpn_gateway_id: aws_vpn_gateway_id) do

--- a/test/integration/verify/controls/aws_vpn_gateways.rb
+++ b/test/integration/verify/controls/aws_vpn_gateways.rb
@@ -6,7 +6,6 @@ aws_amazon_side_asn = input(:aws_amazon_side_asn, value: '', description: 'The A
 aws_vpn_gw_name = input(:aws_vpn_gw_name, value: '', description: 'The AWS VPN Gateway Name')
 
 control 'aws-vpn-gateways-1.0' do
-  impact 1.0
   title 'Ensure AWS VPN Gateways has the correct properties.'
 
   describe aws_vpn_gateways do

--- a/test/integration/verify/controls/aws_waf_byte_match_set.rb
+++ b/test/integration/verify/controls/aws_waf_byte_match_set.rb
@@ -4,7 +4,6 @@ aws_waf_byte_match_set_name = input(:aws_waf_byte_match_set_name, value: '', des
 title 'Ensure the byte match set have the correct properties.'
 
 control 'aws-waf-byte-match-set-1.0' do
-  impact 1.0
   title 'Test the properties of a WAF Byte Match Set.'
 
   describe aws_waf_byte_match_set(byte_match_set_id: aws_waf_byte_match_set_id) do

--- a/test/integration/verify/controls/aws_waf_byte_match_sets.rb
+++ b/test/integration/verify/controls/aws_waf_byte_match_sets.rb
@@ -4,7 +4,6 @@ aws_waf_byte_match_set_name = input(:aws_waf_byte_match_set_name, value: '', des
 title 'Ensure the byte match sets have the correct properties.'
 
 control 'aws-waf-byte-match-sets-1.0' do
-  impact 1.0
   title 'Test the properties of a WAF Byte Match Sets.'
 
   describe aws_waf_byte_match_sets do

--- a/test/integration/verify/controls/aws_waf_ip_set.rb
+++ b/test/integration/verify/controls/aws_waf_ip_set.rb
@@ -4,7 +4,6 @@ aws_waf_ipset_name = input(:aws_waf_ipset_name, value: '', description: '')
 title 'Ensure the ip set have the correct properties.'
 
 control 'aws-waf-ip-set-1.0' do
-  impact 1.0
   title 'Test the properties of a WAF IP Set.'
 
   describe aws_waf_ip_set(ip_set_id: aws_waf_ipset_id) do

--- a/test/integration/verify/controls/aws_waf_ip_sets.rb
+++ b/test/integration/verify/controls/aws_waf_ip_sets.rb
@@ -4,7 +4,6 @@ aws_waf_ipset_name = input(:aws_waf_ipset_name, value: '', description: '')
 title 'Ensure the ip sets have the correct properties.'
 
 control 'aws-waf-ip-sets-1.0' do
-  impact 1.0
   title 'Test the properties of a WAF IP Sets.'
 
   describe aws_waf_ip_sets do

--- a/test/integration/verify/controls/aws_waf_rule.rb
+++ b/test/integration/verify/controls/aws_waf_rule.rb
@@ -2,7 +2,6 @@ aws_waf_rule_name = input(:aws_waf_rule_name, value: '', description: '')
 aws_waf_rule_id = input(:aws_waf_rule_id, value: '', description: '')
 
 control 'aws_waf_rule-1.0' do
-  impact 1.0
   title 'Test the properties of a WAF Rule.'
 
   describe aws_waf_rule(rule_id: aws_waf_rule_id) do

--- a/test/integration/verify/controls/aws_waf_rules.rb
+++ b/test/integration/verify/controls/aws_waf_rules.rb
@@ -2,7 +2,6 @@ aws_waf_rule_name = input(:aws_waf_rule_name, value: '', description: '')
 aws_waf_rule_id = input(:aws_waf_rule_id, value: '', description: '')
 
 control 'aws_waf_rules-1.0' do
-  impact 1.0
   title 'Test the properties of all the WAF Rules.'
 
   describe aws_waf_rules do

--- a/test/integration/verify/controls/aws_waf_size_constraint_set.rb
+++ b/test/integration/verify/controls/aws_waf_size_constraint_set.rb
@@ -4,7 +4,6 @@ aws_waf_size_constraint_set_name = input(aws_waf_size_constraint_set_name, value
 title 'Ensure the size constraint set have the correct properties.'
 
 control 'aws-waf-size-constraint-set-1.0' do
-  impact 1.0
   title 'Test the properties of the WAF size constraint set.'
 
   describe aws_waf_size_constraint_set(size_constraint_set_id: aws_waf_size_constraint_set_id) do

--- a/test/integration/verify/controls/aws_waf_size_constraint_sets.rb
+++ b/test/integration/verify/controls/aws_waf_size_constraint_sets.rb
@@ -4,7 +4,6 @@ aws_waf_size_constraint_set_name = input(aws_waf_size_constraint_set_name, value
 title 'Ensure the size constraint sets have the correct properties.'
 
 control 'aws-waf-size-constraint-sets-1.0' do
-  impact 1.0
   title 'Test all the properties of the WAF size constraint set.'
 
   describe aws_waf_size_constraint_sets do

--- a/test/integration/verify/controls/aws_waf_sql_injection_match_set.rb
+++ b/test/integration/verify/controls/aws_waf_sql_injection_match_set.rb
@@ -4,7 +4,6 @@ aws_waf_sql_injection_match_set_name = input(aws_waf_sql_injection_match_set_nam
 title 'Ensure the waf sql injection match set have the correct properties.'
 
 control 'aws-waf-sql-injection-match-set-1.0' do
-  impact 1.0
   title 'Test the properties of the WAF SQL injection match sets.'
 
   describe aws_waf_sql_injection_match_set(sql_injection_match_set_id: aws_waf_sql_injection_match_set_id) do

--- a/test/integration/verify/controls/aws_waf_sql_injection_match_sets.rb
+++ b/test/integration/verify/controls/aws_waf_sql_injection_match_sets.rb
@@ -4,7 +4,6 @@ aws_waf_sql_injection_match_set_name = input(aws_waf_sql_injection_match_set_nam
 title 'Ensure the waf match sets have the correct properties.'
 
 control 'aws-waf-sql-injection-match-sets-1.0' do
-  impact 1.0
   title 'Test the properties of all the WAF SQL injection match sets.'
 
   describe aws_waf_sql_injection_match_sets do

--- a/test/integration/verify/controls/aws_waf_web_acl.rb
+++ b/test/integration/verify/controls/aws_waf_web_acl.rb
@@ -4,7 +4,6 @@ aws_waf_web_acl_name = input(aws_waf_web_acl_name, value: '', description: '')
 title 'Ensure the web acl have the correct properties.'
 
 control 'aws-waf-web-acl-1.0' do
-  impact 1.0
   title 'Test the properties of the WAF ACL.'
 
   describe aws_waf_web_acl(web_acl_id: aws_waf_web_acl_id) do

--- a/test/integration/verify/controls/aws_waf_web_acls.rb
+++ b/test/integration/verify/controls/aws_waf_web_acls.rb
@@ -4,7 +4,6 @@ aws_waf_web_acl_name = input(aws_waf_web_acl_name, value: '', description: '')
 title 'Ensure the web acls have the correct properties.'
 
 control 'aws-waf-web-acls-1.0' do
-  impact 1.0
   title 'Test the properties of all WAF ACLs.'
 
   describe aws_waf_web_acls do

--- a/test/integration/verify/controls/aws_waf_xss_match_match_set.rb
+++ b/test/integration/verify/controls/aws_waf_xss_match_match_set.rb
@@ -2,7 +2,6 @@ aws_waf_xss_match_set_name = input(:aws_waf_xss_match_set_name, value: '', descr
 aws_waf_xss_match_set_id = input(:aws_waf_xss_match_set_id, value: '', description: '')
 
 control 'aws-waf-xss-match-set-1.0' do
-  impact 1.0
   title 'Test the properties of the WAF XSS match set.'
 
   describe aws_waf_xss_match_sets do

--- a/test/integration/verify/controls/aws_waf_xss_match_match_sets.rb
+++ b/test/integration/verify/controls/aws_waf_xss_match_match_sets.rb
@@ -2,7 +2,6 @@ aws_waf_xss_match_set_name = input(:aws_waf_xss_match_set_name, value: '', descr
 aws_waf_xss_match_set_id = input(:aws_waf_xss_match_set_id, value: '', description: '')
 
 control 'aws-waf-size-constraint-sets-1.0' do
-  impact 1.0
   title 'Test the properties of all WAF xss match sets.'
 
   describe aws_waf_xss_match_sets do

--- a/test/integration/verify/controls/vpc_endpoint_notification.rb
+++ b/test/integration/verify/controls/vpc_endpoint_notification.rb
@@ -4,7 +4,6 @@ aws_notification_arn = input(:aws_vpc_notifications_arn, value: '', description:
 title "Test single AWS VPC Notification"
 
 control "aws-vpc-endpoint-connection-notification-1.0" do
-  impact 1.0
   title "Check AWS vpc-endpoint-connection-notification has the correct properties."
 
   describe aws_vpc_endpoint_connection_notification(connection_notification_id: aws_notification_id) do

--- a/test/integration/verify/controls/vpc_endpoint_notifications.rb
+++ b/test/integration/verify/controls/vpc_endpoint_notifications.rb
@@ -4,7 +4,6 @@ aws_notification_arn = input(:aws_vpc_notifications_arn, value: '', description:
 title "Test multiple AWS VPC Notifications"
 
 control "aws-vpc-endpoint-connection-notifications-1.0" do
-  impact 1.0
   title "Check AWS vpc-endpoint-connection-notifications has the correct properties."
 
   describe aws_vpc_endpoint_connection_notifications do


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

In all the integration controls we have impact 1.0. So we can remove this impact 1.0 from the controls in the integration test in inspec-aws.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
