### PR TITLE
CHEF-8423 : load ActiveSupport core_ext methods

### DIFF
--- a/libraries/aws_backend.rb
+++ b/libraries/aws_backend.rb
@@ -1,4 +1,5 @@
 require "active_support"
+require "active_support/core_ext"
 require "active_support/core_ext/string"
 
 require "aws-sdk-autoscaling"


### PR DESCRIPTION
calling `.presence` on ruby objects fail with NoMethodError

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec AWS](https://github.com/inspec/inspec-aws/CONTRIBUTING.md) document before submitting.

requiring the core_ext module of ActiveSupport makes sure the methods are loaded before they are called. In this case, it is used to make `.presence` available

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant
https://buildkite.com/chef-oss/inspec-inspec-aws-main-verify/builds/5677#018bbf84-1317-46cb-b695-74a947e786b4

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [X] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
