### PR TITLE
Work around for #977

### DIFF
--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -363,8 +363,7 @@ class AwsResourceBase < Inspec.resource(1)
       client_args[:client_args][:retry_backoff] = "lambda { |c| sleep(#{opts[:aws_retry_backoff]}) }" if opts[:aws_retry_backoff]
       # this catches the stub_data true option for unit testing - and others that could be useful for consumers
       client_args[:client_args].update(opts[:client_args]) if opts[:client_args]
-
-      @resource_data = opts[:resource_data].presence&.to_h
+      @resource_data = opts[:resource_data].presence&.to_h if opts[:resource_data]
     end
     @aws = AwsConnection.new(client_args)
     # N.B. if/when we migrate AwsConnection to train, can update above and inject args via:


### PR DESCRIPTION
The addition of the last line in the init method in the aws_backend seems to be breaking the resource pack because it doesn't account for the nil? case. Added a protection for this.

Review of why and for what function this was added 2 years ago may be useful but doesn't seem to be core to the function of the resources overall.

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AWS](https://github.com/inspec/inspec-aws/CONTRIBUTING.md) document before submitting.

### Issues Resolved

Fixes #977
