### PR TITLE
RESOURCE-567  Change the unit tests names in their proper names

### DIFF
--- a/test/unit/resources/aws_api_gateway_deployments_test.rb
+++ b/test/unit/resources/aws_api_gateway_deployments_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayDeploymentsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayDeployments.new('rubbish') }
   end
 
-  def test_items_non_existing_for_empty_response
+  def test_api_gateway_deployments_non_existing_for_empty_response
     refute AWSApiGatewayDeployments.new(rest_api_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_api_gateway_documentation_parts_test.rb
+++ b/test/unit/resources/aws_api_gateway_documentation_parts_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayDocumentationPartsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayDocumentationParts.new('rubbish') }
   end
 
-  def test_documentation_parts_non_existing_for_empty_response
+  def test_api_gateway_documentation_parts_non_existing_for_empty_response
     refute AWSApiGatewayDocumentationParts.new(rest_api_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_api_gateway_documentation_versions_test.rb
+++ b/test/unit/resources/aws_api_gateway_documentation_versions_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayDocumentationVersionsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayDocumentationVersions.new('rubbish') }
   end
 
-  def test_documentation_versions_non_existing_for_empty_response
+  def test_api_gateway_documentation_versions_non_existing_for_empty_response
     refute AWSApiGatewayDocumentationVersions.new(rest_api_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_api_gateway_responses_test.rb
+++ b/test/unit/resources/aws_api_gateway_responses_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayResponsesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayResponses.new('rubbish') }
   end
 
-  def test_non_existing_for_empty_response
+  def test_api_gateway_responses_non_existing_for_empty_response
     refute AWSApiGatewayResponses.new(rest_api_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_api_gateway_restapis_test.rb
+++ b/test/unit/resources/aws_api_gateway_restapis_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayRestApisConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayRestApis.new('rubbish') }
   end
 
-  def test_work_groups_non_existing_for_empty_response
+  def test_api_gateway_restapis_non_existing_for_empty_response
     refute AWSApiGatewayRestApis.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_api_gateway_stages_test.rb
+++ b/test/unit/resources/aws_api_gateway_stages_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayStagesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayStages.new('rubbish') }
   end
 
-  def test_stages_non_existing_for_empty_response
+  def test_api_gateway_stages_non_existing_for_empty_response
     refute AWSApiGatewayStages.new(rest_api_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_apigateway_api_keys_test.rb
+++ b/test/unit/resources/aws_apigateway_api_keys_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayAPIKeysConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayAPIKeys.new('rubbish') }
   end
 
-  def test_api_mapping_non_existing_for_empty_response
+  def test_api_mapping_api_keys_non_existing_for_empty_response
     refute AWSApiGatewayAPIKeys.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_apigateway_authorizers_test.rb
+++ b/test/unit/resources/aws_apigateway_authorizers_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayAuthorizersConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayAuthorizers.new('rubbish') }
   end
 
-  def test_api_mapping_non_existing_for_empty_response
+  def test_api_mapping_authorizers_non_existing_for_empty_response
     refute AWSApiGatewayAuthorizers.new(rest_api_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_apigateway_base_path_mappings_test.rb
+++ b/test/unit/resources/aws_apigateway_base_path_mappings_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayBasePathMappingsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayBasePathMappings.new('rubbish') }
   end
 
-  def test_api_mapping_non_existing_for_empty_response
+  def test_api_mapping_base_path_mappings_non_existing_for_empty_response
     refute AWSApiGatewayBasePathMappings.new(domain_name: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_apigateway_client_certificates_test.rb
+++ b/test/unit/resources/aws_apigateway_client_certificates_test.rb
@@ -12,7 +12,7 @@ class AWSApiGatewayClientCertificatesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApiGatewayClientCertificates.new('rubbish') }
   end
 
-  def test_api_mapping_non_existing_for_empty_response
+  def test_api_mapping_client_certificates_non_existing_for_empty_response
     refute AWSApiGatewayClientCertificates.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_application_autoscaling_scalable_targets_test.rb
+++ b/test/unit/resources/aws_application_autoscaling_scalable_targets_test.rb
@@ -12,7 +12,7 @@ class AWSApplicationAutoScalingScalableTargetsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSApplicationAutoScalingScalableTargets.new('rubbish') }
   end
 
-  def test_associations_non_existing_for_empty_response
+  def test_scalable_targets_non_existing_for_empty_response
     refute AWSApplicationAutoScalingScalableTargets.new(service_namespace: "test", client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_athena_work_group_test.rb
+++ b/test/unit/resources/aws_athena_work_group_test.rb
@@ -31,7 +31,7 @@ class AWSAthenaWorkGroupSuccessPathTest < Minitest::Test
     @work_group = AWSAthenaWorkGroup.new(work_group: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
-  def test_parameter_group_exists
+  def test_work_group_exists
     assert @work_group.exists?
   end
 

--- a/test/unit/resources/aws_autoscaling_scaling_policies_test.rb
+++ b/test/unit/resources/aws_autoscaling_scaling_policies_test.rb
@@ -12,7 +12,7 @@ class AWSAutoScalingScalingPoliciesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSAutoScalingScalingPolicies.new('rubbish') }
   end
 
-  def test_work_groups_non_existing_for_empty_response
+  def test_autoscaling_scaling_policies_non_existing_for_empty_response
     refute AWSAutoScalingScalingPolicies.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_batch_compute_environments_test.rb
+++ b/test/unit/resources/aws_batch_compute_environments_test.rb
@@ -12,7 +12,7 @@ class AWSBatchComputeEnvironmentsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSBatchComputeEnvironments.new('rubbish') }
   end
 
-  def test_work_groups_non_existing_for_empty_response
+  def test_compute_environments_non_existing_for_empty_response
     refute AWSBatchComputeEnvironments.new(client_args: { stub_responses: true }).exist?
   end
 end
@@ -36,7 +36,7 @@ class AWSBatchComputeEnvironmentsHappyPathTest < Minitest::Test
     @compute_environments = AWSBatchComputeEnvironments.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
-  def test_work_groups_exists
+  def test_compute_environments_exists
     assert @compute_environments.exist?
   end
 

--- a/test/unit/resources/aws_batch_job_definition_test.rb
+++ b/test/unit/resources/aws_batch_job_definition_test.rb
@@ -28,11 +28,6 @@ class AWSBatchJobDefinitionSuccessPathTest < Minitest::Test
     mock_parameter[:revision] = 1
     mock_parameter[:status] = 'test1'
     mock_parameter[:type] = 'test1'
-    # mock_parameter[:parameters] = 1
-    # mock_parameter[:container_properties] = 'test1'
-    # mock_parameter[:timeout] = 'test1'
-    # mock_parameter[:node_properties] = 'test1'
-    # mock_parameter[:tags] = 'test1'
     mock_parameter[:propagate_tags] = true
     mock_parameter[:platform_capabilities] = ['test1']
     data[:data] = { job_definitions: [mock_parameter] }

--- a/test/unit/resources/aws_batch_job_definitions_test.rb
+++ b/test/unit/resources/aws_batch_job_definitions_test.rb
@@ -28,11 +28,6 @@ class AWSBatchJobDefinitionsHappyPathTest < Minitest::Test
     mock_parameter[:revision] = 1
     mock_parameter[:status] = 'test1'
     mock_parameter[:type] = 'test1'
-    # mock_parameter[:parameters] = 1
-    # mock_parameter[:container_properties] = 'test1'
-    # mock_parameter[:timeout] = 'test1'
-    # mock_parameter[:node_properties] = 'test1'
-    # mock_parameter[:tags] = 'test1'
     mock_parameter[:propagate_tags] = true
     mock_parameter[:platform_capabilities] = ['test1']
     data[:data] = { job_definitions: [mock_parameter] }

--- a/test/unit/resources/aws_batch_job_queues_test.rb
+++ b/test/unit/resources/aws_batch_job_queues_test.rb
@@ -12,7 +12,7 @@ class AWSBatchJobQueuesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSBatchJobQueues.new('rubbish') }
   end
 
-  def test_job_definitions_non_existing_for_empty_response
+  def test_job_queues_non_existing_for_empty_response
     refute AWSBatchJobQueues.new(client_args: { stub_responses: true }).exist?
   end
 end
@@ -32,34 +32,34 @@ class AWSBatchJobQueuesHappyPathTest < Minitest::Test
     mock_parameter[:compute_environment_order] = [{'order':1, 'compute_environment': 'test1'}]
     data[:data] = { job_queues: [mock_parameter] }
     data[:client] = Aws::Batch::Client
-    @job_definitions = AWSBatchJobQueues.new(client_args: { stub_responses: true }, stub_data: [data])
+    @job_queues = AWSBatchJobQueues.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_job_definitions_exists
-    assert @job_definitions.exists?
+    assert @job_queues.exists?
   end
 
   def test_job_queue_names
-    assert_equal(@job_definitions.job_queue_names, ['test1'])
+    assert_equal(@job_queues.job_queue_names, ['test1'])
   end
 
   def test_job_queue_arns
-    assert_equal(@job_definitions.job_queue_arns, ['test1'])
+    assert_equal(@job_queues.job_queue_arns, ['test1'])
   end
 
   def test_states
-    assert_equal(@job_definitions.states, ["test1"])
+    assert_equal(@job_queues.states, ["test1"])
   end
 
   def test_statuses
-    assert_equal(@job_definitions.statuses, ['test1'])
+    assert_equal(@job_queues.statuses, ['test1'])
   end
 
   def test_status_reasons
-    assert_equal(@job_definitions.status_reasons, ['test1'])
+    assert_equal(@job_queues.status_reasons, ['test1'])
   end
 
   def test_priorities
-    assert_equal(@job_definitions.priorities, [1])
+    assert_equal(@job_queues.priorities, [1])
   end
 end

--- a/test/unit/resources/aws_cloudfront_public_keys_test.rb
+++ b/test/unit/resources/aws_cloudfront_public_keys_test.rb
@@ -12,7 +12,7 @@ class AWSCloudFrontPublicKeysConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSCloudFrontPublicKeys.new('rubbish') }
   end
 
-  def test_realtime_log_configs_non_existing_for_empty_response
+  def test_cloudfront_public_keys_non_existing_for_empty_response
     refute AWSCloudFrontPublicKeys.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_cloudfront_streaming_distributions_test.rb
+++ b/test/unit/resources/aws_cloudfront_streaming_distributions_test.rb
@@ -12,7 +12,7 @@ class AWSCloudFrontStreamingDistributionsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSCloudFrontStreamingDistributions.new('rubbish') }
   end
 
-  def test_cache_policy_non_existing_for_empty_response
+  def test_streaming_distribution_list_non_existing_for_empty_response
     refute AWSCloudFrontStreamingDistributions.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_cloudwatch_alarm_test.rb
+++ b/test/unit/resources/aws_cloudwatch_alarm_test.rb
@@ -37,32 +37,32 @@ class AwsCloudwatchAlarmTest < Minitest::Test
     mock_alarm[:alarm_actions] = []
     data[:data] = { :metric_alarms => [mock_alarm] }
     data[:client] = Aws::CloudWatch::Client
-    @alarm = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', client_args: { stub_responses: true }, stub_data: [data])
+    @metric_alarms = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_resource_id
-    refute_nil(@alarm.resource_id)
-    assert_equal(@alarm.resource_id, @alarm.metric_name + '_' + @alarm.metric_namespace)
+    refute_nil(@metric_alarms.resource_id)
+    assert_equal(@metric_alarms.resource_id, @metric_alarms.metric_name + '_' + @metric_alarms.metric_namespace)
   end
 
   def test_alarm_exists
-    assert @alarm.exists?
+    assert @metric_alarms.exists?
   end
 
   def test_alarm_name
-    assert_equal(@alarm.alarm_name, 'alarm-12345678')
+    assert_equal(@metric_alarms.alarm_name, 'alarm-12345678')
   end
 
   def test_alarm_metric_name
-    assert_equal(@alarm.metric_name, 'metric')
+    assert_equal(@metric_alarms.metric_name, 'metric')
   end
 
   def test_alarm_metric_namespace
-    assert_equal(@alarm.metric_namespace, 'space')
+    assert_equal(@metric_alarms.metric_namespace, 'space')
   end
 
   def test_alarm_actions
-    assert_equal(@alarm.alarm_actions, [])
+    assert_equal(@metric_alarms.alarm_actions, [])
   end
 end
 
@@ -77,27 +77,27 @@ class AwsCloudwatchAlarmWithActionTest < Minitest::Test
     mock_alarm[:alarm_actions] = ['arn:aws:sns:us-west-2:0123456789012:aws-sns-arn']
     data[:data] = { :metric_alarms => [mock_alarm] }
     data[:client] = Aws::CloudWatch::Client
-    @alarm = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', client_args: { stub_responses: true }, stub_data: [data])
+    @metric_alarms = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_alarm_exists
-    assert @alarm.exists?
+    assert @metric_alarms.exists?
   end
 
   def test_alarm_name
-    assert_equal(@alarm.alarm_name, 'alarm-12345678')
+    assert_equal(@metric_alarms.alarm_name, 'alarm-12345678')
   end
 
   def test_alarm_metric_name
-    assert_equal(@alarm.metric_name, 'metric')
+    assert_equal(@metric_alarms.metric_name, 'metric')
   end
 
   def test_alarm_metric_namespace
-    assert_equal(@alarm.metric_namespace, 'space')
+    assert_equal(@metric_alarms.metric_namespace, 'space')
   end
 
   def test_alarm_actions
-    assert_equal(@alarm.alarm_actions, ['arn:aws:sns:us-west-2:0123456789012:aws-sns-arn'])
+    assert_equal(@metric_alarms.alarm_actions, ['arn:aws:sns:us-west-2:0123456789012:aws-sns-arn'])
   end
 end
 
@@ -137,30 +137,30 @@ class AwsCloudwatchAlarmWithDimensionsTest < Minitest::Test
     mock_alarm[:alarm_actions] = []
     data[:data] = { :metric_alarms => [mock_alarm] }
     data[:client] = Aws::CloudWatch::Client
-    @alarm = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', dimensions: [{:name=>'Server', :value=>'Prod'},{:name=>'Domain', :value=>'Frankfurt'}], client_args: { stub_responses: true }, stub_data: [data])
+    @metric_alarms = AwsCloudwatchAlarm.new(metric_name: 'metric', metric_namespace: 'space', dimensions: [{:name=>'Server', :value=>'Prod'},{:name=>'Domain', :value=>'Frankfurt'}], client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_alarm_exists
-    assert @alarm.exists?
+    assert @metric_alarms.exists?
   end
 
   def test_alarm_name
-    assert_equal(@alarm.alarm_name, 'alarm-12345678')
+    assert_equal(@metric_alarms.alarm_name, 'alarm-12345678')
   end
 
   def test_alarm_metric_name
-    assert_equal(@alarm.metric_name, 'metric')
+    assert_equal(@metric_alarms.metric_name, 'metric')
   end
 
   def test_alarm_metric_namespace
-    assert_equal(@alarm.metric_namespace, 'space')
+    assert_equal(@metric_alarms.metric_namespace, 'space')
   end
 
   def test_alarm_dimensions
-    assert_equal(@alarm.dimensions, [{name:'Server', value:'Prod'},{name:'Domain', value:'Frankfurt'}])
+    assert_equal(@metric_alarms.dimensions, [{name:'Server', value:'Prod'},{name:'Domain', value:'Frankfurt'}])
   end
 
   def test_alarm_actions
-    assert_equal(@alarm.alarm_actions, [])
+    assert_equal(@metric_alarms.alarm_actions, [])
   end
 end

--- a/test/unit/resources/aws_ec2_dhcp_options_test.rb
+++ b/test/unit/resources/aws_ec2_dhcp_options_test.rb
@@ -12,7 +12,7 @@ class AwsEc2DHCPOptionsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsEc2DHCPOptions.new('random') }
   end
 
-  def test_instances_non_existing_for_empty_response
+  def test_dhcp_options_non_existing_for_empty_response
     refute AwsEc2DHCPOptions.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_eips_test.rb
+++ b/test/unit/resources/aws_ec2_eips_test.rb
@@ -11,7 +11,7 @@ class AwsEIPsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsEc2Eips.new('rubbish') }
   end
 
-  def test_vpcs_non_existing_for_empty_response
+  def test_addresses_non_existing_for_empty_response
     refute AwsEc2Eips.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_fleets_test.rb
+++ b/test/unit/resources/aws_ec2_fleets_test.rb
@@ -12,7 +12,7 @@ class AWSEC2FleetsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEC2Fleets.new('rubbish') }
   end
 
-  def test_egress_only_internet_gateways_non_existing_for_empty_response
+  def test_fleets_non_existing_for_empty_response
     refute AWSEC2Fleets.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_hosts_test.rb
+++ b/test/unit/resources/aws_ec2_hosts_test.rb
@@ -12,7 +12,7 @@ class AWSEC2HostsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEC2Hosts.new('rubbish') }
   end
 
-  def test_egress_only_internet_gateways_non_existing_for_empty_response
+  def test_hosts_non_existing_for_empty_response
     refute AWSEC2Hosts.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_internet_gateways_test.rb
+++ b/test/unit/resources/aws_ec2_internet_gateways_test.rb
@@ -12,7 +12,7 @@ class AWSEC2InternetGatewaysConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEC2InternetGateways.new('rubbish') }
   end
 
-  def test_internet_gateway_non_existing_for_empty_response
+  def test_internet_gateways_non_existing_for_empty_response
     refute AWSEC2InternetGateways.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_network_insights_paths_test.rb
+++ b/test/unit/resources/aws_ec2_network_insights_paths_test.rb
@@ -12,7 +12,7 @@ class AWSEC2NetworkInsightsPathsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEC2NetworkInsightsPaths.new('rubbish') }
   end
 
-  def test_internet_gateway_non_existing_for_empty_response
+  def test_network_insights_paths_non_existing_for_empty_response
     refute AWSEC2NetworkInsightsPaths.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_network_interfaces_test.rb
+++ b/test/unit/resources/aws_ec2_network_interfaces_test.rb
@@ -12,7 +12,7 @@ class AWSEC2NetworkInterfacesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEC2NetworkInterfaces.new('rubbish') }
   end
 
-  def test_internet_gateway_non_existing_for_empty_response
+  def test_network_interfaces_non_existing_for_empty_response
     refute AWSEC2NetworkInterfaces.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_transit_gateway_attachments_test.rb
+++ b/test/unit/resources/aws_ec2_transit_gateway_attachments_test.rb
@@ -12,7 +12,7 @@ class AwsEc2TransitGatewayAttachmentsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsEc2TransitGatewayAttachments.new('rubbish') }
   end
 
-  def test_Ec2TransitGatewayAttachments_non_existing_for_empty_response
+  def test_transit_gateway_attachments_non_existing_for_empty_response
     refute AwsEc2TransitGatewayAttachments.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_transit_gateway_route_table_association_test.rb
+++ b/test/unit/resources/aws_ec2_transit_gateway_route_table_association_test.rb
@@ -7,11 +7,7 @@ class AwsEc2TransitGatewayRouteTableAssociationConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsEc2TransitGatewayRouteTableAssociation.new(client_args: { stub_responses: true }) }
   end
 
-  def test_accepts_transit_gateway_attachment_id_as_hash_eight_sign
-    AwsEc2TransitGatewayRouteTableAssociation.new(transit_gateway_route_table_id: 'test', client_args: { stub_responses: true })
-  end
-
-  def test_accepts_transit_gateway_attachment_id_as_hash
+  def test_accepts_transit_gateway_route_table_id_as_hash_eight_sign
     AwsEc2TransitGatewayRouteTableAssociation.new(transit_gateway_route_table_id: 'test', client_args: { stub_responses: true })
   end
 

--- a/test/unit/resources/aws_ec2_transit_gateway_route_table_associations_test.rb
+++ b/test/unit/resources/aws_ec2_transit_gateway_route_table_associations_test.rb
@@ -12,7 +12,7 @@ class AwsEc2TransitGatewayRouteTableAssociationsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsEc2TransitGatewayRouteTableAssociations.new('rubbish') }
   end
 
-  def test_associations_non_existing_for_empty_response
+  def test_transit_gateway_route_table_associations_non_existing_for_empty_response
     refute AwsEc2TransitGatewayRouteTableAssociations.new(transit_gateway_route_table_id: "test", client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_transit_gateway_route_tables_test.rb
+++ b/test/unit/resources/aws_ec2_transit_gateway_route_tables_test.rb
@@ -12,7 +12,7 @@ class AwsEc2TransitGatewayRouteTablesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsEc2TransitGatewayRouteTables.new('rubbish') }
   end
 
-  def test_Ec2TransitGatewayRouteTables_non_existing_for_empty_response
+  def test_transit_gateway_route_tables_non_existing_for_empty_response
     refute AwsEc2TransitGatewayRouteTables.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_volume_attachments_test.rb
+++ b/test/unit/resources/aws_ec2_volume_attachments_test.rb
@@ -12,7 +12,7 @@ class AWSEC2VolumeAttachmentsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEC2VolumeAttachments.new('rubbish') }
   end
 
-  def test_volumes_configs_non_existing_for_empty_response
+  def test_volume_attachments_configs_non_existing_for_empty_response
     refute AWSEC2VolumeAttachments.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_vpn_connection_routes_test.rb
+++ b/test/unit/resources/aws_ec2_vpn_connection_routes_test.rb
@@ -12,7 +12,7 @@ class AWSEC2VPNConnectionRoutesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEC2VPNConnectionRoutes.new('rubbish') }
   end
 
-  def test_vpn_connections_configs_non_existing_for_empty_response
+  def test_vpn_connection_routes_non_existing_for_empty_response
     refute AWSEC2VPNConnectionRoutes.new(vpn_connection_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ec2_vpn_gateway_route_propagations_test.rb
+++ b/test/unit/resources/aws_ec2_vpn_gateway_route_propagations_test.rb
@@ -12,7 +12,7 @@ class AWSEc2VPNGatewayRoutePropagationsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSEc2VPNGatewayRoutePropagations.new('rubbish') }
   end
 
-  def test_functions_non_existing_for_empty_response
+  def test_route_tables_non_existing_for_empty_response
     refute AWSEc2VPNGatewayRoutePropagations.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_ecr_repositories_test.rb
+++ b/test/unit/resources/aws_ecr_repositories_test.rb
@@ -16,7 +16,6 @@ class AwsEcrRepositoriesConstructorTest < Minitest::Test
   def test_non_existing_repositories
     refute AwsEcrRepositories.new(client_args: { stub_responses: true }).exist?
   end
-
 end
 
 class AwsEcrRepositoriesTest < Minitest::Test

--- a/test/unit/resources/aws_ecr_test.rb
+++ b/test/unit/resources/aws_ecr_test.rb
@@ -17,7 +17,7 @@ class AwsEcrConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsEcr .new(rubbish: 9) }
   end
 
-  def test_group_not_existing
+  def test_ecr_not_existing
     refute AwsEcr.new(repository_name: 'repo-not-there', client_args: { stub_responses: true }).exists?
   end
 end

--- a/test/unit/resources/aws_ecs_service_test.rb
+++ b/test/unit/resources/aws_ecs_service_test.rb
@@ -28,27 +28,27 @@ class AWSECSServiceSuccessPathTest < Minitest::Test
     mock_parameter[:cluster_arn] = 'test1'
     data[:data] = { services: [mock_parameter] }
     data[:client] = Aws::ECS::Client
-    @work_group = AWSECSService.new(cluster: 'test1', service: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @services = AWSECSService.new(cluster: 'test1', service: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_resource_id
-    refute_nil(@work_group.resource_id)
-    assert_equal(@work_group.resource_id, 'test1')
+    refute_nil(@services.resource_id)
+    assert_equal(@services.resource_id, 'test1')
   end
 
   def test_parameter_group_exists
-    assert @work_group.exists?
+    assert @services.exists?
   end
 
   def test_service_arn
-    assert_equal(@work_group.service_arn, 'test1')
+    assert_equal(@services.service_arn, 'test1')
   end
 
   def test_service_name
-    assert_equal(@work_group.service_name, 'test1')
+    assert_equal(@services.service_name, 'test1')
   end
 
   def test_cluster_arn
-    assert_equal(@work_group.cluster_arn, 'test1')
+    assert_equal(@services.cluster_arn, 'test1')
   end
 end

--- a/test/unit/resources/aws_ecs_services_test.rb
+++ b/test/unit/resources/aws_ecs_services_test.rb
@@ -22,15 +22,15 @@ class AWSECSServicesHappyPathTest < Minitest::Test
     mock_data[:service_arn] = 'test1'
     data[:data] = {services: [ mock_data] }
     data[:client] = Aws::ECS::Client
-    @res = AWSECSServices.new(cluster: "test1", client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSECSServices.new(cluster: "test1", client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_service_exists
-    assert @res.exist?
+    assert @resp.exist?
   end
 
   def test_names
 
-    assert_equal(@res.service_arns, ['test1'])
+    assert_equal(@resp.service_arns, ['test1'])
   end
 end

--- a/test/unit/resources/aws_ecs_task_definitions_test.rb
+++ b/test/unit/resources/aws_ecs_task_definitions_test.rb
@@ -22,14 +22,14 @@ class AWSECSTaskDefinitionsHappyPathTest < Minitest::Test
     mock_data[:task_definition_arns] = ['test1']
     data[:data] = [mock_data] 
     data[:client] = Aws::ECS::Client
-    @work_group = AWSECSTaskDefinitions.new(client_args: { stub_responses: true }, stub_data: [data])
+    @task_definitions = AWSECSTaskDefinitions.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
-  def test_work_groups_exists
-    assert @work_group.exist?
+  def test_task_definitions_exists
+    assert @task_definitions.exist?
   end
 
   def test_task_definition_arns
-    assert_equal(@work_group.task_definition_arns, [['test1']])
+    assert_equal(@task_definitions.task_definition_arns, [['test1']])
   end
 end

--- a/test/unit/resources/aws_elastic_search_domains_test.rb
+++ b/test/unit/resources/aws_elastic_search_domains_test.rb
@@ -12,7 +12,7 @@ class AWSElasticSearchServiceDomainsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSElasticSearchServiceDomains.new('rubbish') }
   end
 
-  def test_work_groups_non_existing_for_empty_response
+  def test_domain_names_non_existing_for_empty_response
     refute AWSElasticSearchServiceDomains.new(client_args: { stub_responses: true }).exist?
   end
 end
@@ -26,14 +26,14 @@ class AWSElasticSearchServiceDomainsHappyPathTest < Minitest::Test
     mock_data[:domain_name] = 'test1'
     data[:data] = { :domain_names => [mock_data] }
     data[:client] = Aws::ElasticsearchService::Client
-    @domain_names = AWSElasticSearchServiceDomains.new(client_args: { stub_responses: true }, stub_data: [data])
+    @domains = AWSElasticSearchServiceDomains.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_domain_names_exists
-    assert @domain_names.exist?
+    assert @domains.exist?
   end
 
   def test_domain_name
-    assert_equal(@domain_names.domain_names, ['test1'])
+    assert_equal(@domains.domain_names, ['test1'])
   end
 end

--- a/test/unit/resources/aws_elasticloadbalancingv2_listener_certificates_test.rb
+++ b/test/unit/resources/aws_elasticloadbalancingv2_listener_certificates_test.rb
@@ -12,7 +12,7 @@ class AWSElasticLoadBalancingV2ListenerCertificatesConstructorTest < Minitest::T
     assert_raises(ArgumentError) { AWSElasticLoadBalancingV2ListenerCertificates.new('rubbish') }
   end
 
-  def test_work_groups_non_existing_for_empty_response
+  def test_listener_certificates_non_existing_for_empty_response
     refute AWSElasticLoadBalancingV2ListenerCertificates.new(listener_arn: 'test1', client_args: { stub_responses: true }).exist?
   end
 end
@@ -27,18 +27,18 @@ class AWSElasticLoadBalancingV2ListenerCertificatesHappyPathTest < Minitest::Tes
     mock_data[:is_default] = true
     data[:data] = { :certificates => [mock_data] }
     data[:client] = Aws::ElasticLoadBalancingV2::Client
-    @certificates = AWSElasticLoadBalancingV2ListenerCertificates.new(listener_arn: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @listener_certificates = AWSElasticLoadBalancingV2ListenerCertificates.new(listener_arn: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_certificates_exists
-    assert @certificates.exist?
+    assert @listener_certificates.exist?
   end
 
   def test_certificate_arns
-    assert_equal(@certificates.certificate_arns, ['test1'])
+    assert_equal(@listener_certificates.certificate_arns, ['test1'])
   end
 
   def test_is_defaults
-    assert_equal(@certificates.is_defaults, [true])
+    assert_equal(@listener_certificates.is_defaults, [true])
   end
 end

--- a/test/unit/resources/aws_elasticloadbalancingv2_listener_rule_test.rb
+++ b/test/unit/resources/aws_elasticloadbalancingv2_listener_rule_test.rb
@@ -28,28 +28,28 @@ class AWSElasticLoadBalancingV2ListenerRuleSuccessPathTest < Minitest::Test
     mock_parameter[:is_default] = false
     data[:data] = { rules: [mock_parameter] }
     data[:client] = Aws::ElasticLoadBalancingV2::Client
-    @rules = AWSElasticLoadBalancingV2ListenerRule.new(rule_arns: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @listener_rule = AWSElasticLoadBalancingV2ListenerRule.new(rule_arns: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_rules_exists
-    assert @rules.exists?
+    assert @listener_rule.exists?
   end
 
   def test_rule_arn
-    assert_equal(@rules.rule_arn, 'test1')
+    assert_equal(@listener_rule.rule_arn, 'test1')
   end
 
   def test_priority
-    assert_equal(@rules.priority, 'test1')
+    assert_equal(@listener_rule.priority, 'test1')
   end
 
   def test_is_default
-    assert_equal(@rules.is_default, false)
+    assert_equal(@listener_rule.is_default, false)
   end
 
   def test_resource_id
-    refute_nil(@rules.resource_id)
-    assert_equal(@rules.resource_id, 'test1')
+    refute_nil(@listener_rule.resource_id)
+    assert_equal(@listener_rule.resource_id, 'test1')
   end
 
 end

--- a/test/unit/resources/aws_elasticloadbalancingv2_listener_rules_test.rb
+++ b/test/unit/resources/aws_elasticloadbalancingv2_listener_rules_test.rb
@@ -11,7 +11,6 @@ class AWSElasticLoadBalancingV2ListenerRulesConstructorTest < Minitest::Test
   def test_rejects_other_args
     assert_raises(ArgumentError) { AWSElasticLoadBalancingV2ListenerRules.new('rubbish') }
   end
-
 end
 
 class AWSElasticLoadBalancingV2ListenerRulesHappyPathTest < Minitest::Test
@@ -25,22 +24,22 @@ class AWSElasticLoadBalancingV2ListenerRulesHappyPathTest < Minitest::Test
     mock_data[:is_default] = true
     data[:data] = { :rules => [mock_data] }
     data[:client] = Aws::ElasticLoadBalancingV2::Client
-    @rules = AWSElasticLoadBalancingV2ListenerRules.new(listener_arn: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @listener_rule = AWSElasticLoadBalancingV2ListenerRules.new(listener_arn: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_rules_exists
-    assert @rules.exist?
+    assert @listener_rule.exist?
   end
 
   def test_rule_arns
-    assert_equal(@rules.rule_arns, ['test1'])
+    assert_equal(@listener_rule.rule_arns, ['test1'])
   end
 
   def test_priorities
-    assert_equal(@rules.priorities, ['test1'])
+    assert_equal(@listener_rule.priorities, ['test1'])
   end
 
   def test_is_defaults
-    assert_equal(@rules.is_defaults, [true])
+    assert_equal(@listener_rule.is_defaults, [true])
   end
 end

--- a/test/unit/resources/aws_eventbridge_rule_test.rb
+++ b/test/unit/resources/aws_eventbridge_rule_test.rb
@@ -28,27 +28,27 @@ class AWSEventBridgeRuleSuccessPathTest < Minitest::Test
     mock_parameter[:state] = 'test1'
     data[:data] = mock_parameter
     data[:client] = Aws::EventBridge::Client
-    @res = AWSEventBridgeRule.new(name: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSEventBridgeRule.new(name: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_event_rule_exists
-    assert @res.exists?
+    assert @resp.exists?
   end
 
   def test_name
-    assert_equal(@res.name, 'test1')
+    assert_equal(@resp.name, 'test1')
   end
 
   def test_arn
-    assert_equal(@res.arn, 'test1')
+    assert_equal(@resp.arn, 'test1')
   end
 
   def test_state
-    assert_equal(@res.state, 'test1')
+    assert_equal(@resp.state, 'test1')
   end
 
   def test_resource_id
-    refute_nil(@res.resource_id)
-    assert_equal(@res.resource_id, 'test1')
+    refute_nil(@resp.resource_id)
+    assert_equal(@resp.resource_id, 'test1')
   end
 end

--- a/test/unit/resources/aws_eventbridge_rules_test.rb
+++ b/test/unit/resources/aws_eventbridge_rules_test.rb
@@ -24,22 +24,22 @@ class AWSEventBridgeRulesHappyPathTest < Minitest::Test
     mock_data[:event_pattern] = 'test1'
     data[:data] = { :rules => [mock_data] }
     data[:client] = Aws::EventBridge::Client
-    @rules = AWSEventBridgeRules.new(client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSEventBridgeRules.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_rules_exists
-    assert @rules.exist?
+    assert @resp.exist?
   end
 
   def test_names
-    assert_equal(@rules.names, ['test1'])
+    assert_equal(@resp.names, ['test1'])
   end
 
   def test_states
-    assert_equal(@rules.arns, ['test1'])
+    assert_equal(@resp.arns, ['test1'])
   end
 
   def test_event_patterns
-    assert_equal(@rules.event_patterns, ['test1'])
+    assert_equal(@resp.event_patterns, ['test1'])
   end
 end

--- a/test/unit/resources/aws_glue_databases_test.rb
+++ b/test/unit/resources/aws_glue_databases_test.rb
@@ -12,7 +12,7 @@ class AWSGlueDatabasesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSGlueDatabases.new('rubbish') }
   end
 
-  def test_database_list_non_existing_for_empty_response
+  def test_databases_list_non_existing_for_empty_response
     refute AWSGlueDatabases.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_iam_instance_profiles_test.rb
+++ b/test/unit/resources/aws_iam_instance_profiles_test.rb
@@ -12,7 +12,7 @@ class AWSIAMInstanceProfilesConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSIAMInstanceProfiles.new('rubbish') }
   end
 
-  def test_iam_client_non_existing_for_empty_response
+  def test_instance_profiles_non_existing_for_empty_response
     refute AWSIAMInstanceProfiles.new(client_args: { stub_responses: true }).exist?
   end
 end
@@ -31,26 +31,26 @@ class AWSIAMInstanceProfilesHappyPathTest < Minitest::Test
     mock_data[:create_date] = Time.parse("2013-06-11T23:52:02Z2020-06-05T11:30:39.730000+01:00")
     data[:data] = { :instance_profiles => [mock_data] }
     data[:client] = Aws::IAM::Client
-    @iam_client = AWSIAMInstanceProfiles.new(client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSIAMInstanceProfiles.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
-  def test_iam_client_exists
-    assert @iam_client.exist?
+  def test_instance_profiles_exists
+    assert @resp.exist?
   end
 
   def test_paths
-    assert_equal(@iam_client.paths, ['test1'])
+    assert_equal(@resp.paths, ['test1'])
   end
 
   def test_instance_profile_names
-    assert_equal(@iam_client.instance_profile_names, ['test1'])
+    assert_equal(@resp.instance_profile_names, ['test1'])
   end
 
   def test_instance_profile_ids
-    assert_equal(@iam_client.instance_profile_ids, ['test1'])
+    assert_equal(@resp.instance_profile_ids, ['test1'])
   end
 
   def test_arns
-    assert_equal(@iam_client.arns, ['test1'])
+    assert_equal(@resp.arns, ['test1'])
   end
 end

--- a/test/unit/resources/aws_iam_managed_policies_test.rb
+++ b/test/unit/resources/aws_iam_managed_policies_test.rb
@@ -12,7 +12,7 @@ class AWSIAMManagedPoliciesTest < Minitest::Test
     assert_raises(ArgumentError) { AwsIamManagedPolicies.new('rubbish') }
   end
 
-  def test_iam_client_non_existing_for_empty_response
+  def test_policies_non_existing_for_empty_response
     refute AwsIamManagedPolicies.new(client_args: { stub_responses: true }).exist?
   end
 end
@@ -29,22 +29,22 @@ class AwsIamManagedPoliciesHappyPathTest < Minitest::Test
     mock_data[:create_date] = Time.parse("2013-06-11T23:52:02Z2020-06-05T11:30:39.730000+01:00")
     data[:data] = { :policies => [mock_data] }
     data[:client] = Aws::IAM::Client
-    @iam_client = AwsIamManagedPolicies.new(client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AwsIamManagedPolicies.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_iam_client_exists
-    assert @iam_client.exist?
+    assert @resp.exist?
   end
 
   def test_policy_names
-    assert_equal(@iam_client.policy_names, ['test1'])
+    assert_equal(@resp.policy_names, ['test1'])
   end
 
   def test_instance_profile_ids
-    assert_equal(@iam_client.policy_ids, ['test1'])
+    assert_equal(@resp.policy_ids, ['test1'])
   end
 
   def test_arns
-    assert_equal(@iam_client.arns, ['test1'])
+    assert_equal(@resp.arns, ['test1'])
   end
 end

--- a/test/unit/resources/aws_iam_server_certificates_test.rb
+++ b/test/unit/resources/aws_iam_server_certificates_test.rb
@@ -12,7 +12,7 @@ class AWSIAMServerCertificateConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSIAMServerCertificates.new('rubbish') }
   end
 
-  def test_iam_client_non_existing_for_empty_response
+  def test_iam_server_certificates_non_existing_for_empty_response
     refute AWSIAMServerCertificates.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_iam_service_linked_role_deletion_status_test.rb
+++ b/test/unit/resources/aws_iam_service_linked_role_deletion_status_test.rb
@@ -26,19 +26,19 @@ class AWSIAMServiceLinkedRoleDeletionStatusSuccessPathTest < Minitest::Test
     mock_parameter[:status] = 'SUCCEEDED'
     data[:data] = mock_parameter
     data[:client] = Aws::IAM::Client
-    @response = AWSIAMServiceLinkedRoleDeletionStatus.new(deletion_task_id: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSIAMServiceLinkedRoleDeletionStatus.new(deletion_task_id: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_resource_id
-    refute_nil(@response.resource_id)
-    assert_equal(@response.resource_id, 'test1')
+    refute_nil(@resp.resource_id)
+    assert_equal(@resp.resource_id, 'test1')
   end
 
   def test_service_linked_role_deletion_status_exists
-    assert @response.exists?
+    assert @resp.exists?
   end
 
   def test_status
-    assert_equal(@response.status, 'SUCCEEDED')
+    assert_equal(@resp.status, 'SUCCEEDED')
   end
 end

--- a/test/unit/resources/aws_iam_virtual_mfa_devices_test.rb
+++ b/test/unit/resources/aws_iam_virtual_mfa_devices_test.rb
@@ -36,7 +36,7 @@ class AWSIAMVirtualMFADevicesHappyPathTest < Minitest::Test
     @resp = AWSIAMVirtualMFADevices.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
-  def test_iam_client_exists
+  def test_virtual_mfa_devices_exists
     assert @resp.exist?
   end
 

--- a/test/unit/resources/aws_lambda_event_invoke_config_test.rb
+++ b/test/unit/resources/aws_lambda_event_invoke_config_test.rb
@@ -30,23 +30,23 @@ class AWSLambdaEventInvokeConfigSuccessPathTest < Minitest::Test
     mock_data[:destination_config] = {}
     data[:data] = mock_data
     data[:client] = Aws::Lambda::Client
-    @res = AWSLambdaEventInvokeConfig.new(function_name: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSLambdaEventInvokeConfig.new(function_name: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_function_arn
-    assert_equal(@res.function_arn, 'test1')
+    assert_equal(@resp.function_arn, 'test1')
   end
 
   def test_last_modified
-    assert_equal(@res.last_modified, Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+    assert_equal(@resp.last_modified, Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
   end
 
   def test_maximum_retry_attempts
-    assert_equal(@res.maximum_retry_attempts, 1 )
+    assert_equal(@resp.maximum_retry_attempts, 1 )
   end
 
   def test_resource_id
-    refute_nil(@res.resource_id)
-    assert_equal(@res.resource_id, 'test1')
+    refute_nil(@resp.resource_id)
+    assert_equal(@resp.resource_id, 'test1')
   end
 end

--- a/test/unit/resources/aws_lambda_event_source_mapping_test.rb
+++ b/test/unit/resources/aws_lambda_event_source_mapping_test.rb
@@ -43,91 +43,91 @@ class AWSLambdaEventSourceMappingSuccessPathTest < Minitest::Test
     mock_data[:maximum_retry_attempts] = 1
     data[:data] = mock_data
     data[:client] = Aws::Lambda::Client
-    @res = AWSLambdaEventSourceMapping.new(uuid: 'test1', client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSLambdaEventSourceMapping.new(uuid: 'test1', client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_eventsourcemapping_exists
-    assert @res.exists?
+    assert @resp.exists?
   end
 
   def test_uuid
-    assert_equal(@res.uuid, 'test1')
+    assert_equal(@resp.uuid, 'test1')
   end
 
   def test_starting_position_timestamp
-    assert_equal(@res.starting_position_timestamp, Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+    assert_equal(@resp.starting_position_timestamp, Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
   end
 
   def test_starting_position
-    assert_equal(@res.starting_position, 'test1')
+    assert_equal(@resp.starting_position, 'test1')
   end
 
   def test_batch_size
-    assert_equal(@res.batch_size, 1 )
+    assert_equal(@resp.batch_size, 1 )
   end
 
   def test_maximum_batching_window_in_seconds
-    assert_equal(@res.maximum_batching_window_in_seconds, 1 )
+    assert_equal(@resp.maximum_batching_window_in_seconds, 1 )
   end
 
   def test_starting_position
-    assert_equal(@res.starting_position, 'test1')
+    assert_equal(@resp.starting_position, 'test1')
   end
 
   def test_parallelization_factor
-    assert_equal(@res.parallelization_factor, 1 )
+    assert_equal(@resp.parallelization_factor, 1 )
   end
 
   def test_event_source_arn
-    assert_equal(@res.event_source_arn, 'test1')
+    assert_equal(@resp.event_source_arn, 'test1')
   end
 
   def test_function_arn
-    assert_equal(@res.function_arn, 'test1')
+    assert_equal(@resp.function_arn, 'test1')
   end
 
   def test_last_modified
-    assert_equal(@res.last_modified, Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+    assert_equal(@resp.last_modified, Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
   end
 
   def test_last_processing_result
-    assert_equal(@res.last_processing_result, 'test1')
+    assert_equal(@resp.last_processing_result, 'test1')
   end
 
   def test_state
-    assert_equal(@res.state, 'test1')
+    assert_equal(@resp.state, 'test1')
   end
 
   def test_destination_config
-    assert_equal(@res.destination_config, {})
+    assert_equal(@resp.destination_config, {})
   end
 
   def test_state_transition_reason
-    assert_equal(@res.state_transition_reason, 'test1')
+    assert_equal(@resp.state_transition_reason, 'test1')
   end
 
   def test_topics
-    assert_equal(@res.topics, ['test1'])
+    assert_equal(@resp.topics, ['test1'])
   end
 
   def test_queues
-    assert_equal(@res.queues, ['test1'])
+    assert_equal(@resp.queues, ['test1'])
   end
 
   def test_maximum_record_age_in_seconds
-    assert_equal(@res.maximum_record_age_in_seconds, 1 )
+    assert_equal(@resp.maximum_record_age_in_seconds, 1 )
   end
 
   def test_bisect_batch_on_function_error
-    assert_equal(@res.bisect_batch_on_function_error, true)
+    assert_equal(@resp.bisect_batch_on_function_error, true)
   end
 
   def test_maximum_retry_attempts
-    assert_equal(@res.maximum_retry_attempts, 1 )
+    assert_equal(@resp.maximum_retry_attempts, 1 )
   end
 
   def test_resource_id
-    refute_nil(@res.resource_id)
-    assert_equal(@res.resource_id, 'test1')
+    refute_nil(@resp.resource_id)
+    assert_equal(@resp.resource_id, 'test1')
   end
 end

--- a/test/unit/resources/aws_lambda_event_source_mappings_test.rb
+++ b/test/unit/resources/aws_lambda_event_source_mappings_test.rb
@@ -42,83 +42,82 @@ class AWSLambdaEventSourceMappingsHappyPathTest < Minitest::Test
     mock_data[:maximum_retry_attempts] = 1
     data[:data] = { :event_source_mappings => [mock_data] }
     data[:client] = Aws::Lambda::Client
-    @res = AWSLambdaEventSourceMappings.new(client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSLambdaEventSourceMappings.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
   def test_event_source_mappings_exists
-    assert @res.exist?
+    assert @resp.exist?
   end
 
   def test_uuids
-    assert_equal(@res.uuids, ['test1'])
+    assert_equal(@resp.uuids, ['test1'])
   end
 
   def test_starting_positions
-    assert_equal(@res.starting_positions, ['test1'])
+    assert_equal(@resp.starting_positions, ['test1'])
   end
 
   def test_starting_position_timestamps
-    assert_equal(@res.starting_position_timestamps, [Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")])
+    assert_equal(@resp.starting_position_timestamps, [Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")])
   end
 
   def test_batch_sizes
-    assert_equal(@res.batch_sizes, [1] )
+    assert_equal(@resp.batch_sizes, [1] )
   end
 
   def test_maximum_batching_window_in_seconds
-    assert_equal(@res.maximum_batching_window_in_seconds, [1] )
+    assert_equal(@resp.maximum_batching_window_in_seconds, [1] )
   end
 
   def test_starting_positions
-    assert_equal(@res.starting_positions, ['test1'])
+    assert_equal(@resp.starting_positions, ['test1'])
   end
 
   def test_parallelization_factors
-    assert_equal(@res.parallelization_factors, [1] )
+    assert_equal(@resp.parallelization_factors, [1] )
   end
 
   def test_event_source_arns
-    assert_equal(@res.event_source_arns, ['test1'])
+    assert_equal(@resp.event_source_arns, ['test1'])
   end
 
   def test_function_arns
-    assert_equal(@res.function_arns, ['test1'])
+    assert_equal(@resp.function_arns, ['test1'])
   end
 
   def test_last_modified
-    assert_equal(@res.last_modified, [Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")])
+    assert_equal(@resp.last_modified, [Time.parse("2013-06-12T23:52:02Z2020-06-05T11:30:39.730000+01:00")])
   end
 
   def test_last_processing_results
-    assert_equal(@res.last_processing_results, ['test1'])
+    assert_equal(@resp.last_processing_results, ['test1'])
   end
 
   def test_states
-    assert_equal(@res.states, ['test1'])
+    assert_equal(@resp.states, ['test1'])
   end
 
   def test_state_transition_reasons
-    assert_equal(@res.state_transition_reasons, ['test1'])
+    assert_equal(@resp.state_transition_reasons, ['test1'])
   end
 
   def test_topics
-    assert_equal(@res.topics, [['test1']])
+    assert_equal(@resp.topics, [['test1']])
   end
 
   def test_queues
-    assert_equal(@res.queues, [['test1']])
+    assert_equal(@resp.queues, [['test1']])
   end
 
   def test_maximum_record_age_in_seconds
-    assert_equal(@res.maximum_record_age_in_seconds, [1] )
+    assert_equal(@resp.maximum_record_age_in_seconds, [1] )
   end
 
   def test_bisect_batch_on_function_errors
-    assert_equal(@res.bisect_batch_on_function_errors, [true])
+    assert_equal(@resp.bisect_batch_on_function_errors, [true])
   end
 
   def test_maximum_retry_attempts
-    assert_equal(@res.maximum_retry_attempts, [1] )
+    assert_equal(@resp.maximum_retry_attempts, [1] )
   end
-
 end

--- a/test/unit/resources/aws_lambdas_test.rb
+++ b/test/unit/resources/aws_lambdas_test.rb
@@ -3,7 +3,6 @@ require 'aws_lambdas'
 
 class AwsLambdasTests < Minitest::Test
 
-
   def setup
     def get_list_data
       list_data = {}

--- a/test/unit/resources/aws_mq_configuration_test.rb
+++ b/test/unit/resources/aws_mq_configuration_test.rb
@@ -39,63 +39,63 @@ class AWSMQConfigurationSuccessPathTest < Minitest::Test
     mock_data[:tags] = {}
     data[:data] = [mock_data]
     data[:client] = Aws::MQ::Client
-    @res = AWSMQConfiguration.new(configuration_id: 'config_id', client_args: { stub_responses: true }, stub_data: [data])
+    @resp = AWSMQConfiguration.new(configuration_id: 'config_id', client_args: { stub_responses: true }, stub_data: [data])
   end
   
   def test_resource_id
-    refute_nil(@res.resource_id)
-    assert_equal(@res.resource_id, @res.arn)
+    refute_nil(@resp.resource_id)
+    assert_equal(@resp.resource_id, @res.arn)
   end
   
   def test_mq_exists
-    assert @res.exists?
+    assert @resp.exists?
   end
   
   def test_arn
-    assert_equal(@res.arn, 'test_arn')
+    assert_equal(@resp.arn, 'test_arn')
   end
   
   def test_authentication_strategy
-    assert_equal(@res.authentication_strategy, 'SIMPLE')
+    assert_equal(@resp.authentication_strategy, 'SIMPLE')
   end
   
   def test_created_date
-    assert_equal(@res.created, Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+    assert_equal(@resp.created, Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
   end
 
   def test_description
-    assert_equal(@res.description, 'test_description')
+    assert_equal(@resp.description, 'test_description')
   end
 
   def test_engine_type
-    assert_equal(@res.engine_type, 'ACTIVEMQ')
+    assert_equal(@resp.engine_type, 'ACTIVEMQ')
   end
 
   def test_engine_version
-    assert_equal(@res.engine_version, 'test_engine_version')
+    assert_equal(@resp.engine_version, 'test_engine_version')
   end
   
   def test_id
-    assert_equal(@res.id, 'test_id')
+    assert_equal(@resp.id, 'test_id')
   end
 
   def test_latest_revision_created_date
-    assert_equal(@res.latest_revision.created, Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
+    assert_equal(@resp.latest_revision.created, Time.parse("2013-08-12T23:52:02Z2020-06-05T11:30:39.730000+01:00"))
   end
 
   def test_latest_revision_description
-    assert_equal(@res.latest_revision.description, 'test_revision_description')
+    assert_equal(@resp.latest_revision.description, 'test_revision_description')
   end
 
   def test_latest_revision_revision
-    assert_equal(@res.latest_revision.revision, 1)
+    assert_equal(@resp.latest_revision.revision, 1)
   end
   
   def test_name
-    assert_equal(@res.name, 'test_name')
+    assert_equal(@resp.name, 'test_name')
   end
   
   def test_tags
-    assert_equal(@res.tags, {})
+    assert_equal(@resp.tags, {})
   end
 end

--- a/test/unit/resources/aws_mq_configuration_test.rb
+++ b/test/unit/resources/aws_mq_configuration_test.rb
@@ -44,7 +44,7 @@ class AWSMQConfigurationSuccessPathTest < Minitest::Test
   
   def test_resource_id
     refute_nil(@resp.resource_id)
-    assert_equal(@resp.resource_id, @res.arn)
+    assert_equal(@resp.resource_id, @resp.arn)
   end
   
   def test_mq_exists

--- a/test/unit/resources/aws_nat_gateways_test.rb
+++ b/test/unit/resources/aws_nat_gateways_test.rb
@@ -16,7 +16,6 @@ class AwsNatGatewaysConstructorTest < Minitest::Test
   def test_non_existing_ngws
     refute AwsNatGateways.new(client_args: { stub_responses: true }).exist?
   end
-
 end
 
 class AwsNatGatewaysTest < Minitest::Test

--- a/test/unit/resources/aws_network_acls_test.rb
+++ b/test/unit/resources/aws_network_acls_test.rb
@@ -12,7 +12,7 @@ class AwsNetworkACLsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsNetworkACLs.new('random') }
   end
 
-  def test_instances_non_existing_for_empty_response
+  def test_network_acls_non_existing_for_empty_response
     refute AwsNetworkACLs.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_network_firewall_firewalls_test.rb
+++ b/test/unit/resources/aws_network_firewall_firewalls_test.rb
@@ -12,7 +12,7 @@ class AWSNetworkFirewallFirewallsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSNetworkFirewallFirewalls.new('rubbish') }
   end
 
-  def test_configs_non_existing_for_empty_response
+  def test_firewalls_non_existing_for_empty_response
     refute AWSNetworkFirewallFirewalls.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_network_firewall_rule_groups_test.rb
+++ b/test/unit/resources/aws_network_firewall_rule_groups_test.rb
@@ -12,7 +12,7 @@ class AWSNetworkFirewallRuleGroupsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSNetworkFirewallRuleGroups.new('rubbish') }
   end
 
-  def test_configs_non_existing_for_empty_response
+  def test_rule_groups_non_existing_for_empty_response
     refute AWSNetworkFirewallRuleGroups.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_rds_instance_test.rb
+++ b/test/unit/resources/aws_rds_instance_test.rb
@@ -24,7 +24,7 @@ class AwsRdsInstanceConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsRdsInstance.new(db_instance_identifier: 'rds_rubbish') }
   end
 
-  def test_rds_non_existing
+  def test_db_instances_non_existing
     refute AwsRdsInstance.new(db_instance_identifier: 'rds-1234abcd', client_args: { stub_responses: true }).exists?
   end
 end

--- a/test/unit/resources/aws_rds_option_groups_test.rb
+++ b/test/unit/resources/aws_rds_option_groups_test.rb
@@ -34,8 +34,6 @@ class AwsRdsOptionGroupsHappyPathTest < Minitest::Test
     @option_group = AwsRdsOptionGroups.new(client_args: { stub_responses: true }, stub_data: [data])
   end
 
-
-
   def test_instances_exists
     assert @option_group.exist?
   end

--- a/test/unit/resources/aws_rds_snapshot_test.rb
+++ b/test/unit/resources/aws_rds_snapshot_test.rb
@@ -24,7 +24,7 @@ class AwsRdsSnapshotConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsRdsSnapshot.new(db_snapshot_identifier: 'rds_rubbish') }
   end
 
-  def test_rds_non_existing
+  def test_db_snapshots_non_existing
     refute AwsRdsSnapshot.new(db_snapshot_identifier: 'rds-1234abcd', client_args: { stub_responses: true }).exists?
   end
 end

--- a/test/unit/resources/aws_redshift_cluster_test.rb
+++ b/test/unit/resources/aws_redshift_cluster_test.rb
@@ -23,7 +23,7 @@ class AwsRedshiftClusterConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsRedshiftCluster.new(cluster_identifier: 'rds_rubbish') }
   end
 
-  def test_redshift_non_existing
+  def test_redshift_cluster_non_existing
     refute AwsRedshiftCluster.new(cluster_identifier: 'rds-1234abcd', client_args: { stub_responses: true }).exists?
   end
 end

--- a/test/unit/resources/aws_redshift_clusters_test.rb
+++ b/test/unit/resources/aws_redshift_clusters_test.rb
@@ -12,7 +12,7 @@ class AwsRedshiftClustersConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsRedshiftClusters.new('rubbish') }
   end
 
-  def test_clusters_non_existing_for_empty_response
+  def test_redshift_clusters_non_existing_for_empty_response
     refute AwsRedshiftClusters.new(client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_servicecatalog_launch_role_constraints_test.rb
+++ b/test/unit/resources/aws_servicecatalog_launch_role_constraints_test.rb
@@ -12,7 +12,7 @@ class AWSServiceCatalogLaunchRoleConstraintsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AWSServiceCatalogLaunchRoleConstraints.new('rubbish') }
   end
 
-  def test_functions_non_existing_for_empty_response
+  def test_constraint_details_non_existing_for_empty_response
     refute AWSServiceCatalogLaunchRoleConstraints.new(portfolio_id: 'test1', client_args: { stub_responses: true }).exist?
   end
 end

--- a/test/unit/resources/aws_vpc_endpoint_test.rb
+++ b/test/unit/resources/aws_vpc_endpoint_test.rb
@@ -27,7 +27,7 @@ class AwsVPCEndpointConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsVpce.new(vpc_endpoint_id: 'vpce-rubbish') }
   end
 
-  def test_vpc_non_existing
+  def test_vpc_endpoints_non_existing
     refute AwsVpce.new(vpc_endpoint_id: 'vpce-1234abcd', client_args: { stub_responses: true }).exists?
   end
 end

--- a/test/unit/resources/aws_vpc_endpoints_test.rb
+++ b/test/unit/resources/aws_vpc_endpoints_test.rb
@@ -11,7 +11,7 @@ class AwsVPCEndpointsConstructorTest < Minitest::Test
     assert_raises(ArgumentError) { AwsVpces.new('rubbish') }
   end
 
-  def test_vpcs_non_existing_for_empty_response
+  def test_vpc_endpoints_non_existing_for_empty_response
     refute AwsVpces.new(client_args: { stub_responses: true }).exist?
   end
 end


### PR DESCRIPTION
Signed-off-by: Soumyodeep Karmakar <soumyo.k13@gmail.com>

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AWS](https://github.com/inspec/inspec-aws/CONTRIBUTING.md) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
