### PR TITLE
Add attributes s3_key_prefix & organization_trail to aws_cloudtrail_trail resource

### DIFF
--- a/docs-chef-io/content/inspec/resources/aws_cloudtrail_trail.md
+++ b/docs-chef-io/content/inspec/resources/aws_cloudtrail_trail.md
@@ -110,7 +110,7 @@ end
 
 ```ruby
 describe aws_cloudtrail_trail('my-cloudtrail') do
-  it { should organization_trail }
+  it { should be_organization_trail }
 end
 ```
 

--- a/docs-chef-io/content/inspec/resources/aws_cloudtrail_trail.md
+++ b/docs-chef-io/content/inspec/resources/aws_cloudtrail_trail.md
@@ -37,7 +37,7 @@ end
 ## Parameters
 
 `trail_name` _(required)_
-: This resource expects a single parameter, the CloudTrail Name which uniquely identifies it. 
+: This resource expects a single parameter, the CloudTrail Name which uniquely identifies it.
   This can be passed either as a string or as a `trail_name: 'value'` key-value entry in a hash.
 
 See also the [AWS documentation on CloudTrail](https://docs.aws.amazon.com/cloudtrail/index.html#lang/en_us).
@@ -102,6 +102,15 @@ end
 ```ruby
 describe aws_cloudtrail_trail('my-cloudtrail') do
   it { should be_multi_region_trail }
+end
+```
+
+
+**Test that the specified trail is an organizational trail.**
+
+```ruby
+describe aws_cloudtrail_trail('my-cloudtrail') do
+  it { should organization_trail }
 end
 ```
 

--- a/libraries/aws_cloudtrail_trail.rb
+++ b/libraries/aws_cloudtrail_trail.rb
@@ -10,11 +10,13 @@ class AwsCloudTrailTrail < AwsResourceBase
   EXAMPLE
 
   attr_reader :cloud_watch_logs_log_group_arn, :cloud_watch_logs_role_arn, :home_region, :trail_name,
-              :kms_key_id, :s3_bucket_name, :trail_arn, :is_multi_region_trail, :log_file_validation_enabled
+              :kms_key_id, :s3_bucket_name, :s3_key_prefix, :trail_arn, :is_multi_region_trail,
+              :log_file_validation_enabled, :is_organization_trail
 
   alias multi_region_trail? is_multi_region_trail
   alias log_file_validation_enabled? log_file_validation_enabled
   alias has_log_file_validation_enabled? log_file_validation_enabled
+  alias organization_trail? is_organization_trail
 
   def initialize(opts = {})
     opts = { trail_name: opts } if opts.is_a?(String)
@@ -29,6 +31,8 @@ class AwsCloudTrailTrail < AwsResourceBase
       @kms_key_id = @trail[:kms_key_id]
       @home_region = @trail[:home_region]
       @s3_bucket_name = @trail[:s3_bucket_name]
+      @s3_key_prefix = @trail[:s3_key_prefix]
+      @is_organization_trail = @trail[:is_organization_trail]
       @is_multi_region_trail = @trail[:is_multi_region_trail]
       @cloud_watch_logs_role_arn = @trail[:cloud_watch_logs_role_arn]
       @log_file_validation_enabled = @trail[:log_file_validation_enabled]

--- a/test/unit/resources/aws_cloudtrail_trail_test.rb
+++ b/test/unit/resources/aws_cloudtrail_trail_test.rb
@@ -25,6 +25,8 @@ class AwsCloudTrailTrailPositiveTest < Minitest::Test
     mock_cloudtrail_trail = {}
     mock_cloudtrail_trail[:name] = 'aws-cloud-trail'
     mock_cloudtrail_trail[:s3_bucket_name] = 'aws-cloud-trail-bucket'
+    mock_cloudtrail_trail[:s3_key_prefix] = 'example/org/structure'
+    mock_cloudtrail_trail[:is_organization_trail] = false
     mock_cloudtrail_trail[:is_multi_region_trail] = true
     mock_cloudtrail_trail[:home_region] = 'eu-west-2'
     mock_cloudtrail_trail[:trail_arn] = 'arn:aws:cloudtrail:eu-west-2::trail/aws-cloud-trail'
@@ -58,8 +60,16 @@ class AwsCloudTrailTrailPositiveTest < Minitest::Test
     assert_equal(@cloudtrail_trail.s3_bucket_name, 'aws-cloud-trail-bucket')
   end
 
+  def test_cloudtrail_trail_s3_key_prefix
+    assert_equal(@cloudtrail_trail.s3_key_prefix, 'example/org/structure')
+  end
+
   def test_cloudtrail_trail_is_multi_region_trail
     assert_equal(@cloudtrail_trail.is_multi_region_trail, true)
+  end
+
+  def test_cloudtrail_trail_is_organization_trail
+    assert_equal(@cloudtrail_trail.is_organization_trail, false)
   end
 
   def test_cloudtrail_trail_home_region
@@ -92,6 +102,10 @@ class AwsCloudTrailTrailPositiveTest < Minitest::Test
 
   def test_multi_region_trail_positive
     assert @cloudtrail_trail.multi_region_trail?
+  end
+
+  def test_organization_trail_negative
+    assert ! @cloudtrail_trail.organization_trail?
   end
 
   def test_log_file_validation_enabled_positive


### PR DESCRIPTION
### Description
Added attributes `s3_key_prefix` & `organization_trail` to aws_cloudtrail_trail resource

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [x] New functionality includes integration tests/controls
- N/A New Terraform resources
- [x] Documentation provided or updated for resources 
- [x] All Integration Tests pass
- [x] All Unit Tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
